### PR TITLE
bugfix: missing template tag parameter

### DIFF
--- a/django_ledger/templates/django_ledger/invoice/invoice_list.html
+++ b/django_ledger/templates/django_ledger/invoice/invoice_list.html
@@ -87,7 +87,7 @@
                     {% endif %}
                 </div>
             </div>
-            {% invoice_table %}
+            {% invoice_table invoice_qs %}
             {% if year %}
                 <h5 class="is-size-5">Go to month:</h5>
                 <p>


### PR DESCRIPTION
Hi, when I try open invoice list, got this error
`Exception Type: TemplateSyntaxError at /ledger/invoice/my-company-zfbyqhk6/lastest/
Exception Value: 'invoice_table' did not receive value(s) for the argument(s): 'invoice_qs'
`
