### PR TITLE
Fix deprecated fpdf2 parameters in report renderers

### DIFF
--- a/django_ledger/report/balance_sheet.py
+++ b/django_ledger/report/balance_sheet.py
@@ -64,7 +64,7 @@ class BalanceSheetReport(BaseReportSupport):
             self.cell(
                 w=self.get_string_width(d['role_name']),
                 h=2,
-                txt=d['role_name']
+                text=d['role_name']
             )
             self.ln(h=5)
 
@@ -75,12 +75,12 @@ class BalanceSheetReport(BaseReportSupport):
                 self.cell(
                     w=self.TABLE_HEADERS['role']['width'],
                     h=account_height,
-                    txt=''
+                    text=''
                 )
                 self.cell(
                     w=self.TABLE_HEADERS['code']['width'],
                     h=account_height,
-                    txt='      {code}'.format(code=acc['code'])
+                    text='      {code}'.format(code=acc['code'])
                 )
 
                 if acc['activity']:
@@ -88,26 +88,26 @@ class BalanceSheetReport(BaseReportSupport):
                     self.cell(
                         w=self.TABLE_HEADERS['name']['width'],
                         h=account_height,
-                        txt=f'{acc["name"]} ({act})'
+                        text=f'{acc["name"]} ({act})'
                     )
                 else:
                     self.cell(
                         w=self.TABLE_HEADERS['name']['width'],
                         h=account_height,
-                        txt=acc['name']
+                        text=acc['name']
                     )
 
                 self.cell(
                     w=self.TABLE_HEADERS['balance_type']['width'],
                     h=account_height,
-                    txt=acc['balance_type'],
+                    text=acc['balance_type'],
                     align='C'
                 )
                 self.cell(
                     w=self.TABLE_HEADERS['balance']['width'],
                     h=account_height,
                     align='R',
-                    txt=f"{self.CURRENCY_SYMBOL}{currency_format(acc['balance'])}"
+                    text=f"{self.CURRENCY_SYMBOL}{currency_format(acc['balance'])}"
                 )
                 self.ln(5)
 
@@ -115,7 +115,7 @@ class BalanceSheetReport(BaseReportSupport):
             self.cell(
                 w=20,
                 h=2,
-                txt='Total {r}'.format(r=d['role_name'])
+                text='Total {r}'.format(r=d['role_name'])
             )
 
             self.set_font(self.FONT_FAMILY, style='B', size=self.FONT_SIZE + 1)
@@ -124,7 +124,7 @@ class BalanceSheetReport(BaseReportSupport):
                 w=20,
                 h=2,
                 align='R',
-                txt='{s}{tot}'.format(s=currency_symbol(),
+                text='{s}{tot}'.format(s=currency_symbol(),
                                       tot=currency_format(d['total_balance']))
             )
             self.ln(3)
@@ -148,7 +148,7 @@ class BalanceSheetReport(BaseReportSupport):
                 w=20,
                 h=2,
                 align='R',
-                txt='Total Assets: {s}{tot}'.format(s=currency_symbol(),
+                text='Total Assets: {s}{tot}'.format(s=currency_symbol(),
                                                     tot=currency_format(section_data['total_balance']))
             )
         self.ln(h=5)
@@ -168,7 +168,7 @@ class BalanceSheetReport(BaseReportSupport):
                 w=20,
                 h=2,
                 align='R',
-                txt='Total Liabilities: {s}{tot}'.format(s=currency_symbol(),
+                text='Total Liabilities: {s}{tot}'.format(s=currency_symbol(),
                                                          tot=currency_format(section_data['total_balance']))
             )
         self.ln(h=5)
