### PR TITLE
'RelatedManager' object has no attribute 'posted'

### DIFF
--- a/django_ledger/views/account.py
+++ b/django_ledger/views/account.py
@@ -210,7 +210,7 @@ class AccountModelYearDetailView(DjangoLedgerSecurityMixIn,
         context['header_title'] = f'Account {account.code} - {account.name}'
         context['page_title'] = f'Account {account.code} - {account.name}'
         account_model: AccountModel = self.object
-        txs_qs = account_model.transactionmodel_set.posted().order_by(
+        txs_qs = account_model.transactionmodel_set.all().posted().order_by(
             'journal_entry__timestamp').select_related(
             'journal_entry', 'journal_entry__entity_unit')
         txs_qs = txs_qs.from_date(self.get_from_date())


### PR DESCRIPTION
 access the queryset instance using .all() which returns a queryset.
txs_qs = account_model.transactionmodel_set.all().posted().order_by(
    'journal_entry__timestamp').select_related(
    'journal_entry', 'journal_entry__entity_unit')