### PR TITLE
Fixed some hard coded "$" symbols in HTML files

### DIFF
--- a/django_ledger/templates/django_ledger/account/tags/account_txs_table.html
+++ b/django_ledger/templates/django_ledger/account/tags/account_txs_table.html
@@ -16,8 +16,8 @@
             <tr class="has-text-centered">
                 <td>{{ tx.journal_entry.je_number }}</td>
                 <td>{{ tx.journal_entry.timestamp }}</td>
-                <td>{% if tx.tx_type == 'credit' %}${{ tx.amount | currency_format }}{% endif %}</td>
-                <td>{% if tx.tx_type == 'debit' %}${{ tx.amount | currency_format }}{% endif %}</td>
+                <td>{% if tx.tx_type == 'credit' %}{% currency_symbol %}{{ tx.amount | currency_format }}{% endif %}</td>
+                <td>{% if tx.tx_type == 'debit' %}{% currency_symbol %}{{ tx.amount | currency_format }}{% endif %}</td>
                 <td>{{ tx.description }}</td>
                 <td>{{ tx.journal_entry.entity_unit.name }}</td>
                 <td>
@@ -51,8 +51,8 @@
         <tr class="has-text-weight-bold">
             <td></td>
             <td class="has-text-right">Total</td>
-            <td class="has-text-centered">${{ total_credits | currency_format }}</td>
-            <td class="has-text-centered">${{ total_debits | currency_format }}</td>
+            <td class="has-text-centered">{% currency_symbol %}{{ total_credits | currency_format }}</td>
+            <td class="has-text-centered">{% currency_symbol %}{{ total_debits | currency_format }}</td>
             <td></td>
             <td></td>
             <td></td>

--- a/django_ledger/templates/django_ledger/bills/bill_update.html
+++ b/django_ledger/templates/django_ledger/bills/bill_update.html
@@ -43,20 +43,20 @@
                                     <div class="column is-12">
                                         <h3 class="is-size-3">{% trans 'Bill State' %}</h3>
                                         <p>{{ bill_model.cash_account }}:
-                                            ${{ bill_model.get_amount_cash | currency_format }}</p>
+                                            {% currency_symbol %}{{ bill_model.get_amount_cash | currency_format }}</p>
                                         <p>{{ bill_model.prepaid_account }}:
-                                            ${{ bill_model.get_amount_prepaid | currency_format }}</p>
+                                            {% currency_symbol %}{{ bill_model.get_amount_prepaid | currency_format }}</p>
                                         <p>{{ bill_model.unearned_account }}:
-                                            ${{ bill_model.get_amount_unearned | currency_format }}</p>
+                                            {% currency_symbol %}{{ bill_model.get_amount_unearned | currency_format }}</p>
                                     </div>
                                     <div class="column is-12">
                                         <h3 class="is-size-3">{% trans 'Ledger State' %}</h3>
                                         <p>{{ bill_model.cash_account }}:
-                                            ${{ bill_model.amount_paid | currency_format }}</p>
+                                            {% currency_symbol %}{{ bill_model.amount_paid | currency_format }}</p>
                                         <p>{{ bill_model.prepaid_account }}:
-                                            ${{ bill_model.amount_receivable | currency_format }}</p>
+                                            {% currency_symbol %}{{ bill_model.amount_receivable | currency_format }}</p>
                                         <p>{{ bill_model.unearned_account }}:
-                                            ${{ bill_model.amount_unearned | currency_format }}</p>
+                                            {% currency_symbol %}{{ bill_model.amount_unearned | currency_format }}</p>
                                     </div>
                                     {% now "Y" as current_year %}
                                     {% now "m" as current_month %}

--- a/django_ledger/templates/django_ledger/data_import/tags/data_import_job_txs_imported.html
+++ b/django_ledger/templates/django_ledger/data_import/tags/data_import_job_txs_imported.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load django_ledger %}
 
 <div class="table-container">
     <table class="table is-narrow is-fullwidth is-bordered django-ledger-table-bottom-margin-75">
@@ -20,7 +21,7 @@
                 <td>{{ imported_tx.date_posted }}</td>
                 <td>{{ imported_tx.name }}</td>
                 <td class="{% if imported_tx.get_amount < 0.00 %}has-text-danger{% endif %} has-text-centered">
-                    ${{ imported_tx.get_amount }}</td>
+                    {% currency_symbol %}{{ imported_tx.get_amount }}</td>
                 <td>{% if imported_tx.activity %}
                     {{ imported_tx.get_activity_display }}
                 {% endif %}</td>

--- a/django_ledger/templates/django_ledger/invoice/invoice_update.html
+++ b/django_ledger/templates/django_ledger/invoice/invoice_update.html
@@ -42,20 +42,20 @@
                                     <div class="column is-12">
                                         <h3 class="is-size-3">{% trans 'Invoice State' %}</h3>
                                         <p>{{ invoice.cash_account }}:
-                                            ${{ invoice.get_amount_cash | currency_format }}</p>
+                                            {% currency_symbol %}{{ invoice.get_amount_cash | currency_format }}</p>
                                         <p>{{ invoice.prepaid_account }}:
-                                            ${{ invoice.get_amount_prepaid | currency_format }}</p>
+                                            {% currency_symbol %}{{ invoice.get_amount_prepaid | currency_format }}</p>
                                         <p>{{ invoice.unearned_account }}:
-                                            ${{ invoice.get_amount_unearned | currency_format }}</p>
+                                            {% currency_symbol %}{{ invoice.get_amount_unearned | currency_format }}</p>
                                     </div>
                                     <div class="column is-12">
                                         <h3 class="is-size-3">{% trans 'Ledger State' %}</h3>
                                         <p>{{ invoice.cash_account }}:
-                                            ${{ invoice.amount_paid | currency_format }}</p>
+                                            {% currency_symbol %}{{ invoice.amount_paid | currency_format }}</p>
                                         <p>{{ invoice.prepaid_account }}:
-                                            ${{ invoice.amount_receivable | currency_format }}</p>
+                                            {% currency_symbol %}{{ invoice.amount_receivable | currency_format }}</p>
                                         <p>{{ invoice.unearned_account }}:
-                                            ${{ invoice.amount_unearned | currency_format }}</p>
+                                            {% currency_symbol %}{{ invoice.amount_unearned | currency_format }}</p>
                                     </div>
                                     {% now "Y" as current_year %}
                                     {% now "m" as current_month %}

--- a/django_ledger/templates/django_ledger/invoice/tags/invoice_table.html
+++ b/django_ledger/templates/django_ledger/invoice/tags/invoice_table.html
@@ -22,8 +22,8 @@
                 <td>{{ invoice.get_status_action_date }}</td>
                 <td>{{ invoice.get_invoice_status_display }}</td>
                 <td>{{ invoice.customer.customer_name }}</td>
-                <td>${{ invoice.amount_due | currency_format }}</td>
-                <td>${{ invoice.amount_paid | currency_format }}</td>
+                <td>{% currency_symbol %}{{ invoice.amount_due | currency_format }}</td>
+                <td>{% currency_symbol %}{{ invoice.amount_paid | currency_format }}</td>
                 <td>
                     {% if invoice.is_past_due %}
                         <span class="icon is-small has-text-danger">{% icon 'bi:check-circle-fill' 24 %}</span>

--- a/django_ledger/templates/django_ledger/journal_entry/tags/je_txs_table.html
+++ b/django_ledger/templates/django_ledger/journal_entry/tags/je_txs_table.html
@@ -20,9 +20,9 @@
                     <td>{{ transaction_model.account_name }}</td>
                     <td>{% if transaction_model.entity_unit_name %}
                         {{ transaction_model.entity_unit_name }}{% endif %}</td>
-                    <td>{% if transaction_model.is_credit %}$
+                    <td>{% if transaction_model.is_credit %}{% currency_symbol %}
                         {{ transaction_model.amount | currency_format }}{% endif %}</td>
-                    <td>{% if transaction_model.is_debit %}$
+                    <td>{% if transaction_model.is_debit %}{% currency_symbol %}
                         {{ transaction_model.amount | currency_format }}{% endif %}</td>
                     <td>{% if transaction_model.description %}{{ transaction_model.description }}{% endif %}</td>
                 </tr>
@@ -52,8 +52,8 @@
                 <tr>
                     <td>{{ transaction_model.account_code }}</td>
                     <td>{{ transaction_model.account_name }}</td>
-                    <td>{% if transaction_model.is_credit %}${{ transaction_model.amount | currency_format }}{% endif %}</td>
-                    <td>{% if transaction_model.is_debit %}${{ transaction_model.amount | currency_format }}{% endif %}</td>
+                    <td>{% if transaction_model.is_credit %}{% currency_symbol %}{{ transaction_model.amount | currency_format }}{% endif %}</td>
+                    <td>{% if transaction_model.is_debit %}{% currency_symbol %}{{ transaction_model.amount | currency_format }}{% endif %}</td>
                     <td>{% if transaction_model.description %}{{ transaction_model.description }}{% endif %}</td>
                 </tr>
             {% endfor %}

--- a/django_ledger/templates/django_ledger/transactions/tags/txs_table.html
+++ b/django_ledger/templates/django_ledger/transactions/tags/txs_table.html
@@ -20,9 +20,9 @@
                     <td>{{ transaction_model.account_name }}</td>
                     <td>{% if transaction_model.entity_unit_name %}
                         {{ transaction_model.entity_unit_name }}{% endif %}</td>
-                    <td>{% if transaction_model.is_credit %}$
+                    <td>{% if transaction_model.is_credit %}{% currency_symbol %}
                         {{ transaction_model.amount | currency_format }}{% endif %}</td>
-                    <td>{% if transaction_model.is_debit %}$
+                    <td>{% if transaction_model.is_debit %}{% currency_symbol %}
                         {{ transaction_model.amount | currency_format }}{% endif %}</td>
                     <td>{% if transaction_model.description %}{{ transaction_model.description }}{% endif %}</td>
                 </tr>
@@ -52,8 +52,8 @@
                 <tr>
                     <td>{{ transaction_model.account_code }}</td>
                     <td>{{ transaction_model.account_name }}</td>
-                    <td>{% if transaction_model.is_credit %}${{ transaction_model.amount | currency_format }}{% endif %}</td>
-                    <td>{% if transaction_model.is_debit %}${{ transaction_model.amount | currency_format }}{% endif %}</td>
+                    <td>{% if transaction_model.is_credit %}{% currency_symbol %}{{ transaction_model.amount | currency_format }}{% endif %}</td>
+                    <td>{% if transaction_model.is_debit %}{% currency_symbol %}{{ transaction_model.amount | currency_format }}{% endif %}</td>
                     <td>{% if transaction_model.description %}{{ transaction_model.description }}{% endif %}</td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
Fixed a couple of hard coded dollar `$` symbols and changed them with `{% currency_symbol %}` tag to render the correct symbol when `DJANGO_LEDGER_CURRENCY_SYMBOL` is other than default value `$`.