@@ -189,14 +189,14 @@ class BalanceSheetReport(BaseReportSupport):
         self.cell(
             w=20,
             h=2,
-            txt='Retained Earnings'
+            text='Retained Earnings'
         )
         self.set_x(180)
         self.cell(
             w=20,
             h=2,
             align='R',
-            txt='{s}{tot}'.format(r='Retained Earnings',
+            text='{s}{tot}'.format(r='Retained Earnings',
                                   s=currency_symbol(),
                                   tot=currency_format(bs_data['retained_earnings_balance']))
         )
@@ -210,7 +210,7 @@ class BalanceSheetReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='Total Equity: {s}{tot}'.format(s=currency_symbol(),
+            text='Total Equity: {s}{tot}'.format(s=currency_symbol(),
                                                 tot=currency_format(bs_data['equity_balance']))
         )
         self.ln(h=10)
@@ -221,7 +221,7 @@ class BalanceSheetReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='Total Liabilities + Equity: {s}{tot}'.format(s=currency_symbol(),
+            text='Total Liabilities + Equity: {s}{tot}'.format(s=currency_symbol(),
                                                               tot=currency_format(
                                                                   bs_data['liabilities_equity_balance']))
         )

--- a/django_ledger/report/cash_flow_statement.py
+++ b/django_ledger/report/cash_flow_statement.py
@@ -47,7 +47,7 @@ class CashFlowStatementReport(BaseReportSupport):
             h=5,
             markdown=True,
             align='R',
-            txt=f'**{self.CURRENCY_SYMBOL}{currency_format(amt)}**'
+            text=f'**{self.CURRENCY_SYMBOL}{currency_format(amt)}**'
         )
         self.set_default_font()
 

--- a/django_ledger/report/core.py
+++ b/django_ledger/report/core.py
@@ -51,7 +51,13 @@ class BaseReportSupport(FPDF):
         )
         w = self.get_string_width(self.get_report_name())
         self.set_x((self.PAGE_WIDTH - w) / 2)
