### PR TITLE
Fix 405 method not allowed error on logout

### DIFF
--- a/django_ledger/templates/django_ledger/includes/nav.html
+++ b/django_ledger/templates/django_ledger/includes/nav.html
@@ -28,11 +28,15 @@
                     <div class="navbar-item">CE TO: {{ tx_digest_context.IO_RESULT.ce_to_date | date }}</div>
                 {% endif %}
                 <div class="navbar-item">
-                    <a href="{% url 'django_ledger:logout' %}"
-                       id="djl-el=logout-button-nav"
-                       class="button is-small is-danger is-outlined">
-                        {% trans 'Logout' %}
-                    </a>
+                    <form action="{% url 'django_ledger:logout' %}" method="POST">
+                        {% csrf_token %}
+                        <button
+                            id="djl-el=logout-button-nav"
+                            class="button is-small is-danger is-outlined"
+                            type="submit">
+                            {% trans 'Logout' %}
+                        </button>
+                    </form>
                 </div>
                 <div class="navbar-item">{% feedback_button %}</div>
                 <div class="navbar-item">v{% current_version %}</div>


### PR DESCRIPTION
Fix 405 method not allowed error on logout by replacing logout method from get to post.