### PR TITLE
Fixing bug in the IODatabaseMixIn.database_digest method that is double encapsulating non-string accounts into another list

### DIFF
--- a/django_ledger/io/io_core.py
+++ b/django_ledger/io/io_core.py
@@ -477,7 +477,7 @@ class IODatabaseMixIn:
             txs_queryset = txs_queryset.posted()
 
         if accounts:
-            if not isinstance(accounts, str):
+            if isinstance(accounts, str):
                 accounts = [accounts]
             txs_queryset = txs_queryset.for_accounts(account_list=accounts)
 


### PR DESCRIPTION
Fixing bug in the IODatabaseMixIn.database_digest method that is double encapsulating non-string accounts into another list. This shouldn't happen. If a list is provided, it shouldn't encapsulate it within another list.