-        self.cell(w, 3, self.get_report_name(), ln=1)
+        self.cell(
+            w=w,
+            h=3,
+            text=self.get_report_name(),
+            new_x=XPos.LMARGIN,
+            new_y=YPos.NEXT,
+        )
 
         # Report Title
         self.set_font(
@@ -64,7 +70,7 @@ class BaseReportSupport(FPDF):
         self.set_x((self.PAGE_WIDTH - w) / 2)
         self.cell(w=w,
                   h=6,
-                  txt=report_title,
+                  text=report_title,
                   border=0,
                   new_x=XPos.LMARGIN,
                   new_y=YPos.NEXT,
@@ -80,7 +86,7 @@ class BaseReportSupport(FPDF):
             self.set_x((self.PAGE_WIDTH - w) / 2)
             self.cell(w=w,
                       h=6,
-                      txt=self.REPORT_SUBTITLE.title(),
+                      text=self.REPORT_SUBTITLE.title(),
                       border=0,
                       new_x=XPos.LMARGIN,
                       new_y=YPos.NEXT,
@@ -106,7 +112,7 @@ class BaseReportSupport(FPDF):
         self.set_x((self.PAGE_WIDTH - w) / 2)
         self.cell(w=w,
                   h=5,
-                  txt=period,
+                  text=period,
                   new_x=XPos.LMARGIN,
                   new_y=YPos.NEXT,
                   align='C')
@@ -125,7 +131,7 @@ class BaseReportSupport(FPDF):
             self.cell(
                 w=w,
                 h=5,
-                txt=header['title'],
+                text=header['title'],
                 align=header['align'],
             )
         self.ln(8)
@@ -142,7 +148,7 @@ class BaseReportSupport(FPDF):
             h=5,
             markdown=True,
             align='R',
-            txt=f'**{self.CURRENCY_SYMBOL}{currency_format(amt)}**'
+            text=f'**{self.CURRENCY_SYMBOL}{currency_format(amt)}**'
         )
         self.set_default_font()
 
@@ -189,7 +195,7 @@ class BaseReportSupport(FPDF):
         self.cell(
             w=w,
             h=6,
-            txt=title,
+            text=title,
             align=align
         )
         self.set_default_font()
@@ -197,16 +203,30 @@ class BaseReportSupport(FPDF):
     def footer(self):
         self.set_y(-25)
         self.set_font(self.FONT_FAMILY, 'I', 8)
-        self.cell(0, 5, 'Page ' + str(self.page_no()) + '/{nb}', 0, 1, 'C')
+        self.cell(
+            w=0,
+            h=5,
+            text=f'Page {self.page_no()}/{{nb}}',
+            border=0,
+            new_x=XPos.LMARGIN,
+            new_y=YPos.NEXT,
+            align='C',
+        )
         self.set_font(family=self.FONT_FAMILY, size=self.FONT_SIZE - 3)
         self.image(self.get_report_footer_logo_path(),
                    w=30, x=(200 - 30) / 2,
                    link='https://www.djangoledger.com')
         self.ln(1)
-        self.cell(0, 5,
-                  'Powered by Django Ledger. Open Source software under GPLv3 License. '
-                  'Created by Miguel Sanda <msanda@arrobalytics.com>',
-                  0, 1, 'C')
+        self.cell(
+            w=0,
+            h=5,
+            text='Powered by Django Ledger. Open Source software under GPLv3 License. '
+                'Created by Miguel Sanda <msanda@arrobalytics.com>',
+            border=0,
+            new_x=XPos.LMARGIN,
+            new_y=YPos.NEXT,
+            align='C'
+        )
 
     def create_pdf_report(self):
         raise NotImplementedError()

--- a/django_ledger/report/income_statement.py
+++ b/django_ledger/report/income_statement.py
@@ -64,29 +64,29 @@ class IncomeStatementReport(BaseReportSupport):
             self.cell(
                 w=self.TABLE_HEADERS['role']['width'],
                 h=account_height,
-                txt=''
+                text=''
             )
             self.cell(
                 w=self.TABLE_HEADERS['code']['width'],
                 h=account_height,
-                txt='      {code}'.format(code=acc['code'])
+                text='      {code}'.format(code=acc['code'])
             )
             self.cell(
                 w=self.TABLE_HEADERS['name']['width'],
                 h=account_height,
-                txt=acc['name']
+                text=acc['name']
             )
             self.cell(
                 w=self.TABLE_HEADERS['balance_type']['width'],
                 h=account_height,
-                txt=acc['balance_type'],
+                text=acc['balance_type'],
                 align='C'
             )
             self.cell(
                 w=self.TABLE_HEADERS['balance']['width'],
                 h=account_height,
                 align='R',
-                txt=f"{self.CURRENCY_SYMBOL}{currency_format(acc['balance_abs'])}"
+                text=f"{self.CURRENCY_SYMBOL}{currency_format(acc['balance_abs'])}"
             )
             self.ln(5)
 
@@ -102,7 +102,7 @@ class IncomeStatementReport(BaseReportSupport):
         self.cell(
             w=20,
             h=2,
-            txt='Net Operating Revenue'
+            text='Net Operating Revenue'
         )
         self.set_font(self.FONT_FAMILY, style='B', size=self.FONT_SIZE + 1)
         self.set_x(180)
@@ -110,7 +110,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='{s}{tot}'.format(s=currency_symbol(),
+            text='{s}{tot}'.format(s=currency_symbol(),
                                   tot=currency_format(operating_section['net_operating_revenue']))
         )
         self.ln(h=3)
@@ -128,7 +128,7 @@ class IncomeStatementReport(BaseReportSupport):
         self.cell(
             w=20,
             h=2,
-            txt='Net COGS'
+            text='Net COGS'
         )
         self.set_font(self.FONT_FAMILY, style='B', size=self.FONT_SIZE + 1)
         self.set_x(180)
@@ -136,7 +136,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='{s}{tot}'.format(s=currency_symbol(),
+            text='{s}{tot}'.format(s=currency_symbol(),
                                   tot=currency_format(-operating_section['net_cogs']))
         )
         self.ln(h=3)
@@ -151,7 +151,7 @@ class IncomeStatementReport(BaseReportSupport):
         self.cell(
             w=20,
             h=2,
-            txt='Gross Profit (Op. Revenue - COGS)'
+            text='Gross Profit (Op. Revenue - COGS)'
         )
 
         self.set_font(self.FONT_FAMILY, style='B', size=self.FONT_SIZE + 2)
@@ -160,7 +160,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='{s}{tot}'.format(s=currency_symbol(),
+            text='{s}{tot}'.format(s=currency_symbol(),
                                   tot=currency_format(operating_section['gross_profit']))
         )
         self.ln(h=3)
@@ -179,7 +179,7 @@ class IncomeStatementReport(BaseReportSupport):
         self.cell(
             w=20,
             h=2,
-            txt='Net Operating Expense'
+            text='Net Operating Expense'
         )
         self.set_font(self.FONT_FAMILY, style='B', size=self.FONT_SIZE + 1)
         self.set_x(180)
@@ -187,7 +187,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='{s}{tot}'.format(s=currency_symbol(),
+            text='{s}{tot}'.format(s=currency_symbol(),
                                   tot=currency_format(-operating_section['net_operating_expenses']))
         )
         self.ln(h=3)
@@ -203,7 +203,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='Net Operating Income (Loss): {s}{tot}'.format(s=currency_symbol(),
+            text='Net Operating Income (Loss): {s}{tot}'.format(s=currency_symbol(),
                                                                tot=currency_format(
                                                                    operating_section['net_operating_income']))
         )
@@ -220,7 +220,7 @@ class IncomeStatementReport(BaseReportSupport):
         self.cell(
             w=20,
             h=2,
-            txt='Net Other Revenue'
+            text='Net Other Revenue'
         )
         self.set_font(self.FONT_FAMILY, style='B', size=self.FONT_SIZE + 1)
         self.set_x(180)
@@ -228,7 +228,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='{s}{tot}'.format(s=currency_symbol(),
+            text='{s}{tot}'.format(s=currency_symbol(),
                                   tot=currency_format(other_section['net_other_revenues']))
         )
         self.ln(h=3)
@@ -246,7 +246,7 @@ class IncomeStatementReport(BaseReportSupport):
         self.cell(
             w=20,
             h=2,
-            txt='Net Other Expenses'
+            text='Net Other Expenses'
         )
         self.set_font(self.FONT_FAMILY, style='B', size=self.FONT_SIZE + 1)
         self.set_x(180)
@@ -254,7 +254,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='{s}{tot}'.format(s=currency_symbol(),
+            text='{s}{tot}'.format(s=currency_symbol(),
                                   tot=currency_format(other_section['net_other_expenses']))
         )
         self.ln(h=3)
@@ -270,7 +270,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='Net Other Income (Loss): {s}{tot}'.format(s=currency_symbol(),
+            text='Net Other Income (Loss): {s}{tot}'.format(s=currency_symbol(),
                                                            tot=currency_format(
                                                                operating_section['net_other_income']))
         )
@@ -284,7 +284,7 @@ class IncomeStatementReport(BaseReportSupport):
             w=20,
             h=2,
             align='R',
-            txt='Net Income (Loss): {s}{tot}'.format(s=currency_symbol(),
+            text='Net Income (Loss): {s}{tot}'.format(s=currency_symbol(),
                                                      tot=currency_format(
                                                          ic_data['net_income']))
         )


### PR DESCRIPTION
Update Django Ledger PDF report renderers to avoid deprecated fpdf2 cell parameter usage.

- Replace txt= with text=

- Replace ln= with new_x=XPos.LMARGIN and new_y=YPos.NEXT

- Preserve existing PDF rendering behavior

- Verify PDF generation locally with parseable output using pypdf

### Note on target branch

I noticed the contribution guide mentions opening PRs against `develop`. However, `develop` currently appears to be behind `master`, while the latest release tags seem to be on the `master` line. For that reason, I opened this small maintenance PR against `master`.

If you prefer this contribution to target `develop`, I’m happy to retarget or rebase accordingly.

### Local validation

I validated the change in a small Django Ledger integration spike by generating financial statement PDFs and parsing the generated files with `pypdf`.

The smoke test checks that:

- generated files start with `%PDF`
- generated PDFs can be opened by `pypdf.PdfReader`
- each generated PDF has at least one page
- no fpdf2 `DeprecationWarning` is emitted during PDF report generation

I also ran the local integration test suite successfully.