### PR TITLE
Fix error upon viewing Estimate Detail

### DIFF
--- a/django_ledger/models/purchase_order.py
+++ b/django_ledger/models/purchase_order.py
@@ -115,7 +115,7 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn):
                                  blank=True,
                                  verbose_name=_('Associated Customer Job/Estimate'))
 
-    objects = PurchaseOrderModelManager.from_queryset(queryset_class=PurchaseOrderModelQuerySet)
+    objects = PurchaseOrderModelManager.from_queryset(queryset_class=PurchaseOrderModelQuerySet)()
 
     class Meta:
         abstract = True

--- a/django_ledger/views/estimate.py
+++ b/django_ledger/views/estimate.py
@@ -113,11 +113,12 @@ class EstimateModelDetailView(DjangoLedgerSecurityMixIn, DetailView):
 
         # context['contract_items'] = ce_model.itemtransactionmodel_set.all()
 
-        context['contract_progress'] = ce_model.get_contract_summary(
-            po_qs=po_qs,
-            invoice_qs=invoice_qs,
-            bill_qs=bill_qs
-        )
+        if ce_model.is_contract():
+            context['contract_progress'] = ce_model.get_contract_summary(
+                po_qs=po_qs,
+                invoice_qs=invoice_qs,
+                bill_qs=bill_qs
+            )
 
         return context
 


### PR DESCRIPTION
1) On "Estimates & Contracts" list page, the Action->Detail button will show error 'Estimate xxx is not a Contract.'
It happens when Estimate status is one of Draft/Canceled/In Review/Void.
This exception is thrown from Estimate model's get_contract_summary() method if the object is not a contract.
To avoid this I add contract status checking before get_contract_summary() is called.

2) Add missing '()' in the PurchaseOrderModel's object manager statement.