### PR TITLE
remove locked attribute/field that doesn't exist in the ChartOfAccountModel

### DIFF
--- a/django_ledger/admin/coa.py
+++ b/django_ledger/admin/coa.py
@@ -108,7 +108,6 @@ class ChartOfAccountsModelAdmin(ModelAdmin):
     list_display_links = ['name']
     fields = [
         'name',
-        'locked',
         'description',
     ]
     inlines = [


### PR DESCRIPTION
It was noticed in this issue that the CoA can't be accessed via the admin due to an error : https://github.com/arrobalytics/django-ledger/issues/219

This PR removes the missing field that is causing the error

before:
![2024-08-03_05-16](https://github.com/user-attachments/assets/92c21940-3158-4563-a8d4-1d5392aac295)

after:
![2024-08-03_05-44](https://github.com/user-attachments/assets/ab688cba-2087-4b57-8f55-b82cf3d1e9ac)

