### PR TITLE
Add high-level API behavior coverage and public model fixes

### DIFF
--- a/django_ledger/models/bill.py
+++ b/django_ledger/models/bill.py
@@ -970,6 +970,13 @@ class BillModelAbstract(
                 raise BillModelValidationError('Cannot bind an unapproved PO.')
             return False
 
+        if self.entity_model_id and self.entity_model_id != po_model.entity_id:
+            if raise_exception:
+                raise BillModelValidationError(
+                    'Cannot bind PO from a different entity.'
+                )
+            return False
+
         if po_model.date_approved > self.date_draft:
             if raise_exception:
                 raise BillModelValidationError(

--- a/django_ledger/models/closing_entry.py
+++ b/django_ledger/models/closing_entry.py
@@ -144,10 +144,12 @@ class ClosingEntryModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn):
             k: sum(v.balance for v in l) for k, l in ce_txs_gb
         }
 
-        if len(ce_txs_sum) and ce_txs_sum[TransactionModel.DEBIT] != ce_txs_sum[TransactionModel.CREDIT]:
+        debit_balance = ce_txs_sum.get(TransactionModel.DEBIT, Decimal('0.00'))
+        credit_balance = ce_txs_sum.get(TransactionModel.CREDIT, Decimal('0.00'))
+
+        if len(ce_txs_sum) and debit_balance != credit_balance:
             raise ClosingEntryValidationError(
-                message=f'Invalid transactions. Credits {ce_txs_sum[TransactionModel.CREDIT]} '
-                        f'do not equal Debits {ce_txs_sum[TransactionModel.DEBIT]}'
+                message=f'Invalid transactions. Credits {credit_balance} do not equal Debits {debit_balance}'
             )
 
         key_func = lambda i: (str(i.unit_model_id) if i.unit_model_id else '', i.activity if i.activity else '')
@@ -353,7 +355,7 @@ class ClosingEntryModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn):
     def get_delete_url(self, entity_slug: Optional[str] = None) -> str:
         if not entity_slug:
             entity_slug = self.entity_model.slug
-        return reverse(viewname='django_ledger:closing-entry-action-delete',
+        return reverse(viewname='django_ledger:closing-entry-delete',
                        kwargs={
                            'entity_slug': entity_slug,
                            'closing_entry_pk': self.uuid
@@ -409,7 +411,7 @@ class ClosingEntryTransactionModelManager(Manager):
     @deprecated_entity_slug_behavior
     def for_entity(self, entity_model: EntityModel | str | UUID = None,
                    **kwargs) -> ClosingEntryTransactionModelQuerySet:
-        EntityModel = lazy_loader.get_entity(entity_model)
+        EntityModel = lazy_loader.get_entity_model()
 
         qs = self.get_queryset()
 
@@ -428,7 +430,7 @@ class ClosingEntryTransactionModelManager(Manager):
         elif isinstance(entity_model, UUID):
             qs = qs.filter(closing_entry_model__entity_model_id=entity_model)
         elif isinstance(entity_model, str):
-            qs = qs.filter(closing_entry_model__slug__exact=entity_model)
+            qs = qs.filter(closing_entry_model__entity_model__slug__exact=entity_model)
         else:
             raise ClosingEntryValidationError(
                 message=_('Must pass EntityModel or UUID or str')

--- a/django_ledger/models/customer.py
+++ b/django_ledger/models/customer.py
@@ -350,8 +350,11 @@ class CustomerModelAbstract(ContactInfoMixIn, TaxCollectionMixIn, CreateUpdateMi
         return self.customer_number
 
     def validate_for_entity(self, entity_model: 'EntityModel'):  # noqa: F821
+        EntityModel = lazy_loader.get_entity_model()
+        if not isinstance(entity_model, EntityModel):
+            raise CustomerModelValidationError('Must pass EntityModel')
         if entity_model.uuid != self.entity_model_id:
-            raise CustomerModelValidationError('EntityModel does not belong to this Vendor')
+            raise CustomerModelValidationError('EntityModel does not belong to this Customer')
 
     def get_detail_url(self) -> str:
         return reverse('django_ledger:customer-detail',
@@ -369,6 +372,7 @@ class CustomerModelAbstract(ContactInfoMixIn, TaxCollectionMixIn, CreateUpdateMi
         Custom defined clean method that fetches the next customer number if not yet fetched.
         Additional validation may be provided.
         """
+        super().clean()
         if self.can_generate_customer_number():
             self.generate_customer_number(commit=False)
 

--- a/django_ledger/models/data_import.py
+++ b/django_ledger/models/data_import.py
@@ -195,7 +195,7 @@ class ImportJobModelManager(Manager):
         elif isinstance(entity_model, UUID):
             qs = qs.filter(bank_account_model__entity_model_id=entity_model)
         elif isinstance(entity_model, str):
-            qs = qs.filter(bank_account_model__slug__exact=entity_model)
+            qs = qs.filter(bank_account_model__entity_model__slug__exact=entity_model)
         else:
             raise ImportJobModelValidationError(
                 message=_('Must pass EntityModel, slug or UUID'),

--- a/django_ledger/models/data_import.py
+++ b/django_ledger/models/data_import.py
@@ -2198,9 +2198,10 @@ class StagedTransactionModelAbstract(CreateUpdateMixIn):
                 )
             return
         self.matched_transaction = False
+        self.matched_transaction_model = None
         if commit:
             with transaction.atomic():
-                self.save(update_fields=['matched_transaction', 'updated'])
+                self.save(update_fields=['matched_transaction', 'matched_transaction_model', 'updated'])
 
     def can_delete(self) -> bool:
         if self.is_children():

--- a/django_ledger/models/data_import.py
+++ b/django_ledger/models/data_import.py
@@ -343,7 +343,7 @@ class ImportJobModelAbstract(CreateUpdateMixIn):
     # URLS...
     def get_data_import_url(self) -> str:
         return reverse(
-            'django_ledger:data-import-job-txs',
+            'django_ledger:import-job-detail',
             kwargs={
                 'entity_slug': self.entity_slug,
                 'job_pk': self.uuid,
@@ -399,7 +399,7 @@ class ImportJobModelAbstract(CreateUpdateMixIn):
 
     def get_edit_txs_url(self) -> str:
         return reverse(
-            'django_ledger:data-import-job-txs',
+            'django_ledger:import-job-detail',
             kwargs={
                 'entity_slug': self.entity_slug,
                 'job_pk': self.uuid,

--- a/django_ledger/models/entity.py
+++ b/django_ledger/models/entity.py
@@ -2081,17 +2081,34 @@ class EntityModelAbstract(
                 _(f'Invalid Account Type: choices are {BankAccountModel.VALID_ACCOUNT_TYPES}')
             )
 
-        account_model_qs = self.get_coa_accounts(coa_model=coa_model, active=True)
-        account_model_qs = account_model_qs.with_roles(
-            roles=[BankAccountModel.ACCOUNT_TYPE_DEFAULT_ROLE_MAPPING[account_type]]
-        ).is_role_default()
+        if account_model:
+            if coa_model:
+                coa_model = self.get_coa_accounts(
+                    coa_model=coa_model,
+                    active=True,
+                    return_coa_model=True,
+                )[0]
+                self.validate_account_model_for_coa(
+                    account_model=account_model,
+                    coa_model=coa_model,
+                )
+            else:
+                self.validate_chart_of_accounts_for_entity(
+                    coa_model=account_model.coa_model,
+                )
+        else:
+            account_model_qs = self.get_coa_accounts(coa_model=coa_model, active=True)
+            account_model_qs = account_model_qs.with_roles(
+                roles=[BankAccountModel.ACCOUNT_TYPE_DEFAULT_ROLE_MAPPING[account_type]]
+            ).is_role_default()
+            account_model = account_model_qs.get()
 
         bank_account_model = BankAccountModel(
             name=name,
             entity_model=self,
             account_type=account_type,
             active=active,
-            account_model=account_model_qs.get() if not account_model else account_model,
+            account_model=account_model,
             **bank_account_model_kwargs,
         )
 

--- a/django_ledger/models/entity.py
+++ b/django_ledger/models/entity.py
@@ -515,7 +515,7 @@ class EntityModelClosingEntryMixIn:
 
     def get_closing_entry_digest_for_fiscal_year(self, fiscal_year: int, **kwargs: Dict) -> Tuple:
         closing_date = getattr(self, 'get_fy_end')(year=fiscal_year)
-        return self.get_closing_entry_digest_for_date(to_date=closing_date, **kwargs)
+        return self.get_closing_entry_digest_for_date(closing_date=closing_date, **kwargs)
 
     # ---> Closing Entry QuerySet <---
     def get_closing_entry_queryset_for_date(self, closing_date: date):

--- a/django_ledger/models/entity.py
+++ b/django_ledger/models/entity.py
@@ -864,14 +864,7 @@ class EntityModelAbstract(
         -------
 
         """
-        entity_model = cls(
-            name=name,
-            accrual_method=use_accrual_method,
-            fy_start_month=fy_start_month,
-            admin=admin,
-        )
-        entity_model.clean()
-        entity_model = cls.add_root(instance=entity_model)
+        parent_entity_model = None
         if parent_entity:
             if isinstance(parent_entity, str):
                 # get by slug...
@@ -907,8 +900,17 @@ class EntityModelAbstract(
             else:
                 raise EntityModelValidationError(_('Only slug, UUID or EntityModel allowed.'))
 
-            parent_entity.add_child(instance=entity_model)
-        return entity_model
+        entity_model = cls(
+            name=name,
+            accrual_method=use_accrual_method,
+            fy_start_month=fy_start_month,
+            admin=admin,
+        )
+        entity_model.clean()
+
+        if parent_entity_model:
+            return parent_entity_model.add_child(instance=entity_model)
+        return cls.add_root(instance=entity_model)
 
     # ### ACCRUAL METHODS ######
     def get_accrual_method(self) -> str:

--- a/django_ledger/models/entity.py
+++ b/django_ledger/models/entity.py
@@ -2817,6 +2817,7 @@ class EntityModelAbstract(
             self.last_closing_date = None
 
         self.meta[self.META_KEY_CLOSING_ENTRY_DATES] = [d.isoformat() for d in date_list]
+        self._CLOSING_ENTRY_DATES = None
         if commit:
             self.save(update_fields=['last_closing_date', 'updated', 'meta'])
         return date_list

--- a/django_ledger/models/entity.py
+++ b/django_ledger/models/entity.py
@@ -3090,7 +3090,7 @@ class EntityModelAbstract(
         str
             EntityModel transaction import URL as a string.
         """
-        return reverse('django_ledger:data-import-jobs-list', kwargs={'entity_slug': self.slug})
+        return reverse('django_ledger:import-job-list', kwargs={'entity_slug': self.slug})
 
     def get_coa_list_url(self) -> str:
         return reverse(viewname='django_ledger:coa-list', kwargs={'entity_slug': self.slug})
@@ -3117,6 +3117,7 @@ class EntityModelAbstract(
             'django_ledger:account-list',
             kwargs={
                 'entity_slug': self.slug,
+                'coa_slug': self.get_default_coa().slug,
             },
         )
 

--- a/django_ledger/models/entity.py
+++ b/django_ledger/models/entity.py
@@ -1487,9 +1487,9 @@ class EntityModelAbstract(
         """
         if coa_model:
             if isinstance(coa_model, UUID):
-                coa_model = self.chartofaccountsmodel_set.get(uuid__exact=coa_model)
+                coa_model = self.chartofaccountmodel_set.get(uuid__exact=coa_model)
             elif isinstance(coa_model, str):
-                coa_model = self.chartofaccountsmodel_set.get(slug__exact=coa_model)
+                coa_model = self.chartofaccountmodel_set.get(slug__exact=coa_model)
             elif isinstance(coa_model, ChartOfAccountModel):
                 self.validate_chart_of_accounts_for_entity(coa_model=coa_model, raise_exception=raise_exception)
         else:
@@ -1533,9 +1533,9 @@ class EntityModelAbstract(
         """
         if coa_model:
             if isinstance(coa_model, UUID):
-                coa_model = self.chartofaccountsmodel_set.get(uuid__exact=coa_model)
+                coa_model = self.chartofaccountmodel_set.get(uuid__exact=coa_model)
             elif isinstance(coa_model, str):
-                coa_model = self.chartofaccountsmodel_set.get(slug__exact=coa_model)
+                coa_model = self.chartofaccountmodel_set.get(slug__exact=coa_model)
             elif isinstance(coa_model, ChartOfAccountModel):
                 self.validate_chart_of_accounts_for_entity(coa_model=coa_model, raise_exception=raise_exception)
         else:

--- a/django_ledger/models/entity.py
+++ b/django_ledger/models/entity.py
@@ -2514,7 +2514,11 @@ class EntityModelAbstract(
             if uom_model.entity_id != self.uuid:
                 raise EntityModelValidationError(f'Invalid UnitOfMeasureModel for entity {self.slug}...')
 
-        account_model_qs = self.get_coa_accounts(coa_model=coa_model, active=True)
+        coa_model, account_model_qs = self.get_coa_accounts(
+            coa_model=coa_model,
+            active=True,
+            return_coa_model=True,
+        )
         account_model_qs = account_model_qs.with_roles(roles=roles_module.ASSET_CA_INVENTORY)
         if not inventory_account:
             inventory_account = account_model_qs.is_role_default().get()

--- a/django_ledger/models/estimate.py
+++ b/django_ledger/models/estimate.py
@@ -421,9 +421,13 @@ class EstimateModelAbstract(CreateUpdateMixIn,
 
             self.entity = entity_model
 
+            if customer_model.entity_model_id != entity_model.uuid:
+                raise EstimateModelValidationError(
+                    f'Invalid CustomerModel for entity {entity_model.slug}'
+                )
+
             self.customer = customer_model
-            if not date_draft:
-                self.date_draft = get_localdate()
+            self.date_draft = get_localdate() if not date_draft else date_draft
 
             self.clean()
             self.clean_fields()

--- a/django_ledger/models/invoice.py
+++ b/django_ledger/models/invoice.py
@@ -92,7 +92,7 @@ class InvoiceModelQuerySet(QuerySet):
         InvoiceModelQuerySet
             Returns a QuerySet of in review invoices only.
         """
-        return self.filter(invoice_status__exact=InvoiceModel.INVOICE_STATUS_DRAFT)
+        return self.filter(invoice_status__exact=InvoiceModel.INVOICE_STATUS_REVIEW)
 
     def approved(self):
         """

--- a/django_ledger/models/invoice.py
+++ b/django_ledger/models/invoice.py
@@ -1036,17 +1036,18 @@ class InvoiceModelAbstract(
 
         if draft_date:
             if isinstance(draft_date, datetime):
-                self.draft_date = draft_date.date()
+                self.date_draft = draft_date.date()
             elif isinstance(draft_date, date):
-                self.draft_date = draft_date
+                self.date_draft = draft_date
         else:
-            self.draft_date = get_localdate()
+            self.date_draft = get_localdate()
 
         self.invoice_status = self.INVOICE_STATUS_DRAFT
         self.clean()
         if commit:
             self.save(update_fields=[
                 'invoice_status',
+                'date_draft',
                 'updated'
             ])
         invoice_status_draft.send_robust(sender=self.__class__,
@@ -1228,7 +1229,7 @@ class InvoiceModelAbstract(
             if isinstance(date_approved, datetime):
                 self.date_approved = date_approved.date()
             elif isinstance(date_approved, date):
-                self.draft_date = date_approved
+                self.date_approved = date_approved
         else:
             self.date_approved = get_localdate()
 
@@ -1808,7 +1809,7 @@ class InvoiceModelAbstract(
         return self.invoice_number
 
     def generate_descriptive_title(self) -> str:
-        return f'Bill {self.invoice_number} | {self.get_invoice_status_display()} {self.get_status_action_date()} | {self.customer.customer_name}'
+        return f'Invoice {self.invoice_number} | {self.get_invoice_status_display()} {self.get_status_action_date()} | {self.customer.customer_name}'
 
     # --> URLs <---
     def get_absolute_url(self):

--- a/django_ledger/models/invoice.py
+++ b/django_ledger/models/invoice.py
@@ -882,6 +882,12 @@ class InvoiceModelAbstract(
                 raise InvoiceModelValidationError(f'Invoice {self.invoice_number} already bound to '
                                                   f'Estimate {self.ce_model.estimate_number}')
             return False
+        elif self.entity_model_id and self.entity_model_id != estimate_model.entity_id:
+            if raise_exception:
+                raise InvoiceModelValidationError(
+                    f'Invalid EstimateModel for entity {self.entity_model.slug}'
+                )
+            return False
 
         is_approved = estimate_model.is_approved()
         if not is_approved and raise_exception:

--- a/django_ledger/models/items.py
+++ b/django_ledger/models/items.py
@@ -475,7 +475,7 @@ class ItemModelManager(Manager):
     def for_estimate(self, entity_model: 'EntityModel | str | UUID' = None, **kwargs) -> ItemModelQuerySet:
         """
         Returns a QuerySet of ItemModels that can only be used for EstimateModels for a specific EntityModel &
-        UserModel. These types of items qualify as products.
+        UserModel. These types of items qualify as products or services sold.
         May pass an instance of EntityModel or a String representing the EntityModel slug.
 
         Parameters
@@ -489,7 +489,7 @@ class ItemModelManager(Manager):
             A Filtered ItemModelQuerySet.
         """
         qs = self.for_entity_active(entity_model=entity_model, **kwargs)
-        return qs.products()
+        return qs.estimates()
 
 
 class ItemModelAbstract(CreateUpdateMixIn):

--- a/django_ledger/models/items.py
+++ b/django_ledger/models/items.py
@@ -1551,9 +1551,9 @@ class ItemTransactionModelAbstract(CreateUpdateMixIn):
         Returns
         -------
         bool
-            True if received, else False.
+            True if ordered, else False.
         """
-        return self.po_item_status == self.STATUS_RECEIVED
+        return self.po_item_status == self.STATUS_ORDERED
 
     def is_canceled(self):
         """

--- a/django_ledger/models/items.py
+++ b/django_ledger/models/items.py
@@ -986,6 +986,7 @@ class ItemTransactionModelQuerySet(QuerySet):
         """
         return self.filter(
             Q(bill_model_id__isnull=True) &
+            Q(invoice_model_id__isnull=True) &
             Q(po_model_id__isnull=True) &
             Q(ce_model_id__isnull=True)
         )

--- a/django_ledger/models/ledger.py
+++ b/django_ledger/models/ledger.py
@@ -170,6 +170,7 @@ class LedgerModelQuerySet(QuerySet):
     def current(self) -> 'LedgerModelQuerySet':
         return self.filter(
             Q(earliest_timestamp__date__gt=F('entity__last_closing_date'))
+            | Q(entity__last_closing_date__isnull=True)
             | Q(earliest_timestamp__isnull=True)
         )
 
@@ -331,7 +332,7 @@ class LedgerModelAbstract(CreateUpdateMixIn, IOMixIn):
         except AttributeError:
             if force_evaluation:
                 try:
-                    earliest_je = self.journal_entries.posted().order_by('-timestamp').only('timestamp').first()
+                    earliest_je = self.journal_entries.posted().order_by('timestamp').only('timestamp').first()
                     self.earliest_timestamp = earliest_je.timestamp if earliest_je else None
                 except ObjectDoesNotExist:
                     self.earliest_timestamp = None

--- a/django_ledger/models/ledger.py
+++ b/django_ledger/models/ledger.py
@@ -131,15 +131,15 @@ class LedgerModelQuerySet(QuerySet):
     def unposted(self) -> 'LedgerModelQuerySet':
         """
         Filters a queryset or a similar iterable-like object to include only items that
-        have the attribute `posted` set to `True`. This method returns a new instance
+        have the attribute `posted` set to `False`. This method returns a new instance
         containing the filtered results.
 
         Returns
         -------
         LedgerModelQuerySet
-            A new instance containing only the filtered results with `posted` set to True.
+            A new instance containing only the filtered results with `posted` set to False.
         """
-        return self.filter(posted=True)
+        return self.filter(posted=False)
 
     def hidden(self) -> 'LedgerModelQuerySet':
         """

--- a/django_ledger/models/purchase_order.py
+++ b/django_ledger/models/purchase_order.py
@@ -719,6 +719,7 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
         if commit:
             self.save(update_fields=[
                 'po_status',
+                'date_draft',
                 'updated'
             ])
         po_status_draft.send_robust(sender=self.__class__,
@@ -1012,7 +1013,6 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
         if not all_items_received:
             raise PurchaseOrderModelValidationError('All items must be received before PO is fulfilled.')
 
-        self.date_fulfilled = date_fulfilled
         self.po_status = self.PO_STATUS_FULFILLED
         self.clean()
 
@@ -1022,6 +1022,7 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
             self.save(update_fields=[
                 'date_fulfilled',
                 'po_status',
+                'po_amount_received',
                 'updated'
             ])
         po_status_fulfilled.send_robust(sender=self.__class__,
@@ -1087,7 +1088,6 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
 
         # all bills associated with this PO...
         bill_model_qs = self.get_po_bill_queryset()
-        bill_model_qs = bill_model_qs.only('bill_status')
 
         if not all(b.is_void() for b in bill_model_qs):
             raise PurchaseOrderModelValidationError('Must void all PO bills before PO can be voided.')
@@ -1098,7 +1098,7 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
 
         if commit:
             self.save(update_fields=[
-                'void_date',
+                'date_void',
                 'po_status',
                 'updated'
             ])

--- a/django_ledger/models/purchase_order.py
+++ b/django_ledger/models/purchase_order.py
@@ -423,7 +423,7 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
                 total_items=Count('uuid')
             )
         return queryset, {
-            'po_total_amount__sum': sum(i.total_amount for i in queryset),
+            'po_total_amount__sum': sum(i.po_total_amount or 0 for i in queryset),
             'bill_amount_paid__sum': sum(i.bill_model.amount_paid for i in queryset if i.bill_model_id),
             'total_items': len(queryset)
         } if not lazy_agg else None

--- a/django_ledger/models/purchase_order.py
+++ b/django_ledger/models/purchase_order.py
@@ -995,6 +995,8 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
 
         if not po_items:
             po_items, po_items_agg = self.get_itemtxs_data(queryset=po_items)
+        else:
+            self.validate_item_transaction_qs(po_items)
 
         self.date_fulfilled = get_localdate() if not date_fulfilled else date_fulfilled
         self.po_amount_received = self.po_amount
@@ -1016,8 +1018,12 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
         self.clean()
 
         if commit:
-            # todo: what if PO items is list???...
-            po_items.update(po_item_status=ItemTransactionModel.STATUS_RECEIVED)
+            if isinstance(po_items, list):
+                ItemTransactionModel.objects.filter(
+                    uuid__in=[i.uuid for i in po_items]
+                ).update(po_item_status=ItemTransactionModel.STATUS_RECEIVED)
+            else:
+                po_items.update(po_item_status=ItemTransactionModel.STATUS_RECEIVED)
             self.save(update_fields=[
                 'date_fulfilled',
                 'po_status',
@@ -1151,7 +1157,7 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
         -------
         BillModelQuerySet
         """
-        return BillModel.objects.filter(bill_items__purchaseordermodel__uuid__exact=self.uuid)
+        return BillModel.objects.filter(itemtransactionmodel__po_model__uuid__exact=self.uuid)
 
     def get_status_action_date(self):
         """

--- a/django_ledger/models/purchase_order.py
+++ b/django_ledger/models/purchase_order.py
@@ -332,11 +332,10 @@ class PurchaseOrderModelAbstract(CreateUpdateMixIn,
 
             self.date_draft = get_localdate() if not draft_date else draft_date
             self.po_status = PurchaseOrderModel.PO_STATUS_DRAFT
+            self.entity = entity_model
 
             if estimate_model:
                 self.action_bind_estimate(estimate_model=estimate_model, commit=False)
-
-            self.entity = entity_model
 
             if self.can_generate_po_number():
                 self.generate_po_number(commit=commit)

--- a/django_ledger/models/receipt.py
+++ b/django_ledger/models/receipt.py
@@ -705,7 +705,6 @@ class ReceiptModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn, IOMixIn):
                 self.receipt_date = localdate() if not receipt_date else receipt_date
                 self.charge_account = charge_account
                 self.receipt_account = receipt_account
-                self.unit_model = unit_model
                 self.staged_transaction_model = staged_transaction_model
 
                 if self.is_transfer_receipt():
@@ -748,7 +747,7 @@ class ReceiptModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn, IOMixIn):
                         vendor_model = VendorModel.objects.for_entity(entity_model=entity_model).get(
                             vendor_number__iexact=vendor_model
                         )
-                    elif isinstance(customer_model, UUID):
+                    elif isinstance(vendor_model, UUID):
                         vendor_model = VendorModel.objects.for_entity(entity_model=entity_model).get(
                             uuid__exact=vendor_model
                         )
@@ -763,11 +762,11 @@ class ReceiptModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn, IOMixIn):
                 # get customer model
                 if customer_model:
                     if isinstance(customer_model, str):
-                        customer_model = CustomerModel.objects.for_entity(entity_model=customer_model).get(
+                        customer_model = CustomerModel.objects.for_entity(entity_model=entity_model).get(
                             customer_number__iexact=customer_model
                         )
                     elif isinstance(customer_model, UUID):
-                        customer_model = CustomerModel.objects.for_entity(entity_model=customer_model).get(
+                        customer_model = CustomerModel.objects.for_entity(entity_model=entity_model).get(
                             uuid__exact=customer_model
                         )
                     elif isinstance(customer_model, CustomerModel):
@@ -789,6 +788,7 @@ class ReceiptModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn, IOMixIn):
                         )
                     elif isinstance(unit_model, EntityUnitModel):
                         unit_model.validate_for_entity(entity_model=entity_model)
+                    self.unit_model = unit_model
 
                 self.ledger_model = entity_model.create_ledger(
                     name=entity_model.name,

--- a/django_ledger/models/receipt.py
+++ b/django_ledger/models/receipt.py
@@ -415,9 +415,11 @@ class ReceiptModelAbstract(CreateUpdateMixIn, MarkdownNotesMixIn, IOMixIn):
         bool
             True if the receipt date is after the entity's last closing date.
         """
+        last_closing_date = self.last_closing_date
         return all(
             [
-                self.last_closing_date < self.receipt_date,
+                self.receipt_date is not None,
+                last_closing_date is None or last_closing_date < self.receipt_date,
             ]
         )
 

--- a/django_ledger/models/vendor.py
+++ b/django_ledger/models/vendor.py
@@ -38,9 +38,9 @@ from django_ledger.settings import (
 
 
 def vendor_picture_upload_to(instance, filename):
-    if not instance.customer_number:
-        instance.generate_customer_number(commit=False)
-    vendor_number = instance.customer_number
+    if not instance.vendor_number:
+        instance.generate_vendor_number(commit=False)
+    vendor_number = instance.vendor_number
     name, ext = os.path.splitext(filename)
     safe_name = slugify(name)
     return f'vendor_pictures/{vendor_number}/{safe_name}{ext.lower()}'

--- a/django_ledger/models/vendor.py
+++ b/django_ledger/models/vendor.py
@@ -293,6 +293,8 @@ class VendorModelAbstract(
             is_valid = entity_model == self.entity_model
         elif isinstance(entity_model, UUID):
             is_valid = entity_model == self.entity_model_id
+        else:
+            is_valid = False
 
         if not is_valid:
             raise VendorModelValidationError(
@@ -408,6 +410,7 @@ class VendorModelAbstract(
         Custom defined clean method that fetches the next vendor number if not yet fetched.
         Additional validation may be provided.
         """
+        super().clean()
         if self.can_generate_vendor_number():
             self.generate_vendor_number(commit=False)
 

--- a/django_ledger/tests/api/README.md
+++ b/django_ledger/tests/api/README.md
@@ -1,0 +1,10 @@
+# High-Level API Behavior Tests
+
+This directory contains high-level API behavior tests for Django Ledger.
+
+The goal is to add deterministic, explicit business-logic coverage around
+public API contracts without replacing or reorganizing the existing test suite.
+
+These tests are prepared as a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The intent is to strengthen long-term refactor safety while
+respecting the existing project structure.

--- a/django_ledger/tests/api/README.md
+++ b/django_ledger/tests/api/README.md
@@ -1,207 +1,142 @@
 # High-Level API Behavior Tests
 
+## Purpose
+
 This directory contains deterministic, high-level behavior tests for Django Ledger's public model API.
 
-The goal of this test suite is not to replace the existing test suite, reorganize project testing strategy, or prescribe a different testing philosophy. Instead, it adds an isolated and readable layer of contract-style tests around the public APIs that downstream applications are likely to depend on.
+The goal is not to replace the existing test suite or prescribe a new testing strategy. These tests add a readable contract layer around public APIs that downstream applications are likely to call directly: model methods, managers, querysets, numbering helpers, lifecycle actions, and cross-model orchestration.
 
-These tests were added as a human-reviewed, AI-assisted contribution using OpenAI GPT-5.5. The intent is to be transparent about the development process while keeping responsibility, review, and final judgment with the human contributor.
+The suite now contains 800+ high-level API tests covering the main accounting, document, import, inventory, and party-model surfaces.
 
 ## Why this directory exists
 
-Django Ledger exposes a rich programming API through its models, managers, querysets, and domain methods. Many important behaviors are not merely field-level behaviors; they involve coordinated model interactions such as:
+Django Ledger exposes important behavior through coordinated model interactions rather than isolated field validation alone. Examples include:
 
-* entity-scoped number generation,
-* fiscal-year-scoped document numbering,
-* entity-unit-scoped journal entry sequencing,
+* entity-scoped and fiscal-year-scoped number generation,
 * ledger and journal entry posting behavior,
+* document lifecycle transitions,
 * item transaction ownership across documents,
-* import job staging and migration behavior,
-* receipt generation from staged transactions,
-* closing entry migration into locked journal entries,
+* import job and staged transaction migration,
+* receipt and closing entry behavior,
 * queryset and manager-level filtering contracts.
 
-This directory focuses on those higher-level behaviors.
-
-The tests are intentionally placed under `django_ledger/tests/api/` to keep them separate from the existing test modules. This makes the scope explicit: these are public API behavior tests, not internal implementation tests.
+The tests are intentionally placed under `django_ledger/tests/api/` to make the scope explicit: these are public API behavior tests, not private implementation tests.
 
 ## Design goals
 
-The test suite follows a few guiding principles:
-
 1. **Deterministic setup**
 
-   Tests avoid randomized fixture generation. Each test creates the minimum entity, chart of accounts, accounts, counterparties, items, documents, or staged transactions needed to express the behavior under test.
+   Tests avoid randomized fixture generation. Each module creates the minimum entity, chart of accounts, accounts, counterparties, items, documents, imports, or transactions needed to express the behavior under test.
 
 2. **Public API first**
 
-   Tests prefer public model methods, manager methods, queryset methods, and documented high-level flows over implementation details.
+   Tests prefer public model methods, manager methods, queryset methods, and high-level flows over private helpers or implementation details.
 
 3. **Behavior over implementation**
 
-   The tests assert externally meaningful contracts such as generated numbers, state transitions, ownership links, ledger effects, and queryset results.
+   Assertions focus on externally meaningful contracts such as generated numbers, state transitions, ownership links, ledger effects, queryset results, and public helper output.
 
 4. **Refactor safety**
 
-   The suite is designed to provide confidence before larger model refactors, including possible swappable-model work. If concrete models, abstract bases, foreign keys, or manager implementations change, these tests should help confirm that public behavior remains stable.
+   The suite is intended to provide confidence before larger refactors, including possible swappable-model work. If concrete models, abstract bases, foreign keys, manager implementations, or wrapper relationships change, these tests should help confirm that public behavior remains stable.
 
 5. **Small focused tests**
 
-   Each test tries to verify one business-level invariant. Shared helpers are kept local to each file so individual test modules remain readable in isolation.
+   Test files are grouped by model family or behavior family. Shared setup is kept local enough that each module remains understandable in isolation.
 
-## Current coverage
+## Coverage overview
 
-At the time this README was written, the high-level API suite contains 160 passing tests.
+### Core accounting engine
 
-The suite covers the following areas.
-
-### Core accounting
+Covered model families include:
 
 * `EntityModel`
 * `EntityStateModel`
 * `EntityUnitModel`
-* `ChartOfAccountModel`
+* `ChartOfAccountModel` and bundled default CoA data
 * `AccountModel`
 * `LedgerModel`
 * `JournalEntryModel`
 * `TransactionModel`
-* `IOBluePrint` / IO commit behavior
 
-Covered contracts include:
+Covered behavior includes entity creation, fiscal-period helpers, tree behavior, default chart of accounts orchestration, account creation and role defaults, ledger lifecycle predicates and transitions, journal entry verification and numbering, transaction filtering and validation, entity state sequencing, and core queryset/user scoping contracts.
 
-* entity creation,
-* default chart of accounts behavior,
-* account creation and role defaults,
-* ledger and journal entry creation,
-* balanced transaction behavior,
-* IO blueprint dispatch and commit behavior,
-* journal entry number generation,
-* entity-unit-scoped journal entry state sequencing.
+### Import, staging, receipts, and closing
 
-### Commercial foundation
+Covered model families include:
 
-* `CustomerModel`
-* `VendorModel`
-* `UnitOfMeasureModel`
-* `ItemModel`
-* `ItemTransactionModel`
 * `BankAccountModel`
+* `ImportJobModel`
+* `StagedTransactionModel`
 * `ReceiptModel`
+* `ClosingEntryModel`
+* `ClosingEntryTransactionModel`
 
-Covered contracts include:
+Covered behavior includes bank account configuration, import job setup and annotations, staged transaction splitting and matching, import/undo behavior, receipt configuration and deletion guards, closing entry posting/unposting, closing transaction normalization, and locked-period behavior.
 
-* customer and vendor creation,
-* active, inactive, hidden, and visible queryset behavior,
-* unit of measure creation,
-* service, product, inventory, and expense item creation,
-* item transaction ownership across documents,
-* bank account configuration and entity scoping,
-* sales, expense, transfer, and refund receipt behavior,
-* receipt number generation via `EntityStateModel.KEY_RECEIPT`.
+### Commercial documents
 
-### Documents
+Covered model families include:
 
 * `BillModel`
 * `InvoiceModel`
 * `EstimateModel`
 * `PurchaseOrderModel`
-* `ClosingEntryModel`
-* `ClosingEntryTransactionModel`
 
-Covered contracts include:
+Covered behavior includes document configuration, itemization, lifecycle transitions, payment or fulfillment behavior where applicable, document numbering, URL/message helpers, status signals, queryset filters, deletion/void guards, and selected cross-document bindings.
 
-* document configuration,
-* draft, review, approved, paid, completed, and fulfilled state behavior where applicable,
-* document amount aggregation from item transactions,
-* entity-scoped and fiscal-year-scoped document numbering,
-* purchase order fulfillment guard rails,
-* closing entry posting and unposting,
-* locked closing journal entry generation,
-* balanced closing entry validation,
-* closing entry transaction normalization.
+### Items, units, and line items
 
-### Import and staging
+Covered model families include:
 
-* `ImportJobModel`
-* `StagedTransactionModel`
+* `UnitOfMeasureModel`
+* `ItemModel`
+* `ItemTransactionModel`
 
-Covered contracts include:
+Covered behavior includes unit creation and scoping, item role/account behavior, product/service/expense/inventory helpers, item transaction ownership across documents, amount/status helpers, inventory pipeline filters, inventory count aggregation, and inventory update behavior.
 
-* import job configuration and ledger creation,
-* import job entity scoping,
-* pending/imported annotation behavior,
-* staged transaction filtering by entity and import job,
-* staged transaction splitting,
-* parent/child staged transaction behavior,
-* customer/vendor mutual exclusion,
-* staged transaction readiness for import,
-* non-receipt staged transaction migration into journal entries,
-* receipt staged transaction migration into `ReceiptModel` and posted journal entries.
+### Commercial parties
 
-### QuerySet and manager contracts
+Covered model families include:
 
-The suite includes explicit coverage for public queryset and manager APIs such as:
+* `CustomerModel`
+* `VendorModel`
 
-* `for_entity(...)`
-* `for_user(...)`
-* `active()`
-* `inactive()`
-* `hidden()`
-* `visible()`
-* `draft()`
-* `approved()`
-* `paid()`
-* `posted()`
-* `not_posted()`
-* `services()`
-* `products()`
-* `expenses()`
-* `inventory_all()`
-* `contracts()`
-* `estimates()`
-* `for_customer(...)`
-* `for_vendor(...)`
-* `for_dates(...)`
-* `for_import_job(...)`
+Covered behavior includes entity/user scoping, active/inactive/hidden/visible filters, direct numbering APIs, entity factory helpers, display and URL helpers, upload paths, contact validation, customer tax collection validation, and light vendor tax/financial-account helper behavior.
 
-These contracts are important because downstream code often depends on queryset behavior as much as direct model methods.
+### Infrastructure and compatibility
 
-## Known observations captured by the suite
+Covered infrastructure includes:
 
-The test suite intentionally documents some non-obvious current behaviors.
+* `lazy_loader` model and report class resolution,
+* public schema constant top-level shape,
+* deprecated `entity_slug=` compatibility behavior,
+* selected IO blueprint/commit behavior.
 
-### Entity state scoping
+These tests are intentionally smoke-level. They protect public infrastructure contracts without asserting private import mechanics or full schema bodies.
 
-`EntityStateModel` sequences are scoped by:
+## Behavior patterns documented by the suite
 
-```text
-entity_model + entity_unit + fiscal_year + key
-```
+The suite intentionally documents recurring behavior patterns that downstream code may depend on:
 
-Customer, vendor, and item numbering use entity-level state without fiscal year or entity unit.
+* `EntityStateModel` sequences are scoped by entity, optional entity unit, fiscal year, and key.
+* Customer, vendor, and item numbering use entity-level state without fiscal year or entity unit.
+* Bills, invoices, estimates, purchase orders, receipts, and journal entries use fiscal-year-scoped numbering.
+* Journal entry numbering also uses entity-unit scoping when an entity unit is present.
+* Some `commit=False` APIs still mutate the in-memory model and may consume entity state sequence values.
+* Hidden-but-active records are often included by `active()` filters but excluded by `visible()` filters.
+* Cross-entity bindings are guarded for accounts, counterparties, documents, receipts, imports, inventory, and staged transactions.
+* Some documents have wrapper ledgers before they are fully migrated into accounting transactions.
+* Staged transaction operations that rely on annotation-backed state are exercised through annotated queryset instances.
 
-Bills, invoices, estimates, purchase orders, receipts, and journal entries use fiscal-year-scoped state.
+## Bug fixes and characterization coverage
 
-Journal entries additionally use `entity_unit` when present.
+The suite distinguishes between public bugs and characterization:
 
-### EntityUnitModel creation
+* Clear public bugs discovered during test development received minimal production fixes and regression tests.
+* Surprising but stable current behavior is documented as characterization when changing it would require a broader product or API decision.
 
-`EntityUnitModel` is based on Treebeard `MP_Node`. It should be created through Treebeard APIs such as `add_root(...)`, not by plain `Model(...).save()` construction.
-
-### ClosingEntry behavior
-
-Posting a balanced closing entry creates locked and posted journal entries under the closing entry ledger. Unposting removes those generated journal entries and transactions.
-
-Closing entries cannot be posted with future timestamps because the generated journal entries are validated as posted journal entries.
-
-### StagedTransaction annotation dependency
-
-Some staged transaction operations, such as `add_split()`, expect annotation-backed fields like `children_count`. Tests use annotated queryset instances when exercising those behaviors.
-
-### Current upstream issue surfaced by tests
-
-`ClosingEntryTransactionModel.objects.for_entity(...)` currently exposes an apparent bug: it calls `lazy_loader.get_entity(...)`, but that method is not available on the lazy loader. The test suite documents this current behavior explicitly instead of hiding it.
-
-This can be addressed separately with a focused regression test and fix.
+This keeps the suite useful for maintainers: tests describe expected public behavior without turning every oddity into an immediate refactor.
 
 ## Running the suite
 
@@ -209,6 +144,24 @@ Run all high-level API behavior tests:
 
 ```bash
 python manage.py test django_ledger.tests.api
+```
+
+Latest full API suite result after the Customer/Vendor campaign:
+
+```bash
+.venv/bin/python manage.py test django_ledger.tests.api
+# Ran 816 tests
+# OK (skipped=1)
+```
+
+The final isolated infrastructure and compatibility smoke tests were also run:
+
+```bash
+.venv/bin/python manage.py test \
+  django_ledger.tests.api.test_model_infrastructure_api \
+  django_ledger.tests.api.test_deprecated_entity_slug_api
+# Ran 6 tests
+# OK
 ```
 
 Run an individual module:
@@ -221,22 +174,21 @@ python manage.py test django_ledger.tests.api.test_closing_entry_api
 
 ## Contribution notes
 
-These tests are intentionally verbose in setup. The verbosity is a tradeoff: it keeps each test module understandable without relying on hidden randomized fixtures or broad shared test state.
+These tests are intentionally more explicit than fixture-heavy tests. The verbosity is a tradeoff: it keeps each behavior contract readable without relying on hidden randomized fixtures or broad shared state.
 
-The suite is intended to support future refactors by making current public behavior explicit. It should be especially useful before changes involving:
+The suite is especially useful before changes involving:
 
 * abstract/concrete model boundaries,
 * swappable model support,
 * manager/queryset refactors,
 * foreign key target changes,
 * document lifecycle changes,
-* ledger posting internals,
-* entity state and numbering internals.
+* ledger and journal entry posting internals,
+* entity state and numbering internals,
+* import/staging and receipt orchestration.
 
 ## AI assistance disclosure
 
-This test suite was developed with AI assistance from OpenAI GPT-5.5 and reviewed by a human contributor.
+This test suite was developed with AI assistance and human review.
 
-The AI system helped draft test structures, identify likely behavior contracts, and iterate on failures. The human contributor ran the tests, inspected failures, reviewed behavior against the source code, and decided which contracts should be preserved.
-
-The contribution should therefore be understood as human-owned and human-reviewed, with AI used as a development aid.
+AI was used to help draft test structures, identify likely behavior contracts, and iterate on failures. The human contributor ran the tests, inspected failures, reviewed behavior against the source code, and made the final decisions about which contracts and fixes to keep.

--- a/django_ledger/tests/api/README.md
+++ b/django_ledger/tests/api/README.md
@@ -1,10 +1,242 @@
 # High-Level API Behavior Tests
 
-This directory contains high-level API behavior tests for Django Ledger.
+This directory contains deterministic, high-level behavior tests for Django Ledger's public model API.
 
-The goal is to add deterministic, explicit business-logic coverage around
-public API contracts without replacing or reorganizing the existing test suite.
+The goal of this test suite is not to replace the existing test suite, reorganize project testing strategy, or prescribe a different testing philosophy. Instead, it adds an isolated and readable layer of contract-style tests around the public APIs that downstream applications are likely to depend on.
 
-These tests are prepared as a human-reviewed, AI-assisted contribution using
-OpenAI GPT-5.5. The intent is to strengthen long-term refactor safety while
-respecting the existing project structure.
+These tests were added as a human-reviewed, AI-assisted contribution using OpenAI GPT-5.5. The intent is to be transparent about the development process while keeping responsibility, review, and final judgment with the human contributor.
+
+## Why this directory exists
+
+Django Ledger exposes a rich programming API through its models, managers, querysets, and domain methods. Many important behaviors are not merely field-level behaviors; they involve coordinated model interactions such as:
+
+* entity-scoped number generation,
+* fiscal-year-scoped document numbering,
+* entity-unit-scoped journal entry sequencing,
+* ledger and journal entry posting behavior,
+* item transaction ownership across documents,
+* import job staging and migration behavior,
+* receipt generation from staged transactions,
+* closing entry migration into locked journal entries,
+* queryset and manager-level filtering contracts.
+
+This directory focuses on those higher-level behaviors.
+
+The tests are intentionally placed under `django_ledger/tests/api/` to keep them separate from the existing test modules. This makes the scope explicit: these are public API behavior tests, not internal implementation tests.
+
+## Design goals
+
+The test suite follows a few guiding principles:
+
+1. **Deterministic setup**
+
+   Tests avoid randomized fixture generation. Each test creates the minimum entity, chart of accounts, accounts, counterparties, items, documents, or staged transactions needed to express the behavior under test.
+
+2. **Public API first**
+
+   Tests prefer public model methods, manager methods, queryset methods, and documented high-level flows over implementation details.
+
+3. **Behavior over implementation**
+
+   The tests assert externally meaningful contracts such as generated numbers, state transitions, ownership links, ledger effects, and queryset results.
+
+4. **Refactor safety**
+
+   The suite is designed to provide confidence before larger model refactors, including possible swappable-model work. If concrete models, abstract bases, foreign keys, or manager implementations change, these tests should help confirm that public behavior remains stable.
+
+5. **Small focused tests**
+
+   Each test tries to verify one business-level invariant. Shared helpers are kept local to each file so individual test modules remain readable in isolation.
+
+## Current coverage
+
+At the time this README was written, the high-level API suite contains 160 passing tests.
+
+The suite covers the following areas.
+
+### Core accounting
+
+* `EntityModel`
+* `EntityStateModel`
+* `EntityUnitModel`
+* `ChartOfAccountModel`
+* `AccountModel`
+* `LedgerModel`
+* `JournalEntryModel`
+* `TransactionModel`
+* `IOBluePrint` / IO commit behavior
+
+Covered contracts include:
+
+* entity creation,
+* default chart of accounts behavior,
+* account creation and role defaults,
+* ledger and journal entry creation,
+* balanced transaction behavior,
+* IO blueprint dispatch and commit behavior,
+* journal entry number generation,
+* entity-unit-scoped journal entry state sequencing.
+
+### Commercial foundation
+
+* `CustomerModel`
+* `VendorModel`
+* `UnitOfMeasureModel`
+* `ItemModel`
+* `ItemTransactionModel`
+* `BankAccountModel`
+* `ReceiptModel`
+
+Covered contracts include:
+
+* customer and vendor creation,
+* active, inactive, hidden, and visible queryset behavior,
+* unit of measure creation,
+* service, product, inventory, and expense item creation,
+* item transaction ownership across documents,
+* bank account configuration and entity scoping,
+* sales, expense, transfer, and refund receipt behavior,
+* receipt number generation via `EntityStateModel.KEY_RECEIPT`.
+
+### Documents
+
+* `BillModel`
+* `InvoiceModel`
+* `EstimateModel`
+* `PurchaseOrderModel`
+* `ClosingEntryModel`
+* `ClosingEntryTransactionModel`
+
+Covered contracts include:
+
+* document configuration,
+* draft, review, approved, paid, completed, and fulfilled state behavior where applicable,
+* document amount aggregation from item transactions,
+* entity-scoped and fiscal-year-scoped document numbering,
+* purchase order fulfillment guard rails,
+* closing entry posting and unposting,
+* locked closing journal entry generation,
+* balanced closing entry validation,
+* closing entry transaction normalization.
+
+### Import and staging
+
+* `ImportJobModel`
+* `StagedTransactionModel`
+
+Covered contracts include:
+
+* import job configuration and ledger creation,
+* import job entity scoping,
+* pending/imported annotation behavior,
+* staged transaction filtering by entity and import job,
+* staged transaction splitting,
+* parent/child staged transaction behavior,
+* customer/vendor mutual exclusion,
+* staged transaction readiness for import,
+* non-receipt staged transaction migration into journal entries,
+* receipt staged transaction migration into `ReceiptModel` and posted journal entries.
+
+### QuerySet and manager contracts
+
+The suite includes explicit coverage for public queryset and manager APIs such as:
+
+* `for_entity(...)`
+* `for_user(...)`
+* `active()`
+* `inactive()`
+* `hidden()`
+* `visible()`
+* `draft()`
+* `approved()`
+* `paid()`
+* `posted()`
+* `not_posted()`
+* `services()`
+* `products()`
+* `expenses()`
+* `inventory_all()`
+* `contracts()`
+* `estimates()`
+* `for_customer(...)`
+* `for_vendor(...)`
+* `for_dates(...)`
+* `for_import_job(...)`
+
+These contracts are important because downstream code often depends on queryset behavior as much as direct model methods.
+
+## Known observations captured by the suite
+
+The test suite intentionally documents some non-obvious current behaviors.
+
+### Entity state scoping
+
+`EntityStateModel` sequences are scoped by:
+
+```text
+entity_model + entity_unit + fiscal_year + key
+```
+
+Customer, vendor, and item numbering use entity-level state without fiscal year or entity unit.
+
+Bills, invoices, estimates, purchase orders, receipts, and journal entries use fiscal-year-scoped state.
+
+Journal entries additionally use `entity_unit` when present.
+
+### EntityUnitModel creation
+
+`EntityUnitModel` is based on Treebeard `MP_Node`. It should be created through Treebeard APIs such as `add_root(...)`, not by plain `Model(...).save()` construction.
+
+### ClosingEntry behavior
+
+Posting a balanced closing entry creates locked and posted journal entries under the closing entry ledger. Unposting removes those generated journal entries and transactions.
+
+Closing entries cannot be posted with future timestamps because the generated journal entries are validated as posted journal entries.
+
+### StagedTransaction annotation dependency
+
+Some staged transaction operations, such as `add_split()`, expect annotation-backed fields like `children_count`. Tests use annotated queryset instances when exercising those behaviors.
+
+### Current upstream issue surfaced by tests
+
+`ClosingEntryTransactionModel.objects.for_entity(...)` currently exposes an apparent bug: it calls `lazy_loader.get_entity(...)`, but that method is not available on the lazy loader. The test suite documents this current behavior explicitly instead of hiding it.
+
+This can be addressed separately with a focused regression test and fix.
+
+## Running the suite
+
+Run all high-level API behavior tests:
+
+```bash
+python manage.py test django_ledger.tests.api
+```
+
+Run an individual module:
+
+```bash
+python manage.py test django_ledger.tests.api.test_receipt_api
+python manage.py test django_ledger.tests.api.test_data_import_api
+python manage.py test django_ledger.tests.api.test_closing_entry_api
+```
+
+## Contribution notes
+
+These tests are intentionally verbose in setup. The verbosity is a tradeoff: it keeps each test module understandable without relying on hidden randomized fixtures or broad shared test state.
+
+The suite is intended to support future refactors by making current public behavior explicit. It should be especially useful before changes involving:
+
+* abstract/concrete model boundaries,
+* swappable model support,
+* manager/queryset refactors,
+* foreign key target changes,
+* document lifecycle changes,
+* ledger posting internals,
+* entity state and numbering internals.
+
+## AI assistance disclosure
+
+This test suite was developed with AI assistance from OpenAI GPT-5.5 and reviewed by a human contributor.
+
+The AI system helped draft test structures, identify likely behavior contracts, and iterate on failures. The human contributor ran the tests, inspected failures, reviewed behavior against the source code, and decided which contracts should be preserved.
+
+The contribution should therefore be understood as human-owned and human-reviewed, with AI used as a development aid.

--- a/django_ledger/tests/api/test_account_api.py
+++ b/django_ledger/tests/api/test_account_api.py
@@ -1,0 +1,259 @@
+"""
+High-level API behavior tests for AccountModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import AccountModel
+from django_ledger.models.entity import EntityModel
+
+
+class AccountHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for AccountModel public API contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document small, deterministic business invariants that should
+    remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_account_contract_user",
+            email="api-account-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Account Contract Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_entity_with_default_coa(self):
+        entity_model = self.create_entity()
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Account Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def test_create_account_adds_non_root_transaction_account(self):
+        entity_model, coa_model = self.create_entity_with_default_coa()
+
+        account_model = coa_model.create_account(
+            code="1010",
+            name="API Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        account_model.refresh_from_db()
+
+        self.assertEqual(account_model.coa_model_id, coa_model.uuid)
+        self.assertFalse(account_model.is_root_account())
+        self.assertTrue(account_model.active)
+        self.assertFalse(account_model.locked)
+        self.assertTrue(account_model.can_transact())
+
+        self.assertTrue(
+            AccountModel.objects.for_entity(entity_model)
+            .not_coa_root()
+            .filter(uuid=account_model.uuid)
+            .exists()
+        )
+
+    def test_created_account_is_inserted_under_matching_role_root(self):
+        entity_model, coa_model = self.create_entity_with_default_coa()
+
+        account_model = coa_model.create_account(
+            code="6010",
+            name="API Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+
+        account_model.refresh_from_db()
+
+        ancestors = list(account_model.get_ancestors())
+
+        self.assertGreater(
+            len(ancestors),
+            0,
+            "A real account should be inserted under the configured CoA tree.",
+        )
+
+        self.assertTrue(
+            any(ancestor.is_root_account() for ancestor in ancestors),
+            "A real account should have a technical CoA root ancestor.",
+        )
+
+        self.assertEqual(account_model.role, "ex_regular")
+        self.assertEqual(account_model.balance_type, "debit")
+        self.assertEqual(account_model.coa_model_id, coa_model.uuid)
+
+    def test_inactive_account_is_excluded_from_available_queryset(self):
+        entity_model, coa_model = self.create_entity_with_default_coa()
+
+        account_model = coa_model.create_account(
+            code="1020",
+            name="API Inactive Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=False,
+        )
+
+        account_model.refresh_from_db()
+
+        self.assertFalse(account_model.active)
+        self.assertFalse(
+            AccountModel.objects.for_entity(entity_model)
+            .available()
+            .filter(uuid=account_model.uuid)
+            .exists()
+        )
+
+    def test_locked_account_cannot_transact(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa()
+
+        account_model = coa_model.create_account(
+            code="1030",
+            name="API Locked Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        account_model.locked = True
+        account_model.save(update_fields=["locked"])
+        account_model.refresh_from_db()
+
+        self.assertTrue(account_model.active)
+        self.assertTrue(account_model.locked)
+        self.assertFalse(account_model.can_transact())
+
+    def test_available_queryset_excludes_inactive_and_locked_accounts(self):
+        entity_model, coa_model = self.create_entity_with_default_coa()
+
+        available_account = coa_model.create_account(
+            code="1040",
+            name="API Available Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        inactive_account = coa_model.create_account(
+            code="1050",
+            name="API Inactive Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=False,
+        )
+
+        locked_account = coa_model.create_account(
+            code="1060",
+            name="API Locked Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        locked_account.locked = True
+        locked_account.save(update_fields=["locked"])
+
+        available_qs = AccountModel.objects.for_entity(entity_model).available()
+
+        self.assertTrue(available_qs.filter(uuid=available_account.uuid).exists())
+        self.assertFalse(available_qs.filter(uuid=inactive_account.uuid).exists())
+        self.assertFalse(available_qs.filter(uuid=locked_account.uuid).exists())
+
+    def test_not_coa_root_excludes_technical_root_accounts(self):
+        entity_model, coa_model = self.create_entity_with_default_coa()
+
+        real_account = coa_model.create_account(
+            code="1070",
+            name="API Real Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        all_accounts_qs = AccountModel.objects.for_entity(entity_model)
+        root_accounts_qs = all_accounts_qs.is_coa_root()
+        real_accounts_qs = all_accounts_qs.not_coa_root()
+
+        self.assertGreater(root_accounts_qs.count(), 0)
+        self.assertTrue(real_accounts_qs.filter(uuid=real_account.uuid).exists())
+
+        for root_account in root_accounts_qs:
+            self.assertFalse(
+                real_accounts_qs.filter(uuid=root_account.uuid).exists(),
+                "Technical CoA root accounts should be excluded by not_coa_root().",
+            )
+
+    def test_role_default_account_is_exposed_by_queryset_helper(self):
+        entity_model, coa_model = self.create_entity_with_default_coa()
+
+        default_cash_account = coa_model.create_account(
+            code="1080",
+            name="API Default Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        non_default_cash_account = coa_model.create_account(
+            code="1090",
+            name="API Non Default Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        role_default_qs = AccountModel.objects.for_entity(entity_model).is_role_default()
+
+        self.assertTrue(role_default_qs.filter(uuid=default_cash_account.uuid).exists())
+        self.assertFalse(role_default_qs.filter(uuid=non_default_cash_account.uuid).exists())
+
+    def test_role_specific_queryset_helpers_expose_expected_accounts(self):
+        entity_model, coa_model = self.create_entity_with_default_coa()
+
+        cash_account = coa_model.create_account(
+            code="1100",
+            name="API Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6110",
+            name="API Regular Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+
+        accounts_qs = AccountModel.objects.for_entity(entity_model).not_coa_root()
+
+        self.assertTrue(accounts_qs.cash().filter(uuid=cash_account.uuid).exists())
+        self.assertFalse(accounts_qs.cash().filter(uuid=expense_account.uuid).exists())
+
+        self.assertTrue(accounts_qs.expenses().filter(uuid=expense_account.uuid).exists())
+        self.assertFalse(accounts_qs.expenses().filter(uuid=cash_account.uuid).exists())

--- a/django_ledger/tests/api/test_account_filter_api.py
+++ b/django_ledger/tests/api/test_account_filter_api.py
@@ -1,0 +1,428 @@
+"""
+High-level API behavior tests for AccountModel queryset filters.
+
+These tests cover public account filtering helpers without lifecycle or model
+property assertions.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.exceptions import InvalidRoleError
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_PREPAID,
+    ASSET_CA_RECEIVABLES,
+    CREDIT,
+    DEBIT,
+    EXPENSE_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import AccountModel
+from django_ledger.models.entity import EntityModel
+
+
+class AccountFilterAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_account_filter_user",
+            email="api-account-filter-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Account Filter Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(
+        self,
+        entity_model,
+        *,
+        name="API Account Filter CoA",
+        active=True,
+        assign_as_default=True,
+    ):
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=assign_as_default,
+        )
+        if coa_model.active != active:
+            coa_model.active = active
+            coa_model.save(update_fields=["active", "updated"])
+        entity_model.refresh_from_db()
+        return coa_model
+
+    def create_account(
+        self,
+        coa_model,
+        *,
+        code,
+        name,
+        role=ASSET_CA_CASH,
+        balance_type=DEBIT,
+        active=True,
+        locked=False,
+        is_role_default=False,
+    ):
+        account_model = coa_model.create_account(
+            code=code,
+            name=name,
+            role=role,
+            balance_type=balance_type,
+            active=active,
+            is_role_default=is_role_default,
+        )
+        if locked:
+            account_model.locked = True
+            account_model.save(update_fields=["locked", "updated"])
+        return account_model
+
+    def create_entity_with_default_coa(self, *, name="API Account Filter Entity"):
+        entity_model = self.create_entity(name=name)
+        coa_model = self.create_coa(entity_model, name=f"{name} CoA")
+        return entity_model, coa_model
+
+    def test_active_inactive_locked_and_unlocked_filters_return_matching_accounts(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account State Filter Entity",
+        )
+        active_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Active Account",
+            active=True,
+        )
+        inactive_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Inactive Account",
+            active=False,
+        )
+        locked_account = self.create_account(
+            coa_model,
+            code="1030",
+            name="API Locked Account",
+            active=True,
+            locked=True,
+        )
+
+        account_qs = AccountModel.objects.for_entity(entity_model).not_coa_root()
+
+        self.assertTrue(account_qs.active().filter(uuid=active_account.uuid).exists())
+        self.assertFalse(account_qs.active().filter(uuid=inactive_account.uuid).exists())
+
+        self.assertTrue(account_qs.inactive().filter(uuid=inactive_account.uuid).exists())
+        self.assertFalse(account_qs.inactive().filter(uuid=active_account.uuid).exists())
+
+        self.assertTrue(account_qs.locked().filter(uuid=locked_account.uuid).exists())
+        self.assertFalse(account_qs.locked().filter(uuid=active_account.uuid).exists())
+
+        self.assertTrue(account_qs.unlocked().filter(uuid=active_account.uuid).exists())
+        self.assertFalse(account_qs.unlocked().filter(uuid=locked_account.uuid).exists())
+
+    def test_with_roles_accepts_single_role_and_role_list(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Role Filter Entity",
+        )
+        cash_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Cash Account",
+            role=ASSET_CA_CASH,
+        )
+        expense_account = self.create_account(
+            coa_model,
+            code="6010",
+            name="API Expense Account",
+            role=EXPENSE_OPERATIONAL,
+        )
+        payable_account = self.create_account(
+            coa_model,
+            code="2010",
+            name="API Payable Account",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type=CREDIT,
+        )
+
+        account_qs = AccountModel.objects.for_entity(entity_model).not_coa_root()
+
+        cash_qs = account_qs.with_roles(ASSET_CA_CASH)
+        self.assertTrue(cash_qs.filter(uuid=cash_account.uuid).exists())
+        self.assertFalse(cash_qs.filter(uuid=expense_account.uuid).exists())
+
+        cash_and_expense_qs = account_qs.with_roles([
+            ASSET_CA_CASH,
+            EXPENSE_OPERATIONAL,
+        ])
+        self.assertTrue(cash_and_expense_qs.filter(uuid=cash_account.uuid).exists())
+        self.assertTrue(cash_and_expense_qs.filter(uuid=expense_account.uuid).exists())
+        self.assertFalse(cash_and_expense_qs.filter(uuid=payable_account.uuid).exists())
+
+    def test_with_roles_rejects_invalid_role(self):
+        entity_model, _coa_model = self.create_entity_with_default_coa(
+            name="API Account Invalid Role Filter Entity",
+        )
+
+        with self.assertRaises(InvalidRoleError):
+            AccountModel.objects.for_entity(entity_model).with_roles("not_a_real_role")
+
+    def test_with_codes_accepts_string_list_and_set(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Code Filter Entity",
+        )
+        first_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API First Code Account",
+        )
+        second_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Second Code Account",
+        )
+        third_account = self.create_account(
+            coa_model,
+            code="1030",
+            name="API Third Code Account",
+        )
+
+        account_qs = AccountModel.objects.for_entity(entity_model).not_coa_root()
+
+        single_code_qs = account_qs.with_codes("1010")
+        self.assertTrue(single_code_qs.filter(uuid=first_account.uuid).exists())
+        self.assertFalse(single_code_qs.filter(uuid=second_account.uuid).exists())
+
+        for codes in (["1010", "1020"], {"1010", "1020"}):
+            with self.subTest(codes=codes):
+                code_qs = account_qs.with_codes(codes)
+
+                self.assertTrue(code_qs.filter(uuid=first_account.uuid).exists())
+                self.assertTrue(code_qs.filter(uuid=second_account.uuid).exists())
+                self.assertFalse(code_qs.filter(uuid=third_account.uuid).exists())
+
+    def test_cash_and_expenses_filters_return_matching_roles(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Cash Expense Filter Entity",
+        )
+        cash_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Cash Account",
+            role=ASSET_CA_CASH,
+        )
+        expense_account = self.create_account(
+            coa_model,
+            code="6010",
+            name="API Expense Account",
+            role=EXPENSE_OPERATIONAL,
+        )
+
+        account_qs = AccountModel.objects.for_entity(entity_model).not_coa_root()
+
+        self.assertTrue(account_qs.cash().filter(uuid=cash_account.uuid).exists())
+        self.assertFalse(account_qs.cash().filter(uuid=expense_account.uuid).exists())
+
+        self.assertTrue(account_qs.expenses().filter(uuid=expense_account.uuid).exists())
+        self.assertFalse(account_qs.expenses().filter(uuid=cash_account.uuid).exists())
+
+    def test_root_and_role_default_filters_expose_expected_accounts(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Root Default Filter Entity",
+        )
+        default_cash_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Default Cash Account",
+            role=ASSET_CA_CASH,
+            is_role_default=True,
+        )
+        non_default_cash_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Non Default Cash Account",
+            role=ASSET_CA_CASH,
+        )
+
+        account_qs = AccountModel.objects.for_entity(entity_model)
+        root_qs = account_qs.is_coa_root()
+        real_account_qs = account_qs.not_coa_root()
+        role_default_qs = account_qs.is_role_default()
+
+        self.assertGreater(root_qs.count(), 0)
+        self.assertTrue(real_account_qs.filter(uuid=default_cash_account.uuid).exists())
+
+        for root_account in root_qs:
+            self.assertFalse(real_account_qs.filter(uuid=root_account.uuid).exists())
+
+        self.assertTrue(role_default_qs.filter(uuid=default_cash_account.uuid).exists())
+        self.assertFalse(role_default_qs.filter(uuid=non_default_cash_account.uuid).exists())
+
+    def test_can_transact_and_available_filters_exclude_unavailable_accounts(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Available Filter Entity",
+        )
+        available_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Available Account",
+            active=True,
+            locked=False,
+        )
+        inactive_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Inactive Account",
+            active=False,
+            locked=False,
+        )
+        locked_account = self.create_account(
+            coa_model,
+            code="1030",
+            name="API Locked Account",
+            active=True,
+            locked=True,
+        )
+        inactive_coa = self.create_coa(
+            entity_model,
+            name="API Account Inactive CoA",
+            active=False,
+            assign_as_default=False,
+        )
+        inactive_coa_account = self.create_account(
+            inactive_coa,
+            code="1010",
+            name="API Inactive CoA Account",
+            active=True,
+            locked=False,
+        )
+
+        default_account_qs = AccountModel.objects.for_entity(entity_model).not_coa_root()
+        inactive_coa_qs = AccountModel.objects.for_entity(
+            entity_model,
+            coa_model=inactive_coa,
+        ).not_coa_root()
+
+        for filter_name in ("can_transact", "available"):
+            with self.subTest(filter_name=filter_name):
+                default_filtered_qs = getattr(default_account_qs, filter_name)()
+                inactive_coa_filtered_qs = getattr(inactive_coa_qs, filter_name)()
+
+                self.assertTrue(default_filtered_qs.filter(uuid=available_account.uuid).exists())
+                self.assertFalse(default_filtered_qs.filter(uuid=inactive_account.uuid).exists())
+                self.assertFalse(default_filtered_qs.filter(uuid=locked_account.uuid).exists())
+                self.assertFalse(
+                    inactive_coa_filtered_qs.filter(uuid=inactive_coa_account.uuid).exists()
+                )
+
+    def test_for_bill_returns_available_bill_role_accounts_only(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Bill Filter Entity",
+        )
+        cash_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Bill Cash Account",
+            role=ASSET_CA_CASH,
+        )
+        prepaid_account = self.create_account(
+            coa_model,
+            code="1210",
+            name="API Bill Prepaid Account",
+            role=ASSET_CA_PREPAID,
+        )
+        payable_account = self.create_account(
+            coa_model,
+            code="2010",
+            name="API Bill Payable Account",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type=CREDIT,
+        )
+        receivable_account = self.create_account(
+            coa_model,
+            code="1310",
+            name="API Invoice Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+        )
+        deferred_revenue_account = self.create_account(
+            coa_model,
+            code="2210",
+            name="API Invoice Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type=CREDIT,
+        )
+        expense_account = self.create_account(
+            coa_model,
+            code="6010",
+            name="API Expense Account",
+            role=EXPENSE_OPERATIONAL,
+        )
+
+        bill_qs = AccountModel.objects.for_entity(entity_model).for_bill()
+
+        self.assertTrue(bill_qs.filter(uuid=cash_account.uuid).exists())
+        self.assertTrue(bill_qs.filter(uuid=prepaid_account.uuid).exists())
+        self.assertTrue(bill_qs.filter(uuid=payable_account.uuid).exists())
+        self.assertFalse(bill_qs.filter(uuid=receivable_account.uuid).exists())
+        self.assertFalse(bill_qs.filter(uuid=deferred_revenue_account.uuid).exists())
+        self.assertFalse(bill_qs.filter(uuid=expense_account.uuid).exists())
+
+    def test_for_invoice_returns_available_invoice_role_accounts_only(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Invoice Filter Entity",
+        )
+        cash_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Invoice Cash Account",
+            role=ASSET_CA_CASH,
+        )
+        receivable_account = self.create_account(
+            coa_model,
+            code="1210",
+            name="API Invoice Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+        )
+        deferred_revenue_account = self.create_account(
+            coa_model,
+            code="2010",
+            name="API Invoice Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type=CREDIT,
+        )
+        prepaid_account = self.create_account(
+            coa_model,
+            code="1310",
+            name="API Bill Prepaid Account",
+            role=ASSET_CA_PREPAID,
+        )
+        payable_account = self.create_account(
+            coa_model,
+            code="2210",
+            name="API Bill Payable Account",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type=CREDIT,
+        )
+        expense_account = self.create_account(
+            coa_model,
+            code="6010",
+            name="API Expense Account",
+            role=EXPENSE_OPERATIONAL,
+        )
+
+        invoice_qs = AccountModel.objects.for_entity(entity_model).for_invoice()
+
+        self.assertTrue(invoice_qs.filter(uuid=cash_account.uuid).exists())
+        self.assertTrue(invoice_qs.filter(uuid=receivable_account.uuid).exists())
+        self.assertTrue(invoice_qs.filter(uuid=deferred_revenue_account.uuid).exists())
+        self.assertFalse(invoice_qs.filter(uuid=prepaid_account.uuid).exists())
+        self.assertFalse(invoice_qs.filter(uuid=payable_account.uuid).exists())
+        self.assertFalse(invoice_qs.filter(uuid=expense_account.uuid).exists())

--- a/django_ledger/tests/api/test_account_lifecycle_api.py
+++ b/django_ledger/tests/api/test_account_lifecycle_api.py
@@ -1,0 +1,278 @@
+"""
+High-level API behavior tests for AccountModel lifecycle transitions.
+
+These tests cover direct public state changes without queryset, URL, or model
+property assertions.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models.accounts import AccountModelValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class AccountLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_account_lifecycle_user",
+            email="api-account-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Account Lifecycle Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_entity_with_default_coa(self, *, name="API Account Lifecycle Entity"):
+        entity_model = self.create_entity(name=name)
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def create_account(
+        self,
+        coa_model,
+        *,
+        code="1010",
+        name="API Account Lifecycle Cash",
+        active=True,
+        locked=False,
+    ):
+        account_model = coa_model.create_account(
+            code=code,
+            name=name,
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=active,
+        )
+        if locked:
+            account_model.locked = True
+            account_model.save(update_fields=["locked", "updated"])
+        return account_model
+
+    def test_activate_commit_false_updates_only_in_memory_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Activate Commit False Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Activate Commit False",
+            active=False,
+        )
+
+        account_model.activate(commit=False)
+
+        self.assertTrue(account_model.active)
+
+        account_model.refresh_from_db()
+        self.assertFalse(account_model.active)
+
+    def test_activate_commit_true_persists_active_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Activate Commit True Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Activate Commit True",
+            active=False,
+        )
+
+        account_model.activate(commit=True)
+
+        account_model.refresh_from_db()
+        self.assertTrue(account_model.active)
+
+    def test_deactivate_commit_true_persists_inactive_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Deactivate Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Deactivate",
+            active=True,
+        )
+
+        account_model.deactivate(commit=True)
+
+        account_model.refresh_from_db()
+        self.assertFalse(account_model.active)
+
+    def test_lock_commit_false_updates_only_in_memory_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Lock Commit False Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Lock Commit False",
+            locked=False,
+        )
+
+        account_model.lock(commit=False)
+
+        self.assertTrue(account_model.locked)
+
+        account_model.refresh_from_db()
+        self.assertFalse(account_model.locked)
+
+    def test_lock_commit_true_persists_locked_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Lock Commit True Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Lock Commit True",
+            locked=False,
+        )
+
+        account_model.lock(commit=True)
+
+        account_model.refresh_from_db()
+        self.assertTrue(account_model.locked)
+
+    def test_unlock_commit_true_persists_unlocked_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Unlock Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Unlock",
+            locked=True,
+        )
+
+        account_model.unlock(commit=True)
+
+        account_model.refresh_from_db()
+        self.assertFalse(account_model.locked)
+
+    def test_predicate_helpers_reflect_current_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Predicate Entity",
+        )
+        inactive_unlocked_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Inactive Unlocked",
+            active=False,
+            locked=False,
+        )
+        active_locked_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Account Active Locked",
+            active=True,
+            locked=True,
+        )
+
+        self.assertTrue(inactive_unlocked_account.can_activate())
+        self.assertFalse(inactive_unlocked_account.can_deactivate())
+        self.assertTrue(inactive_unlocked_account.can_lock())
+        self.assertFalse(inactive_unlocked_account.can_unlock())
+
+        self.assertFalse(active_locked_account.can_activate())
+        self.assertTrue(active_locked_account.can_deactivate())
+        self.assertFalse(active_locked_account.can_lock())
+        self.assertTrue(active_locked_account.can_unlock())
+
+    def test_invalid_transitions_with_raise_exception_false_are_noops(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Invalid Noop Entity",
+        )
+        active_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Already Active",
+            active=True,
+        )
+        inactive_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Account Already Inactive",
+            active=False,
+        )
+        locked_account = self.create_account(
+            coa_model,
+            code="1030",
+            name="API Account Already Locked",
+            locked=True,
+        )
+        unlocked_account = self.create_account(
+            coa_model,
+            code="1040",
+            name="API Account Already Unlocked",
+            locked=False,
+        )
+
+        active_account.activate(commit=True, raise_exception=False)
+        inactive_account.deactivate(commit=True, raise_exception=False)
+        locked_account.lock(commit=True, raise_exception=False)
+        unlocked_account.unlock(commit=True, raise_exception=False)
+
+        active_account.refresh_from_db()
+        inactive_account.refresh_from_db()
+        locked_account.refresh_from_db()
+        unlocked_account.refresh_from_db()
+
+        self.assertTrue(active_account.active)
+        self.assertFalse(inactive_account.active)
+        self.assertTrue(locked_account.locked)
+        self.assertFalse(unlocked_account.locked)
+
+    def test_invalid_transitions_with_raise_exception_true_raise_validation_error(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Invalid Raise Entity",
+        )
+        active_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Active Invalid",
+            active=True,
+        )
+        inactive_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Account Inactive Invalid",
+            active=False,
+        )
+        locked_account = self.create_account(
+            coa_model,
+            code="1030",
+            name="API Account Locked Invalid",
+            locked=True,
+        )
+        unlocked_account = self.create_account(
+            coa_model,
+            code="1040",
+            name="API Account Unlocked Invalid",
+            locked=False,
+        )
+
+        with self.assertRaises(AccountModelValidationError):
+            active_account.activate(commit=True)
+
+        with self.assertRaises(AccountModelValidationError):
+            inactive_account.deactivate(commit=True)
+
+        with self.assertRaises(AccountModelValidationError):
+            locked_account.lock(commit=True)
+
+        with self.assertRaises(AccountModelValidationError):
+            unlocked_account.unlock(commit=True)

--- a/django_ledger/tests/api/test_account_move_display_api.py
+++ b/django_ledger/tests/api/test_account_move_display_api.py
@@ -1,0 +1,171 @@
+"""
+High-level API behavior tests for AccountModel move-choice and display helpers.
+
+These tests cover representative tree/display helper behavior without URL,
+lifecycle, filter, or role-code assertions.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_PPE_BUILDINGS,
+    ASSET_PPE_BUILDINGS_ACCUM_DEPRECIATION,
+    CREDIT,
+    DEBIT,
+    ROOT_ASSETS,
+)
+from django_ledger.models import AccountModel
+from django_ledger.models.entity import EntityModel
+
+
+class AccountMoveDisplayAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_account_move_display_user",
+            email="api-account-move-display-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Account Move Display Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_entity_with_default_coa(self, *, name="API Account Move Display Entity"):
+        entity_model = self.create_entity(name=name)
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def create_account(
+        self,
+        coa_model,
+        *,
+        code,
+        name,
+        role=ASSET_CA_CASH,
+        balance_type=DEBIT,
+        active=True,
+    ):
+        return coa_model.create_account(
+            code=code,
+            name=name,
+            role=role,
+            balance_type=balance_type,
+            active=active,
+        )
+
+    def test_get_account_move_choice_queryset_returns_legal_same_coa_candidates(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Move Choice Entity",
+        )
+        _other_entity, other_coa = self.create_entity_with_default_coa(
+            name="API Account Other Move Choice Entity",
+        )
+        same_role_candidate = self.create_account(
+            coa_model,
+            code="1790",
+            name="API Building Accumulated Depreciation Candidate",
+            role=ASSET_PPE_BUILDINGS_ACCUM_DEPRECIATION,
+            balance_type=CREDIT,
+        )
+        valid_parent_candidate = self.create_account(
+            coa_model,
+            code="1710",
+            name="API Building Parent Candidate",
+            role=ASSET_PPE_BUILDINGS,
+            balance_type=DEBIT,
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1795",
+            name="API Building Accumulated Depreciation Account",
+            role=ASSET_PPE_BUILDINGS_ACCUM_DEPRECIATION,
+            balance_type=CREDIT,
+        )
+        other_coa_candidate = self.create_account(
+            other_coa,
+            code="1790",
+            name="API Other CoA Building Candidate",
+            role=ASSET_PPE_BUILDINGS_ACCUM_DEPRECIATION,
+            balance_type=CREDIT,
+        )
+        root_asset_account = AccountModel.objects.for_entity(coa_model.entity).get(
+            role=ROOT_ASSETS,
+        )
+
+        choice_qs = account_model.get_account_move_choice_queryset()
+
+        self.assertTrue(choice_qs.filter(uuid=same_role_candidate.uuid).exists())
+        self.assertTrue(choice_qs.filter(uuid=valid_parent_candidate.uuid).exists())
+        self.assertTrue(choice_qs.filter(uuid=root_asset_account.uuid).exists())
+        self.assertFalse(choice_qs.filter(uuid=account_model.uuid).exists())
+        self.assertFalse(choice_qs.filter(uuid=other_coa_candidate.uuid).exists())
+
+    def test_indentation_helpers_reflect_current_tree_depth(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Indent Entity",
+        )
+        root_asset_account = AccountModel.objects.for_entity(coa_model.entity).get(
+            role=ROOT_ASSETS,
+        )
+        cash_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Cash Indent Account",
+        )
+
+        self.assertFalse(root_asset_account.is_indented())
+        self.assertEqual(root_asset_account.get_html_pixel_indent(), "0px")
+
+        self.assertTrue(cash_account.is_indented())
+        self.assertEqual(
+            cash_account.get_html_pixel_indent(),
+            f"{(cash_account.depth - 2) * 40}px",
+        )
+
+    def test_string_helpers_include_stable_account_fragments(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account String Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Cash Display Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+        )
+
+        string_value = str(account_model)
+        alt_string_value = account_model.alt_str()
+
+        for fragment in (
+            "1010",
+            "API Cash Display Account",
+            ASSET_CA_CASH.upper(),
+            DEBIT,
+            account_model.role_bs.upper(),
+        ):
+            with self.subTest(fragment=fragment, display="__str__"):
+                self.assertIn(fragment, string_value)
+
+        for fragment in (
+            "1010",
+            "API Cash Display Account",
+            ASSET_CA_CASH.upper(),
+            DEBIT,
+        ):
+            with self.subTest(fragment=fragment, display="alt_str"):
+                self.assertIn(fragment, alt_string_value)

--- a/django_ledger/tests/api/test_account_properties_api.py
+++ b/django_ledger/tests/api/test_account_properties_api.py
@@ -1,0 +1,334 @@
+"""
+High-level API behavior tests for AccountModel properties and instance helpers.
+
+These tests cover model-level helper behavior without queryset filter or
+lifecycle transition assertions.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    COGS,
+    CREDIT,
+    DEBIT,
+    EQUITY_CAPITAL,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+    ROOT_COA,
+)
+from django_ledger.models import AccountModel
+from django_ledger.models.entity import EntityModel
+
+
+class AccountPropertiesAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_account_properties_user",
+            email="api-account-properties-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Account Properties Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(
+        self,
+        entity_model,
+        *,
+        name="API Account Properties CoA",
+        active=True,
+        assign_as_default=True,
+    ):
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=assign_as_default,
+        )
+        if coa_model.active != active:
+            coa_model.active = active
+            coa_model.save(update_fields=["active", "updated"])
+        entity_model.refresh_from_db()
+        return coa_model
+
+    def create_entity_with_default_coa(self, *, name="API Account Properties Entity"):
+        entity_model = self.create_entity(name=name)
+        coa_model = self.create_coa(entity_model, name=f"{name} CoA")
+        return entity_model, coa_model
+
+    def create_account(
+        self,
+        coa_model,
+        *,
+        code,
+        name,
+        role=ASSET_CA_CASH,
+        balance_type=DEBIT,
+        active=True,
+        locked=False,
+    ):
+        account_model = coa_model.create_account(
+            code=code,
+            name=name,
+            role=role,
+            balance_type=balance_type,
+            active=active,
+        )
+        if locked:
+            account_model.locked = True
+            account_model.save(update_fields=["locked", "updated"])
+        return account_model
+
+    def make_direct_account(self, coa_model):
+        return AccountModel(
+            code="1999",
+            name="API Direct Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            coa_model=coa_model,
+        )
+
+    def test_coa_slug_uses_manager_annotation_and_direct_instance_fallback(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account CoA Slug Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account CoA Slug",
+        )
+
+        annotated_account = AccountModel.objects.get(uuid=account_model.uuid)
+        direct_account = self.make_direct_account(coa_model)
+
+        self.assertEqual(annotated_account.coa_slug, coa_model.slug)
+        self.assertEqual(direct_account.coa_slug, coa_model.slug)
+
+    def test_entity_slug_uses_manager_annotation_and_currently_has_no_direct_fallback(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Entity Slug Entity",
+        )
+        account_model = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Account Entity Slug",
+        )
+
+        annotated_account = AccountModel.objects.get(uuid=account_model.uuid)
+        direct_account = self.make_direct_account(coa_model)
+
+        self.assertEqual(annotated_account.entity_slug, entity_model.slug)
+        with self.assertRaises(AttributeError):
+            direct_account.entity_slug
+
+    def test_role_balance_and_root_helpers_reflect_account_role(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Role Balance Entity",
+        )
+        cash_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Debit Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+        )
+        payable_account = self.create_account(
+            coa_model,
+            code="2010",
+            name="API Credit Payable Account",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type=CREDIT,
+        )
+        coa_root_account = AccountModel.objects.for_entity(coa_model.entity).get(
+            role=ROOT_COA,
+        )
+
+        self.assertEqual(cash_account.role_bs, "assets")
+        self.assertFalse(cash_account.is_root_account())
+        self.assertFalse(cash_account.is_coa_root())
+        self.assertTrue(cash_account.is_debit())
+        self.assertFalse(cash_account.is_credit())
+
+        self.assertTrue(payable_account.is_credit())
+        self.assertFalse(payable_account.is_debit())
+
+        self.assertTrue(coa_root_account.is_root_account())
+        self.assertTrue(coa_root_account.is_coa_root())
+
+    def test_role_category_helpers_identify_representative_roles(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Role Category Entity",
+        )
+        asset_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Asset Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+        )
+        liability_account = self.create_account(
+            coa_model,
+            code="2010",
+            name="API Liability Account",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type=CREDIT,
+        )
+        capital_account = self.create_account(
+            coa_model,
+            code="3010",
+            name="API Capital Account",
+            role=EQUITY_CAPITAL,
+            balance_type=CREDIT,
+        )
+        income_account = self.create_account(
+            coa_model,
+            code="4010",
+            name="API Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type=CREDIT,
+        )
+        cogs_account = self.create_account(
+            coa_model,
+            code="5010",
+            name="API COGS Account",
+            role=COGS,
+            balance_type=DEBIT,
+        )
+        expense_account = self.create_account(
+            coa_model,
+            code="6010",
+            name="API Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+        )
+
+        self.assertTrue(asset_account.is_asset())
+        self.assertFalse(asset_account.is_liability())
+
+        self.assertTrue(liability_account.is_liability())
+        self.assertFalse(liability_account.is_asset())
+
+        self.assertTrue(capital_account.is_capital())
+        self.assertFalse(capital_account.is_income())
+
+        self.assertTrue(income_account.is_income())
+        self.assertFalse(income_account.is_capital())
+
+        self.assertTrue(cogs_account.is_cogs())
+        self.assertFalse(cogs_account.is_expense())
+
+        self.assertTrue(expense_account.is_expense())
+        self.assertFalse(expense_account.is_cogs())
+
+    def test_state_helpers_reflect_account_and_coa_state(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account State Helper Entity",
+        )
+        active_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Active Account",
+            active=True,
+            locked=False,
+        )
+        inactive_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Inactive Account",
+            active=False,
+            locked=False,
+        )
+        locked_account = self.create_account(
+            coa_model,
+            code="1030",
+            name="API Locked Account",
+            active=True,
+            locked=True,
+        )
+        inactive_coa = self.create_coa(
+            entity_model,
+            name="API Inactive CoA",
+            active=False,
+            assign_as_default=False,
+        )
+        inactive_coa_account = self.create_account(
+            inactive_coa,
+            code="1010",
+            name="API Inactive CoA Account",
+            active=True,
+            locked=False,
+        )
+
+        annotated_account = AccountModel.objects.get(uuid=active_account.uuid)
+        direct_account = self.make_direct_account(coa_model)
+
+        self.assertTrue(active_account.is_active())
+        self.assertFalse(inactive_account.is_active())
+        self.assertTrue(locked_account.is_locked())
+        self.assertFalse(active_account.is_locked())
+
+        self.assertTrue(annotated_account.is_coa_active())
+        self.assertTrue(direct_account.is_coa_active())
+        self.assertFalse(inactive_coa_account.is_coa_active())
+
+    def test_model_can_transact_reflects_coa_and_lock_state(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Can Transact Entity",
+        )
+        available_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Available Account",
+            active=True,
+            locked=False,
+        )
+        locked_account = self.create_account(
+            coa_model,
+            code="1020",
+            name="API Locked Account",
+            active=True,
+            locked=True,
+        )
+        inactive_coa = self.create_coa(
+            entity_model,
+            name="API Can Transact Inactive CoA",
+            active=False,
+            assign_as_default=False,
+        )
+        inactive_coa_account = self.create_account(
+            inactive_coa,
+            code="1010",
+            name="API Inactive CoA Account",
+            active=True,
+            locked=False,
+        )
+
+        self.assertTrue(available_account.can_transact())
+        self.assertFalse(locked_account.can_transact())
+        self.assertFalse(inactive_coa_account.can_transact())
+
+    def test_model_can_transact_currently_does_not_depend_on_account_active_state(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Can Transact Inactive Account Entity",
+        )
+        inactive_account = self.create_account(
+            coa_model,
+            code="1010",
+            name="API Inactive Account",
+            active=False,
+            locked=False,
+        )
+
+        self.assertFalse(inactive_account.is_active())
+        self.assertTrue(inactive_account.can_transact())

--- a/django_ledger/tests/api/test_account_queryset_api.py
+++ b/django_ledger/tests/api/test_account_queryset_api.py
@@ -1,0 +1,206 @@
+"""
+High-level API behavior tests for AccountModel manager and queryset helpers.
+
+These tests cover entity, chart-of-accounts, and user scoping without relying
+on randomized fixtures.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import AccountModel
+from django_ledger.models.accounts import AccountModelValidationError
+from django_ledger.models.entity import EntityManagementModel, EntityModel
+
+
+class AccountQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_account_queryset_admin",
+            email="api-account-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_account_queryset_other_admin",
+            email="api-account-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_account_queryset_manager",
+            email="api-account-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_account_queryset_unrelated",
+            email="api-account-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_account_queryset_superuser",
+            email="api-account-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Account QuerySet Entity", admin=None):
+        return EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(self, entity_model, *, name, assign_as_default=False):
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=assign_as_default,
+        )
+        entity_model.refresh_from_db()
+        return coa_model
+
+    def create_cash_account(self, coa_model, *, code, name):
+        return coa_model.create_account(
+            code=code,
+            name=name,
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+    def create_entity_with_two_coas(self, *, name="API Account QuerySet Entity", admin=None):
+        entity_model = self.create_entity(name=name, admin=admin)
+        default_coa = self.create_coa(
+            entity_model,
+            name=f"{name} Default CoA",
+            assign_as_default=True,
+        )
+        secondary_coa = self.create_coa(
+            entity_model,
+            name=f"{name} Secondary CoA",
+            assign_as_default=False,
+        )
+        default_account = self.create_cash_account(
+            default_coa,
+            code="1010",
+            name=f"{name} Default Cash",
+        )
+        secondary_account = self.create_cash_account(
+            secondary_coa,
+            code="1010",
+            name=f"{name} Secondary Cash",
+        )
+        return entity_model, default_coa, secondary_coa, default_account, secondary_account
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        (
+            entity_model,
+            _default_coa,
+            _secondary_coa,
+            account_model,
+            _secondary_account,
+        ) = self.create_entity_with_two_coas(name="API Account For Entity A")
+        (
+            _other_entity,
+            _other_default_coa,
+            _other_secondary_coa,
+            other_account,
+            _other_secondary_account,
+        ) = self.create_entity_with_two_coas(
+            name="API Account For Entity B",
+            admin=self.other_admin_user,
+        )
+
+        for entity_lookup in (entity_model, entity_model.slug, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                account_qs = AccountModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(account_qs.filter(uuid=account_model.uuid).exists())
+                self.assertFalse(account_qs.filter(uuid=other_account.uuid).exists())
+
+    def test_for_entity_uses_default_coa_when_no_explicit_coa_is_passed(self):
+        (
+            entity_model,
+            _default_coa,
+            _secondary_coa,
+            default_account,
+            secondary_account,
+        ) = self.create_entity_with_two_coas(name="API Account Default CoA Scope")
+
+        account_qs = AccountModel.objects.for_entity(entity_model)
+
+        self.assertTrue(account_qs.filter(uuid=default_account.uuid).exists())
+        self.assertFalse(account_qs.filter(uuid=secondary_account.uuid).exists())
+
+    def test_for_entity_accepts_explicit_coa_model_slug_and_uuid(self):
+        (
+            entity_model,
+            _default_coa,
+            secondary_coa,
+            default_account,
+            secondary_account,
+        ) = self.create_entity_with_two_coas(name="API Account Explicit CoA Scope")
+
+        for coa_lookup in (secondary_coa, secondary_coa.slug, secondary_coa.uuid):
+            with self.subTest(coa_lookup=coa_lookup):
+                account_qs = AccountModel.objects.for_entity(
+                    entity_model,
+                    coa_model=coa_lookup,
+                )
+
+                self.assertTrue(account_qs.filter(uuid=secondary_account.uuid).exists())
+                self.assertFalse(account_qs.filter(uuid=default_account.uuid).exists())
+
+    def test_for_entity_rejects_invalid_entity_input(self):
+        with self.assertRaises(AccountModelValidationError):
+            AccountModel.objects.for_entity(object())
+
+    def test_for_entity_rejects_invalid_coa_input(self):
+        entity_model = self.create_entity(name="API Account Invalid CoA Entity")
+
+        with self.assertRaises(AccountModelValidationError):
+            AccountModel.objects.for_entity(entity_model, coa_model=object())
+
+    def test_for_user_scopes_accounts_by_entity_access(self):
+        (
+            entity_model,
+            _default_coa,
+            _secondary_coa,
+            account_model,
+            _secondary_account,
+        ) = self.create_entity_with_two_coas(name="API Account User Scope Entity")
+        (
+            _other_entity,
+            _other_default_coa,
+            _other_secondary_coa,
+            other_account,
+            _other_secondary_account,
+        ) = self.create_entity_with_two_coas(
+            name="API Account Other User Scope Entity",
+            admin=self.other_admin_user,
+        )
+
+        EntityManagementModel.objects.create(
+            entity=entity_model,
+            user=self.manager_user,
+            permission_level="read",
+        )
+
+        admin_qs = AccountModel.objects.for_user(self.admin_user)
+        manager_qs = AccountModel.objects.for_user(self.manager_user)
+        unrelated_qs = AccountModel.objects.for_user(self.unrelated_user)
+        superuser_qs = AccountModel.objects.for_user(self.superuser)
+
+        self.assertTrue(admin_qs.filter(uuid=account_model.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_account.uuid).exists())
+
+        self.assertTrue(manager_qs.filter(uuid=account_model.uuid).exists())
+        self.assertFalse(manager_qs.filter(uuid=other_account.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=account_model.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_account.uuid).exists())
+
+        self.assertTrue(superuser_qs.filter(uuid=account_model.uuid).exists())
+        self.assertTrue(superuser_qs.filter(uuid=other_account.uuid).exists())

--- a/django_ledger/tests/api/test_account_role_code_api.py
+++ b/django_ledger/tests/api/test_account_role_code_api.py
@@ -1,0 +1,242 @@
+"""
+High-level API behavior tests for AccountModel role and code helpers.
+
+These tests cover validation, representative role mappings, account-code
+generation/cleaning, and role-default contracts.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    COGS,
+    CREDIT,
+    DEBIT,
+    EQUITY_CAPITAL,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+    ROOT_ASSETS,
+    ROOT_CAPITAL,
+    ROOT_COA,
+    ROOT_EXPENSES,
+    ROOT_GROUP,
+    ROOT_INCOME,
+    ROOT_LIABILITIES,
+)
+from django_ledger.models import AccountModel
+from django_ledger.models.accounts import (
+    AccountModelValidationError,
+    account_code_validator,
+)
+from django_ledger.models.chart_of_accounts import ChartOfAccountsModelValidationError
+from django_ledger.models.entity import EntityModel
+from django_ledger.settings import (
+    DJANGO_LEDGER_ACCOUNT_CODE_GENERATE,
+    DJANGO_LEDGER_ACCOUNT_CODE_USE_PREFIX,
+)
+
+
+class AccountRoleCodeAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_account_role_code_user",
+            email="api-account-role-code-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Account Role Code Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_entity_with_default_coa(self, *, name="API Account Role Code Entity"):
+        entity_model = self.create_entity(name=name)
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def make_account(
+        self,
+        *,
+        role=ASSET_CA_CASH,
+        balance_type=DEBIT,
+        code="1010",
+        name="API Role Code Account",
+    ):
+        return AccountModel(
+            code=code,
+            name=name,
+            role=role,
+            balance_type=balance_type,
+            active=True,
+        )
+
+    def test_account_code_validator_accepts_alphanumeric_codes(self):
+        for code in ("1010", "ABC123", "cash001"):
+            with self.subTest(code=code):
+                account_code_validator(code)
+
+    def test_account_code_validator_rejects_non_alphanumeric_codes(self):
+        for code in ("10-10", "cash_001", "cash 001"):
+            with self.subTest(code=code):
+                with self.assertRaises(AccountModelValidationError):
+                    account_code_validator(code)
+
+    def test_get_code_prefix_returns_representative_role_prefixes(self):
+        role_cases = (
+            (ASSET_CA_CASH, DEBIT, "1"),
+            (LIABILITY_CL_ACC_PAYABLE, CREDIT, "2"),
+            (EQUITY_CAPITAL, CREDIT, "3"),
+            (INCOME_OPERATIONAL, CREDIT, "4"),
+            (COGS, DEBIT, "5"),
+            (EXPENSE_OPERATIONAL, DEBIT, "6"),
+        )
+
+        for role, balance_type, expected_prefix in role_cases:
+            with self.subTest(role=role):
+                account_model = self.make_account(
+                    role=role,
+                    balance_type=balance_type,
+                    code=f"{expected_prefix}010",
+                )
+
+                self.assertEqual(account_model.get_code_prefix(), expected_prefix)
+
+    def test_get_root_role_returns_representative_role_mappings(self):
+        role_cases = (
+            (ASSET_CA_CASH, DEBIT, ROOT_ASSETS),
+            (LIABILITY_CL_ACC_PAYABLE, CREDIT, ROOT_LIABILITIES),
+            (EQUITY_CAPITAL, CREDIT, ROOT_CAPITAL),
+            (INCOME_OPERATIONAL, CREDIT, ROOT_INCOME),
+            (EXPENSE_OPERATIONAL, DEBIT, ROOT_EXPENSES),
+            (ROOT_COA, DEBIT, ROOT_COA),
+        )
+
+        for role, balance_type, expected_root_role in role_cases:
+            with self.subTest(role=role):
+                account_model = self.make_account(
+                    role=role,
+                    balance_type=balance_type,
+                )
+
+                self.assertEqual(account_model.get_root_role(), expected_root_role)
+
+    def test_get_root_role_currently_returns_root_group_for_cogs(self):
+        account_model = self.make_account(
+            role=COGS,
+            balance_type=DEBIT,
+            code="5010",
+        )
+
+        self.assertEqual(account_model.get_root_role(), ROOT_GROUP)
+
+    def test_get_bs_bucket_returns_representative_buckets(self):
+        role_cases = (
+            (ASSET_CA_CASH, DEBIT, "Asset"),
+            (LIABILITY_CL_ACC_PAYABLE, CREDIT, "Liability"),
+            (EQUITY_CAPITAL, CREDIT, "Capital"),
+            (INCOME_OPERATIONAL, CREDIT, "Income"),
+            (COGS, DEBIT, "COGS"),
+            (EXPENSE_OPERATIONAL, DEBIT, "Expenses"),
+        )
+
+        for role, balance_type, expected_bucket in role_cases:
+            with self.subTest(role=role):
+                account_model = self.make_account(
+                    role=role,
+                    balance_type=balance_type,
+                )
+
+                self.assertEqual(account_model.get_bs_bucket(), expected_bucket)
+
+    def test_clean_validates_role_prefix_when_prefix_setting_is_enabled(self):
+        if not DJANGO_LEDGER_ACCOUNT_CODE_USE_PREFIX:
+            self.skipTest("Account code prefix validation is disabled by settings.")
+
+        account_model = self.make_account(
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            code="2010",
+        )
+
+        with self.assertRaises(AccountModelValidationError):
+            account_model.clean()
+
+    def test_clean_generates_account_code_with_role_prefix_when_enabled(self):
+        if not DJANGO_LEDGER_ACCOUNT_CODE_GENERATE:
+            self.skipTest("Account code generation is disabled by settings.")
+
+        account_model = self.make_account(
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            code="",
+        )
+
+        account_model.clean()
+
+        self.assertRegex(account_model.code, r"^1[0-9]{5}$")
+        self.assertTrue(account_model.code.isalnum())
+
+    def test_role_default_false_is_normalized_to_none_on_save(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Role Default Normalize Entity",
+        )
+
+        account_model = coa_model.create_account(
+            code="1010",
+            name="API Non Default Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=False,
+        )
+
+        account_model.refresh_from_db()
+        self.assertIsNone(account_model.role_default)
+
+    def test_role_default_uniqueness_rejects_second_default_for_same_role(self):
+        _entity_model, coa_model = self.create_entity_with_default_coa(
+            name="API Account Role Default Unique Entity",
+        )
+
+        first_default = coa_model.create_account(
+            code="1010",
+            name="API Default Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            coa_model.create_account(
+                code="1020",
+                name="API Second Default Cash Account",
+                role=ASSET_CA_CASH,
+                balance_type=DEBIT,
+                active=True,
+                is_role_default=True,
+            )
+
+        self.assertTrue(
+            AccountModel.objects.filter(uuid=first_default.uuid, role_default=True).exists()
+        )
+        self.assertFalse(
+            AccountModel.objects.filter(
+                coa_model=coa_model,
+                code="1020",
+                role=ASSET_CA_CASH,
+            ).exists()
+        )

--- a/django_ledger/tests/api/test_account_url_helpers_api.py
+++ b/django_ledger/tests/api/test_account_url_helpers_api.py
@@ -1,0 +1,85 @@
+"""
+Smoke tests for AccountModel URL helpers.
+
+These tests verify that account URL helpers resolve to entity/CoA/account
+scoped strings without exercising view permissions or HTTP responses.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models import AccountModel
+from django_ledger.models.entity import EntityModel
+
+
+class AccountURLHelpersAPITest(TestCase):
+    ACCOUNT_SCOPED_URL_HELPERS = (
+        "get_absolute_url",
+        "get_update_url",
+        "get_action_deactivate_url",
+        "get_action_activate_url",
+        "get_action_lock_url",
+        "get_action_unlock_url",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_account_url_helpers_user",
+            email="api-account-url-helpers-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.entity_model = EntityModel.create_entity(
+            name="API Account URL Helpers Entity",
+            admin=cls.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        cls.coa_model = cls.entity_model.create_chart_of_accounts(
+            coa_name="API Account URL Helpers CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cls.entity_model.refresh_from_db()
+        created_account = cls.coa_model.create_account(
+            code="1010",
+            name="API Account URL Helpers Cash",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+        cls.account_model = AccountModel.objects.get(uuid=created_account.uuid)
+
+    def assert_url_contains_entity_and_coa_slugs(self, url):
+        self.assertIsInstance(url, str)
+        self.assertTrue(url)
+        self.assertIn(self.entity_model.slug, url)
+        self.assertIn(self.coa_model.slug, url)
+
+    def assert_url_contains_account_uuid(self, url):
+        self.assertIn(str(self.account_model.uuid), url)
+
+    def test_account_scoped_url_helpers_return_entity_coa_and_account_urls(self):
+        urls_by_helper = {}
+
+        for helper_name in self.ACCOUNT_SCOPED_URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(self.account_model, helper_name)()
+                urls_by_helper[helper_name] = url
+
+                self.assert_url_contains_entity_and_coa_slugs(url)
+                self.assert_url_contains_account_uuid(url)
+
+        self.assertEqual(
+            len(set(urls_by_helper.values())),
+            len(self.ACCOUNT_SCOPED_URL_HELPERS),
+        )
+
+    def test_get_coa_account_list_url_returns_entity_and_coa_scoped_url(self):
+        url = self.account_model.get_coa_account_list_url()
+
+        self.assert_url_contains_entity_and_coa_slugs(url)
+        self.assertNotIn(str(self.account_model.uuid), url)

--- a/django_ledger/tests/api/test_bank_account_api.py
+++ b/django_ledger/tests/api/test_bank_account_api.py
@@ -1,0 +1,223 @@
+"""
+High-level API behavior tests for BankAccountModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import BankAccountModel
+from django_ledger.models.bank_account import BankAccountValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class BankAccountHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for BankAccountModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic bank-account invariants that should
+    remain true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_bank_account_contract_user",
+            email="api-bank-account-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Bank Account Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+        }
+
+    def create_bank_account(
+        self,
+        setup,
+        *,
+        name="API Bank Account",
+        account_number="000123456789",
+        routing_number="000111000",
+        active=False,
+        hidden=False,
+    ):
+        bank_account = BankAccountModel(
+            name=name,
+            account_model=setup["cash_account"],
+            account_number=account_number,
+            routing_number=routing_number,
+            active=active,
+            hidden=hidden,
+        )
+
+        bank_account.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+
+        bank_account.refresh_from_db()
+        return bank_account
+
+    def test_bank_account_configure_binds_entity_and_account(self):
+        setup = self.create_entity_setup()
+
+        bank_account = self.create_bank_account(setup)
+
+        self.assertIsInstance(bank_account, BankAccountModel)
+        self.assertIsNotNone(bank_account.uuid)
+        self.assertEqual(bank_account.entity_model_id, setup["entity_model"].uuid)
+        self.assertEqual(bank_account.account_model_id, setup["cash_account"].uuid)
+        self.assertEqual(bank_account.name, "API Bank Account")
+        self.assertEqual(bank_account.account_number, "000123456789")
+        self.assertEqual(bank_account.routing_number, "000111000")
+
+    def test_bank_account_for_entity_limits_queryset_to_entity_scope(self):
+        setup = self.create_entity_setup(name="API Bank Account Entity A")
+        other_setup = self.create_entity_setup(name="API Bank Account Entity B")
+
+        bank_account = self.create_bank_account(
+            setup,
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+
+        other_bank_account = self.create_bank_account(
+            other_setup,
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+
+        scoped_qs = BankAccountModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=bank_account.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_bank_account.uuid).exists())
+
+    def test_bank_account_active_queryset_and_state_transitions(self):
+        setup = self.create_entity_setup()
+
+        bank_account = self.create_bank_account(setup, active=False)
+
+        bank_accounts_qs = BankAccountModel.objects.for_entity(setup["entity_model"])
+
+        self.assertFalse(bank_account.is_active())
+        self.assertTrue(bank_account.can_activate())
+        self.assertFalse(bank_accounts_qs.active().filter(uuid=bank_account.uuid).exists())
+
+        bank_account.mark_as_active(commit=True)
+        bank_account.refresh_from_db()
+
+        self.assertTrue(bank_account.is_active())
+        self.assertTrue(bank_account.can_inactivate())
+        self.assertTrue(bank_accounts_qs.active().filter(uuid=bank_account.uuid).exists())
+
+        bank_account.mark_as_inactive(commit=True)
+        bank_account.refresh_from_db()
+
+        self.assertFalse(bank_account.is_active())
+        self.assertTrue(bank_account.can_activate())
+        self.assertFalse(bank_accounts_qs.active().filter(uuid=bank_account.uuid).exists())
+
+    def test_bank_account_hidden_queryset_and_state_helpers(self):
+        setup = self.create_entity_setup()
+
+        visible_bank_account = self.create_bank_account(
+            setup,
+            account_number="000123456789",
+            routing_number="000111000",
+            hidden=False,
+        )
+
+        hidden_bank_account = self.create_bank_account(
+            setup,
+            account_number="000987654321",
+            routing_number="000222000",
+            hidden=True,
+        )
+
+        bank_accounts_qs = BankAccountModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(visible_bank_account.can_hide())
+        self.assertFalse(visible_bank_account.can_unhide())
+
+        self.assertFalse(hidden_bank_account.can_hide())
+        self.assertTrue(hidden_bank_account.can_unhide())
+
+        self.assertFalse(bank_accounts_qs.hidden().filter(uuid=visible_bank_account.uuid).exists())
+        self.assertTrue(bank_accounts_qs.hidden().filter(uuid=hidden_bank_account.uuid).exists())
+
+    def test_bank_account_rejects_invalid_entity_configure_input(self):
+        setup = self.create_entity_setup()
+
+        bank_account = BankAccountModel(
+            name="API Invalid Bank Account",
+            account_model=setup["cash_account"],
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+
+        with self.assertRaises(BankAccountValidationError):
+            bank_account.configure(
+                entity_slug=None,
+                user_model=self.user,
+                commit=True,
+            )
+
+    def test_bank_account_requires_user_model_when_configuring_with_slug(self):
+        setup = self.create_entity_setup()
+
+        bank_account = BankAccountModel(
+            name="API Slug Bank Account",
+            account_model=setup["cash_account"],
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+
+        with self.assertRaises(BankAccountValidationError):
+            bank_account.configure(
+                entity_slug=setup["entity_model"].slug,
+                user_model=None,
+                commit=True,
+            )

--- a/django_ledger/tests/api/test_bank_account_configure_api.py
+++ b/django_ledger/tests/api/test_bank_account_configure_api.py
@@ -1,0 +1,152 @@
+"""
+High-level API behavior tests for BankAccountModel.configure().
+
+These tests cover direct bank account configuration without queryset or data
+import behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.http import Http404
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models import BankAccountModel
+from django_ledger.models.bank_account import BankAccountValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class BankAccountConfigureAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_bank_account_configure_admin",
+            email="api-bank-account-configure-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_bank_account_configure_unrelated",
+            email="api-bank-account-configure-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Bank Account Configure Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+        }
+
+    def make_bank_account(
+        self,
+        setup,
+        *,
+        name="API Bank Account Configure Account",
+        account_number="000123456789",
+        routing_number="000111000",
+    ):
+        return BankAccountModel(
+            name=name,
+            account_model=setup["cash_account"],
+            account_number=account_number,
+            routing_number=routing_number,
+            active=True,
+        )
+
+    def test_configure_with_entity_model_binds_entity_and_preserves_account(self):
+        setup = self.create_entity_setup(name="API Bank Account Configure Model Entity")
+        bank_account = self.make_bank_account(setup)
+
+        returned_bank_account, returned_entity = bank_account.configure(
+            entity_slug=setup["entity_model"],
+            user_model=None,
+            commit=True,
+        )
+
+        bank_account.refresh_from_db()
+
+        self.assertEqual(returned_bank_account, bank_account)
+        self.assertEqual(returned_entity, setup["entity_model"])
+        self.assertEqual(bank_account.entity_model_id, setup["entity_model"].uuid)
+        self.assertEqual(bank_account.account_model_id, setup["cash_account"].uuid)
+
+    def test_configure_with_slug_commit_false_updates_only_in_memory_state(self):
+        setup = self.create_entity_setup(name="API Bank Account Configure Commit False Entity")
+        bank_account = self.make_bank_account(setup)
+
+        returned_bank_account, returned_entity = bank_account.configure(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.admin_user,
+            commit=False,
+        )
+
+        self.assertEqual(returned_bank_account, bank_account)
+        self.assertEqual(returned_entity, setup["entity_model"])
+        self.assertEqual(bank_account.entity_model_id, setup["entity_model"].uuid)
+        self.assertFalse(BankAccountModel.objects.filter(uuid=bank_account.uuid).exists())
+
+    def test_configure_with_slug_commit_true_persists_entity_binding(self):
+        setup = self.create_entity_setup(name="API Bank Account Configure Commit True Entity")
+        bank_account = self.make_bank_account(setup)
+
+        bank_account.configure(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.admin_user,
+            commit=True,
+        )
+
+        bank_account.refresh_from_db()
+        self.assertEqual(bank_account.entity_model_id, setup["entity_model"].uuid)
+        self.assertEqual(bank_account.account_model_id, setup["cash_account"].uuid)
+
+    def test_configure_with_slug_requires_user_model(self):
+        setup = self.create_entity_setup(name="API Bank Account Configure Missing User Entity")
+        bank_account = self.make_bank_account(setup)
+
+        with self.assertRaises(BankAccountValidationError):
+            bank_account.configure(
+                entity_slug=setup["entity_model"].slug,
+                user_model=None,
+                commit=True,
+            )
+
+    def test_configure_with_slug_rejects_unrelated_user(self):
+        setup = self.create_entity_setup(name="API Bank Account Configure Unrelated Entity")
+        bank_account = self.make_bank_account(setup)
+
+        with self.assertRaises(Http404):
+            bank_account.configure(
+                entity_slug=setup["entity_model"].slug,
+                user_model=self.unrelated_user,
+                commit=True,
+            )
+
+    def test_configure_rejects_invalid_entity_input(self):
+        setup = self.create_entity_setup(name="API Bank Account Configure Invalid Entity")
+        bank_account = self.make_bank_account(setup)
+
+        with self.assertRaises(BankAccountValidationError):
+            bank_account.configure(
+                entity_slug=object(),
+                user_model=self.admin_user,
+                commit=True,
+            )

--- a/django_ledger/tests/api/test_bank_account_entity_mapping_api.py
+++ b/django_ledger/tests/api/test_bank_account_entity_mapping_api.py
@@ -1,0 +1,188 @@
+"""
+High-level API tests for EntityModel bank account mapping behavior.
+
+These tests cover small user-visible BankAccountModel behaviors that sit at
+the EntityModel.create_bank_account() boundary.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, CREDIT, DEBIT, LIABILITY_CL_ACC_PAYABLE
+from django_ledger.models.bank_account import BankAccountModel
+from django_ledger.models.entity import EntityModel
+
+
+class BankAccountEntityMappingAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_bank_account_entity_mapping_admin",
+            email="api-bank-account-entity-mapping-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Bank Account Entity Mapping Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(self, entity_model, *, name, assign_as_default=False):
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=assign_as_default,
+        )
+        entity_model.refresh_from_db()
+        return coa_model
+
+    def create_default_account(self, coa_model, *, code, role, balance_type, name):
+        return coa_model.create_account(
+            code=code,
+            name=name,
+            role=role,
+            balance_type=balance_type,
+            active=True,
+            is_role_default=True,
+        )
+
+    def create_entity_with_default_cash_account(
+        self,
+        *,
+        name="API Bank Account Entity Mapping Cash Entity",
+    ):
+        entity_model = self.create_entity(name=name)
+        coa_model = self.create_coa(
+            entity_model,
+            name=f"{name} CoA",
+            assign_as_default=True,
+        )
+        cash_account = self.create_default_account(
+            coa_model,
+            code="1010",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            name=f"{name} Cash",
+        )
+        return entity_model, coa_model, cash_account
+
+    def test_str_includes_account_type_display_and_name(self):
+        entity_model, _coa_model, _cash_account = self.create_entity_with_default_cash_account(
+            name="API Bank Account String Entity",
+        )
+        bank_account = entity_model.create_bank_account(
+            name="API Readable Bank Account",
+            account_type=BankAccountModel.ACCOUNT_CHECKING,
+            active=True,
+            bank_account_model_kwargs={
+                "account_number": "000000001",
+                "routing_number": "000000101",
+            },
+        )
+
+        display_value = str(bank_account)
+
+        self.assertIsInstance(display_value, str)
+        self.assertTrue(display_value)
+        self.assertIn("Checking", display_value)
+        self.assertIn("Bank Account", display_value)
+        self.assertIn("API Readable Bank Account", display_value)
+
+    def test_entity_create_bank_account_commit_false_does_not_persist(self):
+        entity_model, _coa_model, cash_account = self.create_entity_with_default_cash_account(
+            name="API Bank Account Commit False Entity",
+        )
+        bank_account_count = BankAccountModel.objects.count()
+
+        bank_account = entity_model.create_bank_account(
+            name="API Unsaved Bank Account",
+            account_type=BankAccountModel.ACCOUNT_CHECKING,
+            active=True,
+            bank_account_model_kwargs={
+                "account_number": "000000002",
+                "routing_number": "000000102",
+            },
+            commit=False,
+        )
+
+        self.assertEqual(bank_account.entity_model_id, entity_model.uuid)
+        self.assertEqual(bank_account.account_model_id, cash_account.uuid)
+        self.assertTrue(bank_account.active)
+        self.assertEqual(BankAccountModel.objects.count(), bank_account_count)
+        self.assertFalse(BankAccountModel.objects.filter(uuid=bank_account.uuid).exists())
+
+    def test_entity_create_bank_account_maps_credit_card_to_default_liability_account(self):
+        entity_model = self.create_entity(name="API Credit Card Mapping Entity")
+        coa_model = self.create_coa(
+            entity_model,
+            name="API Credit Card Mapping CoA",
+            assign_as_default=True,
+        )
+        payable_account = self.create_default_account(
+            coa_model,
+            code="2010",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type=CREDIT,
+            name="API Credit Card Payable",
+        )
+
+        bank_account = entity_model.create_bank_account(
+            name="API Credit Card Account",
+            account_type=BankAccountModel.ACCOUNT_CREDIT_CARD,
+            active=True,
+            bank_account_model_kwargs={
+                "account_number": "000000003",
+                "routing_number": "000000103",
+            },
+        )
+
+        self.assertEqual(bank_account.account_model_id, payable_account.uuid)
+        self.assertEqual(bank_account.account_model.role, LIABILITY_CL_ACC_PAYABLE)
+        self.assertTrue(bank_account.account_model.role_default)
+
+    def test_entity_create_bank_account_uses_explicit_coa_for_default_account_selection(self):
+        entity_model = self.create_entity(name="API Bank Account Explicit CoA Entity")
+        default_coa = self.create_coa(
+            entity_model,
+            name="API Bank Account Default CoA",
+            assign_as_default=True,
+        )
+        secondary_coa = self.create_coa(
+            entity_model,
+            name="API Bank Account Secondary CoA",
+            assign_as_default=False,
+        )
+        default_cash_account = self.create_default_account(
+            default_coa,
+            code="1010",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            name="API Default CoA Cash",
+        )
+        secondary_cash_account = self.create_default_account(
+            secondary_coa,
+            code="1010",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            name="API Secondary CoA Cash",
+        )
+
+        bank_account = entity_model.create_bank_account(
+            name="API Explicit CoA Bank Account",
+            account_type=BankAccountModel.ACCOUNT_CHECKING,
+            active=True,
+            coa_model=secondary_coa.slug,
+            bank_account_model_kwargs={
+                "account_number": "000000004",
+                "routing_number": "000000104",
+            },
+        )
+
+        self.assertEqual(bank_account.account_model_id, secondary_cash_account.uuid)
+        self.assertNotEqual(bank_account.account_model_id, default_cash_account.uuid)
+        self.assertEqual(bank_account.account_model.coa_model_id, secondary_coa.uuid)

--- a/django_ledger/tests/api/test_bank_account_financial_info_api.py
+++ b/django_ledger/tests/api/test_bank_account_financial_info_api.py
@@ -1,0 +1,67 @@
+"""
+High-level API behavior tests for BankAccountModel financial account helpers.
+
+These tests cover public helpers inherited from FinancialAccountInfoMixin
+without exercising import or reconciliation flows.
+"""
+
+from django.core.exceptions import ValidationError
+from django.test import SimpleTestCase, TestCase
+
+from django_ledger.models import BankAccountModel
+
+
+class BankAccountFinancialInfoAPITest(SimpleTestCase):
+    def test_get_account_last_digits_masks_default_and_custom_lengths(self):
+        bank_account = BankAccountModel(account_number="000123456789")
+
+        self.assertEqual(bank_account.get_account_last_digits(), "*6789")
+        self.assertEqual(bank_account.get_account_last_digits(n=6), "*456789")
+
+    def test_get_account_last_digits_returns_fallback_when_missing(self):
+        bank_account = BankAccountModel(account_number="")
+
+        self.assertEqual(bank_account.get_account_last_digits(), "Not Available")
+
+    def test_get_routing_last_digits_masks_default_and_custom_lengths(self):
+        bank_account = BankAccountModel(routing_number="000111222")
+
+        self.assertEqual(bank_account.get_routing_last_digits(), "*1222")
+        self.assertEqual(bank_account.get_routing_last_digits(n=6), "*111222")
+
+    def test_get_routing_last_digits_returns_fallback_when_missing(self):
+        bank_account = BankAccountModel(routing_number=None)
+
+        self.assertEqual(bank_account.get_routing_last_digits(), "Not Available")
+
+    def test_get_account_type_from_ofx_maps_known_and_unknown_types(self):
+        bank_account = BankAccountModel()
+
+        ofx_cases = (
+            ("CHECKING", BankAccountModel.ACCOUNT_CHECKING),
+            ("SAVINGS", BankAccountModel.ACCOUNT_SAVINGS),
+            ("CREDITLINE", BankAccountModel.ACCOUNT_CREDIT_CARD),
+            ("CD", BankAccountModel.ACCOUNT_CERT_DEPOSIT),
+            ("NOT_A_REAL_OFX_TYPE", BankAccountModel.ACCOUNT_OTHER),
+        )
+
+        for ofx_type, expected_account_type in ofx_cases:
+            with self.subTest(ofx_type=ofx_type):
+                self.assertEqual(
+                    bank_account.get_account_type_from_ofx(ofx_type),
+                    expected_account_type,
+                )
+
+
+class BankAccountFinancialInfoValidationAPITest(TestCase):
+    def test_non_digit_account_number_fails_model_validation(self):
+        bank_account = BankAccountModel(account_number="12-34")
+
+        with self.assertRaises(ValidationError):
+            bank_account.full_clean(exclude=["entity_model", "account_model"])
+
+    def test_non_digit_routing_number_fails_model_validation(self):
+        bank_account = BankAccountModel(routing_number="routing-123")
+
+        with self.assertRaises(ValidationError):
+            bank_account.full_clean(exclude=["entity_model", "account_model"])

--- a/django_ledger/tests/api/test_bank_account_lifecycle_api.py
+++ b/django_ledger/tests/api/test_bank_account_lifecycle_api.py
@@ -1,0 +1,206 @@
+"""
+High-level API behavior tests for BankAccountModel lifecycle helpers.
+
+These tests cover direct active/hidden state helpers without data import or
+staged transaction behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models import BankAccountModel
+from django_ledger.models.bank_account import BankAccountValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class BankAccountLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_bank_account_lifecycle_user",
+            email="api-bank-account-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Bank Account Lifecycle Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+        }
+
+    def create_bank_account(
+        self,
+        setup,
+        *,
+        name="API Bank Account Lifecycle Account",
+        account_number="000123456789",
+        routing_number="000111000",
+        active=False,
+        hidden=False,
+    ):
+        bank_account = BankAccountModel(
+            name=name,
+            account_model=setup["cash_account"],
+            account_number=account_number,
+            routing_number=routing_number,
+            active=active,
+            hidden=hidden,
+        )
+        bank_account.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        bank_account.refresh_from_db()
+        return bank_account
+
+    def test_active_predicates_reflect_current_active_state(self):
+        setup = self.create_entity_setup()
+        inactive_bank_account = self.create_bank_account(
+            setup,
+            name="API Inactive Predicate Bank Account",
+            active=False,
+        )
+        active_bank_account = self.create_bank_account(
+            setup,
+            name="API Active Predicate Bank Account",
+            account_number="000987654321",
+            routing_number="000222000",
+            active=True,
+        )
+
+        self.assertFalse(inactive_bank_account.is_active())
+        self.assertTrue(inactive_bank_account.can_activate())
+        self.assertFalse(inactive_bank_account.can_inactivate())
+
+        self.assertTrue(active_bank_account.is_active())
+        self.assertFalse(active_bank_account.can_activate())
+        self.assertTrue(active_bank_account.can_inactivate())
+
+    def test_mark_as_active_commit_false_updates_only_in_memory_state(self):
+        setup = self.create_entity_setup(name="API Bank Account Active Commit False Entity")
+        bank_account = self.create_bank_account(setup, active=False)
+
+        bank_account.mark_as_active(commit=False)
+
+        self.assertTrue(bank_account.active)
+
+        bank_account.refresh_from_db()
+        self.assertFalse(bank_account.active)
+
+    def test_mark_as_active_commit_true_persists_active_state(self):
+        setup = self.create_entity_setup(name="API Bank Account Active Commit True Entity")
+        bank_account = self.create_bank_account(setup, active=False)
+
+        bank_account.mark_as_active(commit=True)
+
+        bank_account.refresh_from_db()
+        self.assertTrue(bank_account.active)
+
+    def test_mark_as_inactive_commit_false_updates_only_in_memory_state(self):
+        setup = self.create_entity_setup(name="API Bank Account Inactive Commit False Entity")
+        bank_account = self.create_bank_account(setup, active=True)
+
+        bank_account.mark_as_inactive(commit=False)
+
+        self.assertFalse(bank_account.active)
+
+        bank_account.refresh_from_db()
+        self.assertTrue(bank_account.active)
+
+    def test_mark_as_inactive_commit_true_persists_inactive_state(self):
+        setup = self.create_entity_setup(name="API Bank Account Inactive Commit True Entity")
+        bank_account = self.create_bank_account(setup, active=True)
+
+        bank_account.mark_as_inactive(commit=True)
+
+        bank_account.refresh_from_db()
+        self.assertFalse(bank_account.active)
+
+    def test_invalid_active_transitions_with_raise_exception_true_raise_validation_error(self):
+        setup = self.create_entity_setup(name="API Bank Account Invalid Raise Entity")
+        active_bank_account = self.create_bank_account(
+            setup,
+            name="API Already Active Bank Account",
+            active=True,
+        )
+        inactive_bank_account = self.create_bank_account(
+            setup,
+            name="API Already Inactive Bank Account",
+            account_number="000987654321",
+            routing_number="000222000",
+            active=False,
+        )
+
+        with self.assertRaises(BankAccountValidationError):
+            active_bank_account.mark_as_active(commit=True)
+
+        with self.assertRaises(BankAccountValidationError):
+            inactive_bank_account.mark_as_inactive(commit=True)
+
+    def test_invalid_active_transitions_with_raise_exception_false_are_noops(self):
+        setup = self.create_entity_setup(name="API Bank Account Invalid Noop Entity")
+        active_bank_account = self.create_bank_account(
+            setup,
+            name="API Already Active Noop Bank Account",
+            active=True,
+        )
+        inactive_bank_account = self.create_bank_account(
+            setup,
+            name="API Already Inactive Noop Bank Account",
+            account_number="000987654321",
+            routing_number="000222000",
+            active=False,
+        )
+
+        active_bank_account.mark_as_active(commit=True, raise_exception=False)
+        inactive_bank_account.mark_as_inactive(commit=True, raise_exception=False)
+
+        active_bank_account.refresh_from_db()
+        inactive_bank_account.refresh_from_db()
+
+        self.assertTrue(active_bank_account.active)
+        self.assertFalse(inactive_bank_account.active)
+
+    def test_hidden_predicates_reflect_current_hidden_state(self):
+        setup = self.create_entity_setup(name="API Bank Account Hidden Predicate Entity")
+        visible_bank_account = self.create_bank_account(
+            setup,
+            name="API Visible Bank Account",
+            hidden=False,
+        )
+        hidden_bank_account = self.create_bank_account(
+            setup,
+            name="API Hidden Bank Account",
+            account_number="000987654321",
+            routing_number="000222000",
+            hidden=True,
+        )
+
+        self.assertTrue(visible_bank_account.can_hide())
+        self.assertFalse(visible_bank_account.can_unhide())
+
+        self.assertFalse(hidden_bank_account.can_hide())
+        self.assertTrue(hidden_bank_account.can_unhide())

--- a/django_ledger/tests/api/test_bank_account_queryset_api.py
+++ b/django_ledger/tests/api/test_bank_account_queryset_api.py
@@ -1,0 +1,246 @@
+"""
+High-level API behavior tests for BankAccountModel queryset helpers.
+
+These tests cover entity/user scoping and simple public queryset filters
+without exercising data import or staged transaction behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models import BankAccountModel
+from django_ledger.models.bank_account import BankAccountValidationError
+from django_ledger.models.entity import EntityManagementModel, EntityModel
+
+
+class BankAccountQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_bank_account_queryset_admin",
+            email="api-bank-account-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_bank_account_queryset_other_admin",
+            email="api-bank-account-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_bank_account_queryset_manager",
+            email="api-bank-account-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_bank_account_queryset_unrelated",
+            email="api-bank-account-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_bank_account_queryset_superuser",
+            email="api-bank-account-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Bank Account QuerySet Entity", admin=None):
+        return EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Bank Account QuerySet Entity",
+        admin=None,
+    ):
+        entity_model = self.create_entity(name=name, admin=admin)
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+        }
+
+    def create_bank_account(
+        self,
+        setup,
+        *,
+        name="API Bank Account QuerySet Account",
+        account_number="000123456789",
+        routing_number="000111000",
+        active=True,
+        hidden=False,
+    ):
+        bank_account = BankAccountModel(
+            name=name,
+            account_model=setup["cash_account"],
+            account_number=account_number,
+            routing_number=routing_number,
+            active=active,
+            hidden=hidden,
+        )
+        bank_account.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            commit=True,
+        )
+        bank_account.refresh_from_db()
+        return bank_account
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Bank Account For Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Bank Account For Entity B",
+            admin=self.other_admin_user,
+        )
+        bank_account = self.create_bank_account(
+            setup,
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+        other_bank_account = self.create_bank_account(
+            other_setup,
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+        entity_model = setup["entity_model"]
+
+        for entity_lookup in (entity_model, entity_model.slug, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                bank_account_qs = BankAccountModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(bank_account_qs.filter(uuid=bank_account.uuid).exists())
+                self.assertFalse(
+                    bank_account_qs.filter(uuid=other_bank_account.uuid).exists()
+                )
+
+    def test_for_entity_rejects_invalid_input(self):
+        with self.assertRaises(BankAccountValidationError):
+            BankAccountModel.objects.for_entity(object())
+
+    def test_for_user_scopes_bank_accounts_by_entity_access(self):
+        setup = self.create_entity_setup(name="API Bank Account User Scope Entity")
+        other_setup = self.create_entity_setup(
+            name="API Bank Account Other User Scope Entity",
+            admin=self.other_admin_user,
+        )
+        bank_account = self.create_bank_account(
+            setup,
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+        other_bank_account = self.create_bank_account(
+            other_setup,
+            account_number="000123456789",
+            routing_number="000111000",
+        )
+
+        EntityManagementModel.objects.create(
+            entity=setup["entity_model"],
+            user=self.manager_user,
+            permission_level="read",
+        )
+
+        bank_account_qs = BankAccountModel.objects.all()
+        admin_qs = bank_account_qs.for_user(self.admin_user)
+        manager_qs = bank_account_qs.for_user(self.manager_user)
+        unrelated_qs = bank_account_qs.for_user(self.unrelated_user)
+        superuser_qs = bank_account_qs.for_user(self.superuser)
+
+        self.assertTrue(admin_qs.filter(uuid=bank_account.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_bank_account.uuid).exists())
+
+        self.assertTrue(manager_qs.filter(uuid=bank_account.uuid).exists())
+        self.assertFalse(manager_qs.filter(uuid=other_bank_account.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=bank_account.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_bank_account.uuid).exists())
+
+        self.assertTrue(superuser_qs.filter(uuid=bank_account.uuid).exists())
+        self.assertTrue(superuser_qs.filter(uuid=other_bank_account.uuid).exists())
+
+    def test_active_and_hidden_filters_return_matching_bank_accounts(self):
+        setup = self.create_entity_setup(name="API Bank Account Filter Entity")
+        active_bank_account = self.create_bank_account(
+            setup,
+            name="API Active Bank Account",
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+            hidden=False,
+        )
+        inactive_bank_account = self.create_bank_account(
+            setup,
+            name="API Inactive Bank Account",
+            account_number="000987654321",
+            routing_number="000222000",
+            active=False,
+            hidden=False,
+        )
+        hidden_bank_account = self.create_bank_account(
+            setup,
+            name="API Hidden Bank Account",
+            account_number="000555555555",
+            routing_number="000333000",
+            active=True,
+            hidden=True,
+        )
+
+        bank_account_qs = BankAccountModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(
+            bank_account_qs.active().filter(uuid=active_bank_account.uuid).exists()
+        )
+        self.assertTrue(
+            bank_account_qs.active().filter(uuid=hidden_bank_account.uuid).exists()
+        )
+        self.assertFalse(
+            bank_account_qs.active().filter(uuid=inactive_bank_account.uuid).exists()
+        )
+
+        self.assertTrue(
+            bank_account_qs.hidden().filter(uuid=hidden_bank_account.uuid).exists()
+        )
+        self.assertFalse(
+            bank_account_qs.hidden().filter(uuid=active_bank_account.uuid).exists()
+        )
+
+    def test_configure_with_entity_slug_and_authorized_user_binds_entity(self):
+        setup = self.create_entity_setup(name="API Bank Account Configure Slug Entity")
+        bank_account = BankAccountModel(
+            name="API Slug Configured Bank Account",
+            account_model=setup["cash_account"],
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+        )
+
+        returned_bank_account, returned_entity = bank_account.configure(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.admin_user,
+            commit=True,
+        )
+
+        returned_bank_account.refresh_from_db()
+
+        self.assertEqual(returned_bank_account, bank_account)
+        self.assertEqual(returned_entity, setup["entity_model"])
+        self.assertEqual(bank_account.entity_model_id, setup["entity_model"].uuid)

--- a/django_ledger/tests/api/test_bill_api.py
+++ b/django_ledger/tests/api/test_bill_api.py
@@ -1,0 +1,272 @@
+"""
+High-level API behavior tests for BillModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import BillModel, ItemTransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class BillHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for BillModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic bill/vendor/item lifecycle invariants
+    that should remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_bill_contract_user",
+            email="api-bill-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_bill_setup(self, *, name="API Bill Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Bill Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name="API Bill Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name="API Bill Prepaid Account",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        unearned_account = coa_model.create_account(
+            code="2010",
+            name="API Bill Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name="API Bill Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name="API Bill Unit",
+            unit_abbr="api-bill",
+            active=True,
+            commit=True,
+        )
+
+        vendor_model = VendorModel(
+            vendor_name="API Bill Vendor",
+            entity_model=entity_model,
+            description="API Bill Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        expense_item = entity_model.create_item_expense(
+            name="API Bill Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "unearned_account": unearned_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+            "vendor_model": vendor_model,
+            "expense_item": expense_item,
+        }
+
+    def create_configured_bill(self, setup):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["unearned_account"],
+        )
+
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return bill_model
+
+    def migrate_expense_item(self, bill_model, setup, *, quantity="2.00", unit_cost="50.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+
+        itemtxs = {
+            setup["expense_item"].item_number: {
+                "quantity": quantity,
+                "unit_cost": unit_cost,
+                "total_amount": quantity * unit_cost,
+            }
+        }
+
+        bill_model.migrate_itemtxs(
+            itemtxs=itemtxs,
+            operation=BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def test_bill_configure_creates_draft_bill_under_entity_and_vendor(self):
+        setup = self.create_entity_with_bill_setup()
+
+        bill_model = self.create_configured_bill(setup)
+
+        self.assertIsInstance(bill_model, BillModel)
+        self.assertIsNotNone(bill_model.uuid)
+        self.assertEqual(bill_model.entity_model_id, setup["entity_model"].uuid)
+        self.assertEqual(bill_model.vendor_id, setup["vendor_model"].uuid)
+        self.assertTrue(bill_model.is_draft())
+        self.assertFalse(bill_model.is_approved())
+        self.assertFalse(bill_model.is_paid())
+        self.assertTrue(bill_model.bill_number)
+
+    def test_bill_item_migration_creates_item_transaction(self):
+        setup = self.create_entity_with_bill_setup()
+        bill_model = self.create_configured_bill(setup)
+
+        self.migrate_expense_item(bill_model, setup)
+
+        item_txs = ItemTransactionModel.objects.filter(bill_model=bill_model)
+
+        self.assertEqual(item_txs.count(), 1)
+
+        item_tx = item_txs.get()
+
+        self.assertEqual(item_tx.item_model_id, setup["expense_item"].uuid)
+        self.assertEqual(item_tx.quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.unit_cost, Decimal("50.00"))
+        self.assertEqual(item_tx.total_amount, Decimal("100.00"))
+
+    def test_bill_item_migration_updates_amount_due(self):
+        setup = self.create_entity_with_bill_setup()
+        bill_model = self.create_configured_bill(setup)
+
+        bill_model = self.migrate_expense_item(bill_model, setup)
+
+        self.assertEqual(bill_model.amount_due, Decimal("100.00"))
+        self.assertEqual(bill_model.amount_paid, Decimal("0.00"))
+
+    def test_bill_for_entity_queryset_limits_scope(self):
+        setup = self.create_entity_with_bill_setup(name="API Bill Entity A")
+        other_setup = self.create_entity_with_bill_setup(name="API Bill Entity B")
+
+        bill_model = self.create_configured_bill(setup)
+        other_bill_model = self.create_configured_bill(other_setup)
+
+        scoped_qs = BillModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=bill_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_bill_model.uuid).exists())
+
+    def test_bill_can_move_from_draft_to_review(self):
+        setup = self.create_entity_with_bill_setup()
+        bill_model = self.create_configured_bill(setup)
+        bill_model = self.migrate_expense_item(bill_model, setup)
+
+        bill_model.mark_as_review(commit=True)
+        bill_model.refresh_from_db()
+
+        self.assertTrue(bill_model.is_review())
+        self.assertFalse(bill_model.is_draft())
+
+    def test_bill_can_move_from_review_to_approved(self):
+        setup = self.create_entity_with_bill_setup()
+        bill_model = self.create_configured_bill(setup)
+        bill_model = self.migrate_expense_item(bill_model, setup)
+
+        bill_model.mark_as_review(commit=True)
+        bill_model.refresh_from_db()
+
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+
+        self.assertTrue(bill_model.is_approved())
+        self.assertFalse(bill_model.is_paid())
+        self.assertEqual(bill_model.amount_due, Decimal("100.00"))
+
+    def test_approved_bill_can_be_marked_paid(self):
+        setup = self.create_entity_with_bill_setup()
+        bill_model = self.create_configured_bill(setup)
+        bill_model = self.migrate_expense_item(bill_model, setup)
+
+        bill_model.mark_as_review(commit=True)
+        bill_model.refresh_from_db()
+
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+
+        bill_model.mark_as_paid(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+
+        self.assertTrue(bill_model.is_paid())
+        self.assertEqual(bill_model.amount_paid, bill_model.amount_due)

--- a/django_ledger/tests/api/test_bill_configure_itemization_api.py
+++ b/django_ledger/tests/api/test_bill_configure_itemization_api.py
@@ -1,0 +1,346 @@
+"""
+High-level API tests for BillModel configuration and itemization behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.http import Http404
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel, ItemTransactionModel
+from django_ledger.models.bill import BillModelValidationError
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class BillConfigureItemizationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_bill_configure_user",
+            email="api-bill-configure-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_bill_configure_unrelated",
+            email="api-bill-configure-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Bill Configure Entity",
+        use_accrual_method=True,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=use_accrual_method,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"{name[:8].lower().replace(' ', '-')}-u",
+            active=True,
+            commit=True,
+        )
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "payable_account": payable_account,
+            "expense_account": expense_account,
+            "vendor_model": vendor_model,
+            "expense_item": expense_item,
+            "inventory_item": inventory_item,
+            "service_item": service_item,
+        }
+
+    def build_bill(self, setup, **overrides):
+        bill_kwargs = {
+            "vendor": setup["vendor_model"],
+            "terms": BillModel.TERMS_NET_30,
+            "cash_account": setup["cash_account"],
+            "prepaid_account": setup["prepaid_account"],
+            "unearned_account": setup["payable_account"],
+        }
+        bill_kwargs.update(overrides)
+        return BillModel(**bill_kwargs)
+
+    def configure_bill(
+        self,
+        setup,
+        *,
+        entity_input=None,
+        user_model=None,
+        commit=True,
+        commit_ledger=False,
+        **bill_overrides,
+    ):
+        bill_model = self.build_bill(setup, **bill_overrides)
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"] if entity_input is None else entity_input,
+            user_model=self.user if user_model is None else user_model,
+            date_draft=date(2026, 1, 15),
+            ledger_name="API Bill Configure Ledger",
+            commit=commit,
+            commit_ledger=commit_ledger,
+        )
+        if commit:
+            bill_model.refresh_from_db()
+        return bill_model
+
+    def migrate_expense_item(self, bill_model, setup, *, quantity="2.00", unit_cost="50.00", operation=None):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        itemtxs = {
+            setup["expense_item"].item_number: {
+                "quantity": quantity,
+                "unit_cost": unit_cost,
+                "total_amount": quantity * unit_cost,
+            }
+        }
+        itemtxs_batch = bill_model.migrate_itemtxs(
+            itemtxs=itemtxs,
+            operation=operation or BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model, itemtxs_batch
+
+    def test_configure_accepts_entity_model_and_authorized_slug(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        by_model = self.configure_bill(setup, entity_input=entity_model)
+        by_slug = self.configure_bill(setup, entity_input=entity_model.slug)
+
+        self.assertEqual(by_model.entity_model_id, entity_model.uuid)
+        self.assertEqual(by_slug.entity_model_id, entity_model.uuid)
+        self.assertEqual(by_model.vendor_id, setup["vendor_model"].uuid)
+        self.assertEqual(by_slug.vendor_id, setup["vendor_model"].uuid)
+        self.assertTrue(by_model.bill_number)
+        self.assertTrue(by_slug.bill_number)
+
+    def test_configure_rejects_uuid_entity_input_and_unauthorized_slug(self):
+        setup = self.create_entity_setup(name="API Bill Configure Rejection Entity")
+
+        with self.assertRaises(BillModelValidationError):
+            self.configure_bill(setup, entity_input=setup["entity_model"].uuid)
+
+        with self.assertRaises(BillModelValidationError):
+            self.build_bill(setup).configure(entity_slug=setup["entity_model"].slug)
+
+        with self.assertRaises(Http404):
+            self.configure_bill(setup, entity_input=setup["entity_model"].slug, user_model=self.unrelated_user)
+
+    def test_configure_commit_false_persists_wrapper_ledger_but_not_bill(self):
+        setup = self.create_entity_setup(name="API Bill Configure Commit False Entity")
+
+        bill_model = self.configure_bill(setup, commit=False, commit_ledger=False)
+
+        self.assertTrue(bill_model.is_configured())
+        self.assertTrue(bill_model.bill_number)
+        self.assertIsNotNone(bill_model.ledger_id)
+        self.assertFalse(BillModel.objects.filter(uuid=bill_model.uuid).exists())
+        self.assertTrue(bill_model.ledger.__class__.objects.filter(uuid=bill_model.ledger_id).exists())
+        self.assertTrue(bill_model.ledger.ledger_xid)
+
+    def test_configure_commit_ledger_true_persists_ledger_without_persisting_bill(self):
+        setup = self.create_entity_setup(name="API Bill Configure Ledger Commit Entity")
+
+        bill_model = self.configure_bill(setup, commit=False, commit_ledger=True)
+
+        self.assertFalse(BillModel.objects.filter(uuid=bill_model.uuid).exists())
+        self.assertTrue(bill_model.ledger.__class__.objects.filter(uuid=bill_model.ledger_id).exists())
+
+    def test_configure_sets_accrual_behavior_from_entity_accounting_method(self):
+        accrual_setup = self.create_entity_setup(name="API Bill Configure Accrual Entity", use_accrual_method=True)
+        cash_setup = self.create_entity_setup(name="API Bill Configure Cash Entity", use_accrual_method=False)
+
+        accrual_bill = self.configure_bill(accrual_setup)
+        cash_bill = self.configure_bill(cash_setup)
+
+        self.assertTrue(accrual_bill.accrue)
+        self.assertEqual(accrual_bill.progress, Decimal("1.00"))
+        self.assertFalse(cash_bill.accrue)
+
+    def test_clean_rejects_invalid_account_roles(self):
+        setup = self.create_entity_setup(name="API Bill Configure Invalid Role Entity")
+
+        with self.assertRaises(ValidationError):
+            self.configure_bill(setup, cash_account=setup["expense_account"])
+
+        with self.assertRaises(ValidationError):
+            self.configure_bill(setup, prepaid_account=setup["cash_account"])
+
+        with self.assertRaises(ValidationError):
+            self.configure_bill(setup, unearned_account=setup["cash_account"])
+
+    def test_get_item_model_qs_returns_bill_eligible_items(self):
+        setup = self.create_entity_setup(name="API Bill Configure Item Query Entity")
+        bill_model = self.configure_bill(setup)
+
+        item_qs = bill_model.get_item_model_qs()
+
+        self.assertTrue(item_qs.filter(uuid=setup["expense_item"].uuid).exists())
+        self.assertTrue(item_qs.filter(uuid=setup["inventory_item"].uuid).exists())
+        self.assertFalse(item_qs.filter(uuid=setup["service_item"].uuid).exists())
+
+    def test_migrate_itemtxs_replace_creates_bill_items_and_updates_amount_due(self):
+        setup = self.create_entity_setup(name="API Bill Configure Item Migration Entity")
+        bill_model = self.configure_bill(setup)
+
+        bill_model, itemtxs_batch = self.migrate_expense_item(bill_model, setup)
+
+        self.assertEqual(len(itemtxs_batch), 1)
+        item_tx = ItemTransactionModel.objects.get(bill_model=bill_model)
+        self.assertEqual(item_tx.item_model_id, setup["expense_item"].uuid)
+        self.assertEqual(item_tx.quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.unit_cost, Decimal("50.00"))
+        self.assertEqual(item_tx.total_amount, Decimal("100.00"))
+        self.assertEqual(bill_model.amount_due, Decimal("100.00"))
+
+        bill_model, replacement_batch = self.migrate_expense_item(
+            bill_model,
+            setup,
+            quantity="1.00",
+            unit_cost="25.00",
+        )
+        self.assertEqual(len(replacement_batch), 1)
+        self.assertEqual(ItemTransactionModel.objects.filter(bill_model=bill_model).count(), 1)
+        self.assertEqual(bill_model.amount_due, Decimal("25.00"))
+
+    def test_validate_itemtxs_qs_rejects_transactions_from_another_bill(self):
+        setup = self.create_entity_setup(name="API Bill Configure Validate ItemTx Entity")
+        bill_model = self.configure_bill(setup)
+        other_bill_model = self.configure_bill(setup)
+        other_bill_model, _itemtxs_batch = self.migrate_expense_item(other_bill_model, setup)
+        other_itemtxs = list(ItemTransactionModel.objects.filter(bill_model=other_bill_model))
+
+        with self.assertRaises(BillModelValidationError):
+            bill_model.validate_itemtxs_qs(other_itemtxs)
+
+    def test_get_itemtxs_data_and_update_amount_due_use_item_transaction_totals(self):
+        setup = self.create_entity_setup(name="API Bill Configure Item Data Entity")
+        bill_model = self.configure_bill(setup)
+        bill_model, _itemtxs_batch = self.migrate_expense_item(bill_model, setup)
+
+        itemtxs_qs, itemtxs_data = bill_model.get_itemtxs_data()
+
+        self.assertEqual(itemtxs_qs.count(), 1)
+        self.assertEqual(itemtxs_data["total_amount__sum"], Decimal("100.00"))
+        self.assertEqual(itemtxs_data["total_items"], 1)
+
+        bill_model.amount_due = Decimal("0.00")
+        bill_model.update_amount_due(itemtxs_qs=itemtxs_qs)
+
+        self.assertEqual(bill_model.amount_due, Decimal("100.00"))

--- a/django_ledger/tests/api/test_bill_lifecycle_api.py
+++ b/django_ledger/tests/api/test_bill_lifecycle_api.py
@@ -1,0 +1,312 @@
+"""
+High-level API tests for BillModel lifecycle transitions.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_PREPAID,
+    EXPENSE_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel, ItemTransactionModel
+from django_ledger.models.bill import BillModelValidationError
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+
+
+class BillLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_bill_lifecycle_user",
+            email="api-bill-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Bill Lifecycle Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"b-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "vendor_model": vendor_model,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup, *, date_draft=date(2025, 1, 15)):
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            date_draft=date_draft,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def migrate_expense_item(self, bill_model, setup, *, total_amount=Decimal("100.00")):
+        bill_model.migrate_itemtxs(
+            itemtxs={
+                setup["expense_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": total_amount,
+                    "total_amount": total_amount,
+                }
+            },
+            operation=BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_review_bill(self, setup):
+        bill_model = self.migrate_expense_item(self.create_bill(setup), setup)
+        bill_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_approved_bill(self, setup):
+        bill_model = self.make_review_bill(setup)
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_paid_bill(self, setup):
+        bill_model = self.make_approved_bill(setup)
+        bill_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def test_valid_status_transitions_set_dates_and_ledger_state(self):
+        setup = self.create_entity_setup(name="API Bill Lifecycle Valid Entity")
+        bill_model = self.migrate_expense_item(self.create_bill(setup), setup)
+
+        bill_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        bill_model.refresh_from_db()
+        self.assertTrue(bill_model.is_review())
+        self.assertEqual(bill_model.date_in_review, date(2025, 1, 16))
+        self.assertFalse(bill_model.ledger.posted)
+
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        self.assertTrue(bill_model.is_approved())
+        self.assertEqual(bill_model.date_approved, date(2025, 1, 17))
+        self.assertTrue(bill_model.ledger.posted)
+        self.assertFalse(bill_model.ledger.locked)
+
+        bill_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        self.assertTrue(bill_model.is_paid())
+        self.assertEqual(bill_model.date_paid, date(2025, 1, 18))
+        self.assertEqual(bill_model.amount_paid, bill_model.amount_due)
+        self.assertTrue(bill_model.ledger.locked)
+
+    def test_cancel_and_void_transitions_set_terminal_status_dates(self):
+        setup = self.create_entity_setup(name="API Bill Lifecycle Terminal Entity")
+
+        draft_bill = self.create_bill(setup)
+        draft_bill.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        draft_bill.refresh_from_db()
+        self.assertTrue(draft_bill.is_canceled())
+        self.assertEqual(draft_bill.date_canceled, date(2025, 1, 20))
+
+        review_bill = self.make_review_bill(setup)
+        review_bill.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 21))
+        review_bill.refresh_from_db()
+        self.assertTrue(review_bill.is_canceled())
+        self.assertEqual(review_bill.date_canceled, date(2025, 1, 21))
+
+        approved_bill = self.make_approved_bill(setup)
+        approved_bill.mark_as_void(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_void=date(2025, 1, 22),
+            commit=True,
+        )
+        approved_bill.refresh_from_db()
+        self.assertTrue(approved_bill.is_void())
+        self.assertEqual(approved_bill.date_void, date(2025, 1, 22))
+        self.assertEqual(approved_bill.amount_paid, Decimal("0.00"))
+
+    def test_invalid_transitions_raise_validation_errors(self):
+        setup = self.create_entity_setup(name="API Bill Lifecycle Invalid Entity")
+        draft_bill = self.create_bill(setup)
+
+        with self.assertRaises(BillModelValidationError):
+            draft_bill.mark_as_paid(
+                entity_slug=setup["entity_model"].slug,
+                user_model=self.user,
+                date_paid=date(2025, 1, 18),
+                commit=True,
+            )
+
+        paid_bill = self.make_paid_bill(setup)
+        with self.assertRaises(BillModelValidationError):
+            paid_bill.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 19))
+        with self.assertRaises(BillModelValidationError):
+            paid_bill.mark_as_void(
+                entity_slug=setup["entity_model"].slug,
+                user_model=self.user,
+                date_void=date(2025, 1, 19),
+                commit=True,
+            )
+
+        canceled_bill = self.create_bill(setup)
+        canceled_bill.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        with self.assertRaises(BillModelValidationError):
+            canceled_bill.mark_as_review(commit=True, date_in_review=date(2025, 1, 21))
+
+    def test_can_predicates_reflect_status_transitions(self):
+        setup = self.create_entity_setup(name="API Bill Lifecycle Predicate Entity")
+        draft_bill = self.create_bill(setup)
+
+        self.assertFalse(draft_bill.can_draft())
+        self.assertTrue(draft_bill.can_review())
+        self.assertFalse(draft_bill.can_approve())
+        self.assertFalse(draft_bill.can_pay())
+        self.assertFalse(draft_bill.can_void())
+        self.assertTrue(draft_bill.can_cancel())
+
+        review_bill = self.make_review_bill(setup)
+        self.assertTrue(review_bill.can_draft())
+        self.assertTrue(review_bill.can_approve())
+        self.assertFalse(review_bill.can_pay())
+        self.assertFalse(review_bill.can_void())
+        self.assertTrue(review_bill.can_cancel())
+
+        approved_bill = self.make_approved_bill(setup)
+        self.assertFalse(approved_bill.can_draft())
+        self.assertFalse(approved_bill.can_approve())
+        self.assertTrue(approved_bill.can_pay())
+        self.assertTrue(approved_bill.can_void())
+        self.assertFalse(approved_bill.can_cancel())
+
+        paid_bill = self.make_paid_bill(setup)
+        self.assertFalse(paid_bill.can_pay())
+        self.assertFalse(paid_bill.can_void())
+        self.assertFalse(paid_bill.can_cancel())
+
+    def test_commit_false_transitions_mutate_in_memory_without_persisting(self):
+        setup = self.create_entity_setup(name="API Bill Lifecycle Commit False Entity")
+        bill_model = self.migrate_expense_item(self.create_bill(setup), setup)
+
+        bill_model.mark_as_review(commit=False, date_in_review=date(2025, 1, 16))
+        self.assertTrue(bill_model.is_review())
+        self.assertEqual(bill_model.date_in_review, date(2025, 1, 16))
+        db_bill = BillModel.objects.get(uuid=bill_model.uuid)
+        self.assertTrue(db_bill.is_draft())
+        self.assertIsNone(db_bill.date_in_review)
+
+        bill_model.refresh_from_db()
+        bill_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        bill_model.refresh_from_db()
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=False,
+        )
+        self.assertTrue(bill_model.is_approved())
+        self.assertEqual(bill_model.date_approved, date(2025, 1, 17))
+        db_bill = BillModel.objects.get(uuid=bill_model.uuid)
+        self.assertTrue(db_bill.is_review())
+        self.assertIsNone(db_bill.date_approved)
+        self.assertFalse(db_bill.ledger.posted)
+
+    def test_review_rejects_bill_without_items(self):
+        setup = self.create_entity_setup(name="API Bill Lifecycle No Items Entity")
+        bill_model = self.create_bill(setup)
+
+        with self.assertRaises(BillModelValidationError):
+            bill_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        self.assertFalse(ItemTransactionModel.objects.filter(bill_model=bill_model).exists())

--- a/django_ledger/tests/api/test_bill_payment_void_delete_api.py
+++ b/django_ledger/tests/api/test_bill_payment_void_delete_api.py
@@ -1,0 +1,273 @@
+"""
+High-level API tests for BillModel payment, void, cancel, and delete behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_PREPAID,
+    EXPENSE_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel
+from django_ledger.models.bill import BillModelValidationError
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+
+
+class BillPaymentVoidDeleteAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_bill_payment_user",
+            email="api-bill-payment-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Bill Payment Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"b-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "vendor_model": vendor_model,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup):
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def migrate_expense_item(self, bill_model, setup, *, total_amount=Decimal("100.00")):
+        bill_model.migrate_itemtxs(
+            itemtxs={
+                setup["expense_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": total_amount,
+                    "total_amount": total_amount,
+                }
+            },
+            operation=BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_review_bill(self, setup):
+        bill_model = self.migrate_expense_item(self.create_bill(setup), setup)
+        bill_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_approved_bill(self, setup):
+        bill_model = self.make_review_bill(setup)
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_paid_bill(self, setup):
+        bill_model = self.make_approved_bill(setup)
+        bill_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def test_make_payment_partial_commit_true_updates_amounts_without_paid_status(self):
+        setup = self.create_entity_setup(name="API Bill Payment Partial Entity")
+        bill_model = self.make_approved_bill(setup)
+
+        bill_model.make_payment(
+            payment_amount=Decimal("25.00"),
+            payment_date=date(2025, 1, 18),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+
+        self.assertTrue(bill_model.is_approved())
+        self.assertEqual(bill_model.amount_paid, Decimal("25.00"))
+        self.assertEqual(bill_model.amount_due, Decimal("100.00"))
+        self.assertTrue(bill_model.can_make_payment())
+
+    def test_make_payment_rejects_overpayment_and_characterizes_no_raise_path(self):
+        setup = self.create_entity_setup(name="API Bill Payment Overpay Entity")
+        bill_model = self.make_approved_bill(setup)
+
+        with self.assertRaises(BillModelValidationError):
+            bill_model.make_payment(payment_amount=Decimal("150.00"), commit=True)
+        self.assertGreater(bill_model.amount_paid, bill_model.amount_due)
+        bill_model.refresh_from_db()
+        self.assertEqual(bill_model.amount_paid, Decimal("0.00"))
+
+        bill_model.make_payment(
+            payment_amount=Decimal("150.00"),
+            commit=True,
+            raise_exception=False,
+        )
+        self.assertGreater(bill_model.amount_paid, bill_model.amount_due)
+        bill_model.refresh_from_db()
+        self.assertEqual(bill_model.amount_paid, Decimal("0.00"))
+
+    def test_mark_as_paid_pays_bill_and_locks_ledger(self):
+        setup = self.create_entity_setup(name="API Bill Payment Paid Entity")
+        bill_model = self.make_approved_bill(setup)
+
+        bill_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+
+        self.assertTrue(bill_model.is_paid())
+        self.assertEqual(bill_model.amount_paid, bill_model.amount_due)
+        self.assertEqual(bill_model.date_paid, date(2025, 1, 18))
+        self.assertTrue(bill_model.ledger.locked)
+
+    def test_mark_as_void_voids_unpaid_approved_bill_and_characterizes_ledger_lock(self):
+        setup = self.create_entity_setup(name="API Bill Payment Void Entity")
+        bill_model = self.make_approved_bill(setup)
+
+        bill_model.mark_as_void(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_void=date(2025, 1, 19),
+            commit=True,
+        )
+        in_memory_locked = bill_model.ledger.locked
+        bill_model.refresh_from_db()
+
+        self.assertTrue(bill_model.is_void())
+        self.assertEqual(bill_model.date_void, date(2025, 1, 19))
+        self.assertEqual(bill_model.amount_paid, Decimal("0.00"))
+        self.assertEqual(bill_model.amount_due, Decimal("100.00"))
+        self.assertTrue(in_memory_locked)
+        self.assertFalse(bill_model.ledger.locked)
+
+    def test_cancel_rejects_active_bills_and_allows_draft_or_review_bills(self):
+        setup = self.create_entity_setup(name="API Bill Payment Cancel Entity")
+
+        draft_bill = self.create_bill(setup)
+        draft_bill.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        draft_bill.refresh_from_db()
+        self.assertTrue(draft_bill.is_canceled())
+
+        review_bill = self.make_review_bill(setup)
+        review_bill.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 21))
+        review_bill.refresh_from_db()
+        self.assertTrue(review_bill.is_canceled())
+
+        approved_bill = self.make_approved_bill(setup)
+        with self.assertRaises(BillModelValidationError):
+            approved_bill.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 22))
+        approved_bill.refresh_from_db()
+        self.assertTrue(approved_bill.is_approved())
+
+    def test_delete_defaults_to_cancel_and_force_delete_removes_deletable_bill(self):
+        setup = self.create_entity_setup(name="API Bill Payment Delete Entity")
+
+        cancel_bill = self.create_bill(setup)
+        cancel_bill.delete()
+        cancel_bill.refresh_from_db()
+        self.assertTrue(cancel_bill.is_canceled())
+
+        delete_bill = self.create_bill(setup)
+        delete_uuid = delete_bill.uuid
+        delete_bill.delete(force_db_delete=True)
+        self.assertFalse(BillModel.objects.filter(uuid=delete_uuid).exists())
+
+    def test_force_delete_rejects_locked_paid_bill_and_leaves_it_intact(self):
+        setup = self.create_entity_setup(name="API Bill Payment Delete Guard Entity")
+        paid_bill = self.make_paid_bill(setup)
+        paid_uuid = paid_bill.uuid
+
+        with self.assertRaises(BillModelValidationError):
+            paid_bill.delete(force_db_delete=True)
+
+        persisted_bill = BillModel.objects.get(uuid=paid_uuid)
+        self.assertTrue(persisted_bill.is_paid())
+        self.assertTrue(persisted_bill.ledger.locked)

--- a/django_ledger/tests/api/test_bill_queryset_api.py
+++ b/django_ledger/tests/api/test_bill_queryset_api.py
@@ -1,0 +1,291 @@
+"""
+High-level API tests for BillModel queryset and manager behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import BillModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class BillQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_bill_queryset_admin",
+            email="api-bill-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_bill_queryset_manager",
+            email="api-bill-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_bill_queryset_other_admin",
+            email="api-bill-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_bill_queryset_unrelated",
+            email="api-bill-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_bill_queryset_superuser",
+            email="api-bill-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Bill Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"{name[:8].lower().replace(' ', '-')}-u",
+            active=True,
+            commit=True,
+        )
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "payable_account": payable_account,
+            "vendor_model": vendor_model,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup, *, date_draft=date(2026, 1, 15)):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["payable_account"],
+        )
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_draft=date_draft,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def migrate_expense_item(self, bill_model, setup, *, quantity="2.00", unit_cost="50.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        bill_model.migrate_itemtxs(
+            itemtxs={
+                setup["expense_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def move_to_review(self, bill_model, setup):
+        bill_model = self.migrate_expense_item(bill_model, setup)
+        bill_model.mark_as_review(commit=True, date_in_review=date(2026, 1, 16))
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def move_to_approved(self, bill_model, setup):
+        bill_model = self.move_to_review(bill_model, setup)
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_approved=date(2026, 1, 17),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def move_to_paid(self, bill_model, setup):
+        bill_model = self.move_to_approved(bill_model, setup)
+        bill_model.mark_as_paid(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_paid=date(2026, 1, 18),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def move_to_void(self, bill_model, setup):
+        bill_model = self.move_to_approved(bill_model, setup)
+        bill_model.mark_as_void(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_void=date(2026, 1, 19),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def move_to_canceled(self, bill_model):
+        bill_model.mark_as_canceled(date_canceled=date(2026, 1, 20), commit=True)
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def assert_bill_uuids(self, queryset, expected_bills):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {bill_model.uuid for bill_model in expected_bills},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Bill Queryset Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Bill Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        bill_model = self.create_bill(setup)
+        self.create_bill(other_setup)
+        entity_model = setup["entity_model"]
+
+        self.assert_bill_uuids(BillModel.objects.for_entity(entity_model), [bill_model])
+        self.assert_bill_uuids(BillModel.objects.for_entity(entity_model.slug), [bill_model])
+        self.assert_bill_uuids(BillModel.objects.for_entity(entity_model.uuid), [bill_model])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_bill(self.create_entity_setup())
+
+        from django_ledger.models.bill import BillModelValidationError
+
+        with self.assertRaises(BillModelValidationError):
+            BillModel.objects.for_entity(object())
+
+        self.assertFalse(BillModel.objects.for_entity("missing-bill-entity-slug").exists())
+
+    def test_for_user_scopes_to_authorized_users_and_superuser(self):
+        setup = self.create_entity_setup(
+            name="API Bill Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API Bill Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        bill_model = self.create_bill(setup)
+        other_bill_model = self.create_bill(other_setup)
+
+        self.assert_bill_uuids(BillModel.objects.all().for_user(self.admin_user), [bill_model])
+        self.assert_bill_uuids(BillModel.objects.all().for_user(self.manager_user), [bill_model])
+        self.assertFalse(BillModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_bill_uuids(BillModel.objects.all().for_user(self.superuser), [bill_model, other_bill_model])
+
+    def test_status_filters_return_matching_bills(self):
+        setup = self.create_entity_setup(name="API Bill Queryset Status Entity")
+        draft_bill = self.create_bill(setup)
+        review_bill = self.move_to_review(self.create_bill(setup), setup)
+        approved_bill = self.move_to_approved(self.create_bill(setup), setup)
+        paid_bill = self.move_to_paid(self.create_bill(setup), setup)
+        void_bill = self.move_to_void(self.create_bill(setup), setup)
+        canceled_bill = self.move_to_canceled(self.create_bill(setup))
+
+        bills_qs = BillModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_bill_uuids(bills_qs.draft(), [draft_bill])
+        self.assert_bill_uuids(bills_qs.in_review(), [review_bill])
+        self.assert_bill_uuids(bills_qs.approved(), [approved_bill])
+        self.assert_bill_uuids(bills_qs.paid(), [paid_bill])
+        self.assert_bill_uuids(bills_qs.void(), [void_bill])
+        self.assert_bill_uuids(bills_qs.canceled(), [canceled_bill])
+
+    def test_semantic_filters_return_active_unpaid_and_overdue_bills(self):
+        setup = self.create_entity_setup(name="API Bill Queryset Semantic Entity")
+        draft_bill = self.create_bill(setup)
+        approved_bill = self.move_to_approved(self.create_bill(setup), setup)
+        paid_bill = self.move_to_paid(self.create_bill(setup), setup)
+        void_bill = self.move_to_void(self.create_bill(setup), setup)
+
+        overdue_bill = self.create_bill(setup)
+        overdue_bill.date_due = date(2000, 1, 1)
+        overdue_bill.save(update_fields=["date_due", "updated"])
+
+        future_due_bill = self.create_bill(setup)
+        future_due_bill.date_due = date(2099, 1, 1)
+        future_due_bill.save(update_fields=["date_due", "updated"])
+
+        bills_qs = BillModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_bill_uuids(bills_qs.active(), [approved_bill, paid_bill])
+        self.assert_bill_uuids(bills_qs.unpaid(), [approved_bill])
+        self.assertTrue(bills_qs.overdue().filter(uuid=overdue_bill.uuid).exists())
+        self.assertFalse(bills_qs.overdue().filter(uuid=future_due_bill.uuid).exists())
+        self.assertFalse(bills_qs.active().filter(uuid=draft_bill.uuid).exists())
+        self.assertFalse(bills_qs.active().filter(uuid=void_bill.uuid).exists())

--- a/django_ledger/tests/api/test_bill_url_signal_api.py
+++ b/django_ledger/tests/api/test_bill_url_signal_api.py
@@ -1,0 +1,307 @@
+"""
+Smoke tests for BillModel URL, display, and lifecycle signal behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_PREPAID,
+    EXPENSE_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.signals import (
+    bill_status_approved,
+    bill_status_canceled,
+    bill_status_draft,
+    bill_status_in_review,
+    bill_status_paid,
+    bill_status_void,
+)
+
+
+class BillURLSignalAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_bill_url_signal_user",
+            email="api-bill-url-signal-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Bill URL Signal Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"b-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "vendor_model": vendor_model,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup):
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def migrate_expense_item(self, bill_model, setup):
+        bill_model.migrate_itemtxs(
+            itemtxs={
+                setup["expense_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": Decimal("100.00"),
+                    "total_amount": Decimal("100.00"),
+                }
+            },
+            operation=BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_review_bill(self, setup):
+        bill_model = self.migrate_expense_item(self.create_bill(setup), setup)
+        bill_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_approved_bill(self, setup):
+        bill_model = self.make_review_bill(setup)
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def collect_signal_calls(self, signal):
+        calls = []
+        dispatch_uid = f"{self.id()}-{id(signal)}"
+
+        def receiver(sender, **kwargs):
+            calls.append(kwargs)
+
+        signal.connect(
+            receiver,
+            sender=BillModel,
+            weak=False,
+            dispatch_uid=dispatch_uid,
+        )
+        self.addCleanup(
+            signal.disconnect,
+            sender=BillModel,
+            dispatch_uid=dispatch_uid,
+        )
+        return calls
+
+    def assert_signal_received_once(self, calls, bill_model, *, commit):
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0]["instance"], bill_model)
+        self.assertEqual(calls[0]["commited"], commit)
+
+    def assert_entity_bill_url(self, url, setup, bill_model):
+        self.assertIsInstance(url, str)
+        self.assertIn(setup["entity_model"].slug, url)
+        self.assertIn(str(bill_model.uuid), url)
+
+    def test_url_helpers_return_entity_scoped_strings(self):
+        setup = self.create_entity_setup(name="API Bill URL Helper Entity")
+        bill_model = self.create_bill(setup)
+
+        url_helpers = [
+            bill_model.get_absolute_url,
+            bill_model.get_mark_as_draft_url,
+            bill_model.get_mark_as_review_url,
+            bill_model.get_mark_as_approved_url,
+            bill_model.get_mark_as_paid_url,
+            bill_model.get_mark_as_void_url,
+            bill_model.get_mark_as_canceled_url,
+        ]
+
+        for helper in url_helpers:
+            self.assert_entity_bill_url(helper(), setup, bill_model)
+
+    def test_display_message_and_html_helpers_include_stable_context(self):
+        setup = self.create_entity_setup(name="API Bill Display Helper Entity")
+        bill_model = self.create_bill(setup)
+
+        self.assertIn(bill_model.bill_number, str(bill_model))
+        self.assertIn(bill_model.get_bill_status_display(), str(bill_model))
+
+        title = bill_model.generate_descriptive_title()
+        self.assertIn(bill_model.bill_number, title)
+        self.assertIn(setup["vendor_model"].vendor_name, title)
+        self.assertIn(bill_model.get_bill_status_display(), title)
+
+        html_helpers = [
+            bill_model.get_html_id,
+            bill_model.get_html_amount_due_id,
+            bill_model.get_html_amount_paid_id,
+            bill_model.get_html_form_id,
+            bill_model.get_mark_as_draft_html_id,
+            bill_model.get_mark_as_review_html_id,
+            bill_model.get_mark_as_approved_html_id,
+            bill_model.get_mark_as_paid_html_id,
+            bill_model.get_mark_as_void_html_id,
+            bill_model.get_mark_as_canceled_html_id,
+        ]
+        for helper in html_helpers:
+            self.assertIn(str(bill_model.uuid), helper())
+
+        message_helpers = [
+            bill_model.get_mark_as_draft_message,
+            bill_model.get_mark_as_review_message,
+            bill_model.get_mark_as_approved_message,
+            bill_model.get_mark_as_paid_message,
+            bill_model.get_mark_as_void_message,
+            bill_model.get_mark_as_canceled_message,
+        ]
+        for helper in message_helpers:
+            self.assertIn(bill_model.bill_number, helper())
+
+    def test_mark_as_review_emits_bill_status_in_review_signal(self):
+        setup = self.create_entity_setup(name="API Bill Review Signal Entity")
+        bill_model = self.migrate_expense_item(self.create_bill(setup), setup)
+        calls = self.collect_signal_calls(bill_status_in_review)
+
+        bill_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        self.assert_signal_received_once(calls, bill_model, commit=True)
+
+    def test_mark_as_draft_emits_bill_status_draft_signal(self):
+        setup = self.create_entity_setup(name="API Bill Draft Signal Entity")
+        bill_model = self.make_review_bill(setup)
+        calls = self.collect_signal_calls(bill_status_draft)
+
+        bill_model.mark_as_draft(commit=True, date_draft=date(2025, 1, 17))
+
+        self.assert_signal_received_once(calls, bill_model, commit=True)
+
+    def test_mark_as_approved_emits_bill_status_approved_signal(self):
+        setup = self.create_entity_setup(name="API Bill Approved Signal Entity")
+        bill_model = self.make_review_bill(setup)
+        calls = self.collect_signal_calls(bill_status_approved)
+
+        bill_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+
+        self.assert_signal_received_once(calls, bill_model, commit=True)
+
+    def test_mark_as_paid_emits_bill_status_paid_signal(self):
+        setup = self.create_entity_setup(name="API Bill Paid Signal Entity")
+        bill_model = self.make_approved_bill(setup)
+        calls = self.collect_signal_calls(bill_status_paid)
+
+        bill_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+
+        self.assert_signal_received_once(calls, bill_model, commit=True)
+
+    def test_mark_as_canceled_emits_bill_status_canceled_signal(self):
+        setup = self.create_entity_setup(name="API Bill Canceled Signal Entity")
+        bill_model = self.create_bill(setup)
+        calls = self.collect_signal_calls(bill_status_canceled)
+
+        bill_model.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+
+        self.assert_signal_received_once(calls, bill_model, commit=True)
+
+    def test_mark_as_void_emits_bill_status_void_signal(self):
+        setup = self.create_entity_setup(name="API Bill Void Signal Entity")
+        bill_model = self.make_approved_bill(setup)
+        calls = self.collect_signal_calls(bill_status_void)
+
+        bill_model.mark_as_void(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_void=date(2025, 1, 19),
+            commit=True,
+        )
+
+        self.assert_signal_received_once(calls, bill_model, commit=True)

--- a/django_ledger/tests/api/test_chart_of_accounts_account_creation_api.py
+++ b/django_ledger/tests/api/test_chart_of_accounts_account_creation_api.py
@@ -1,0 +1,187 @@
+"""
+High-level API behavior tests for ChartOfAccountModel account creation helpers.
+
+These tests cover public account insertion behavior without asserting exact
+tree path strings.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    DEBIT,
+    EXPENSE_OPERATIONAL,
+    ROOT_ASSETS,
+    ROOT_EXPENSES,
+)
+from django_ledger.models import AccountModel
+from django_ledger.models.chart_of_accounts import ChartOfAccountsModelValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class ChartOfAccountsAccountCreationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_coa_account_creation_user",
+            email="api-coa-account-creation-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API CoA Account Creation Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(self, *, name="API CoA Account Creation CoA"):
+        entity_model = self.create_entity(name=f"{name} Entity")
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def assert_account_has_ancestor_role(self, account_model, role):
+        ancestor_roles = {ancestor.role for ancestor in account_model.get_ancestors()}
+        self.assertIn(role, ancestor_roles)
+
+    def test_create_account_creates_non_root_account_attached_to_same_coa(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Create Cash")
+
+        account_model = coa_model.create_account(
+            code="1010",
+            name="API Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+        account_model.refresh_from_db()
+
+        self.assertEqual(account_model.coa_model_id, coa_model.uuid)
+        self.assertFalse(account_model.is_root_account())
+        self.assertTrue(account_model.active)
+        self.assertTrue(coa_model.get_non_root_coa_accounts_qs().filter(uuid=account_model.uuid).exists())
+
+    def test_create_account_inserts_asset_account_under_assets_root(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Asset Root")
+
+        account_model = coa_model.create_account(
+            code="1010",
+            name="API Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+        self.assert_account_has_ancestor_role(account_model, ROOT_ASSETS)
+
+    def test_create_account_inserts_expense_account_under_expenses_root(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Expense Root")
+
+        account_model = coa_model.create_account(
+            code="6010",
+            name="API Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+        self.assert_account_has_ancestor_role(account_model, ROOT_EXPENSES)
+
+    def test_insert_account_rejects_account_tied_to_different_coa(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Insert Target")
+        _other_entity, other_coa = self.create_coa(name="API CoA Insert Other")
+        account_model = AccountModel(
+            code="1010",
+            name="API Wrong CoA Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            coa_model=other_coa,
+        )
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            coa_model.insert_account(account_model)
+
+    def test_get_account_root_node_rejects_root_accounts(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Root Reject")
+        root_account = coa_model.get_coa_root_node()
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            coa_model.get_account_root_node(root_account)
+
+    def test_create_account_can_mark_role_default(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Role Default")
+
+        account_model = coa_model.create_account(
+            code="1010",
+            name="API Default Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+
+        account_model.refresh_from_db()
+        self.assertTrue(account_model.role_default)
+
+    def test_second_role_default_for_same_role_raises_without_force(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Duplicate Default")
+        first_default = coa_model.create_account(
+            code="1010",
+            name="API First Default Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            coa_model.create_account(
+                code="1020",
+                name="API Second Default Cash Account",
+                role=ASSET_CA_CASH,
+                balance_type=DEBIT,
+                active=True,
+                is_role_default=True,
+            )
+
+        first_default.refresh_from_db()
+        self.assertTrue(first_default.role_default)
+        self.assertFalse(coa_model.get_coa_accounts(active_only=False).filter(code="1020").exists())
+
+    def test_force_role_default_clears_old_default_and_sets_new_default(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Force Default")
+        first_default = coa_model.create_account(
+            code="1010",
+            name="API First Default Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+
+        second_default = coa_model.create_account(
+            code="1020",
+            name="API Second Default Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+            force_role_default=True,
+        )
+
+        first_default.refresh_from_db()
+        second_default.refresh_from_db()
+
+        self.assertIsNone(first_default.role_default)
+        self.assertTrue(second_default.role_default)

--- a/django_ledger/tests/api/test_chart_of_accounts_configure_api.py
+++ b/django_ledger/tests/api/test_chart_of_accounts_configure_api.py
@@ -1,0 +1,138 @@
+"""
+High-level API behavior tests for ChartOfAccountModel configuration helpers.
+
+These tests cover root-account setup and public account query helpers without
+asserting fragile tree path internals.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    DEBIT,
+    EXPENSE_OPERATIONAL,
+    ROOT_ASSETS,
+    ROOT_CAPITAL,
+    ROOT_COA,
+    ROOT_COGS,
+    ROOT_EXPENSES,
+    ROOT_INCOME,
+    ROOT_LIABILITIES,
+)
+from django_ledger.models.entity import EntityModel
+
+
+class ChartOfAccountsConfigureAPITest(TestCase):
+    EXPECTED_ROOT_ROLES = {
+        ROOT_COA,
+        ROOT_ASSETS,
+        ROOT_LIABILITIES,
+        ROOT_CAPITAL,
+        ROOT_INCOME,
+        ROOT_COGS,
+        ROOT_EXPENSES,
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_coa_configure_user",
+            email="api-coa-configure-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API CoA Configure Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(self, *, name="API CoA Configure CoA"):
+        entity_model = self.create_entity(name=f"{name} Entity")
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def test_saved_coa_is_configured_with_expected_root_accounts(self):
+        _entity_model, coa_model = self.create_coa(
+            name="API CoA Configured Root Accounts",
+        )
+
+        self.assertTrue(coa_model.is_configured())
+
+        root_accounts = list(coa_model.get_coa_root_accounts_qs())
+        root_roles = {account.role for account in root_accounts}
+
+        self.assertEqual(root_roles, self.EXPECTED_ROOT_ROLES)
+
+        for root_account in root_accounts:
+            with self.subTest(role=root_account.role):
+                self.assertTrue(root_account.is_root_account())
+                self.assertFalse(root_account.active)
+                self.assertTrue(root_account.locked)
+                self.assertTrue(root_account.role_default)
+
+    def test_get_coa_root_node_returns_coa_root_account(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Root Node")
+
+        root_node = coa_model.get_coa_root_node()
+
+        self.assertEqual(root_node.role, ROOT_COA)
+        self.assertTrue(root_node.is_coa_root())
+        self.assertEqual(root_node.coa_model_id, coa_model.uuid)
+
+    def test_root_and_non_root_account_query_helpers_partition_accounts(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Root Partition")
+        cash_account = coa_model.create_account(
+            code="1010",
+            name="API Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+        root_qs = coa_model.get_coa_root_accounts_qs()
+        non_root_qs = coa_model.get_non_root_coa_accounts_qs()
+
+        self.assertTrue(root_qs.exists())
+        self.assertFalse(root_qs.filter(uuid=cash_account.uuid).exists())
+        self.assertTrue(non_root_qs.filter(uuid=cash_account.uuid).exists())
+
+        for root_account in root_qs:
+            self.assertFalse(non_root_qs.filter(uuid=root_account.uuid).exists())
+
+    def test_get_coa_accounts_active_only_controls_active_filter_for_non_root_accounts(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Account Active Filter")
+        active_account = coa_model.create_account(
+            code="1010",
+            name="API Active Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+        inactive_account = coa_model.create_account(
+            code="6010",
+            name="API Inactive Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+            active=False,
+        )
+
+        active_qs = coa_model.get_coa_accounts(active_only=True)
+        all_non_root_qs = coa_model.get_coa_accounts(active_only=False)
+
+        self.assertTrue(active_qs.filter(uuid=active_account.uuid).exists())
+        self.assertFalse(active_qs.filter(uuid=inactive_account.uuid).exists())
+
+        self.assertTrue(all_non_root_qs.filter(uuid=active_account.uuid).exists())
+        self.assertTrue(all_non_root_qs.filter(uuid=inactive_account.uuid).exists())
+        self.assertFalse(all_non_root_qs.filter(role__in=self.EXPECTED_ROOT_ROLES).exists())

--- a/django_ledger/tests/api/test_chart_of_accounts_helpers_api.py
+++ b/django_ledger/tests/api/test_chart_of_accounts_helpers_api.py
@@ -1,0 +1,172 @@
+"""
+High-level API behavior tests for ChartOfAccountModel helper and URL methods.
+
+These tests provide smoke coverage for public helper behavior without asserting
+private tree internals.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT, EXPENSE_OPERATIONAL
+from django_ledger.models import AccountModel, ChartOfAccountModel
+from django_ledger.models.chart_of_accounts import ChartOfAccountsModelValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class ChartOfAccountsHelpersAPITest(TestCase):
+    COA_SCOPED_URL_HELPERS = (
+        "mark_as_default_url",
+        "mark_as_active_url",
+        "mark_as_inactive_url",
+        "get_absolute_url",
+        "get_update_url",
+        "get_account_list_url",
+        "get_create_coa_account_url",
+    )
+    ENTITY_SCOPED_URL_HELPERS = (
+        "get_coa_list_url",
+        "get_coa_list_inactive_url",
+        "get_coa_create_url",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_coa_helpers_user",
+            email="api-coa-helpers-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API CoA Helpers Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(self, *, name="API CoA Helpers CoA", assign_as_default=True):
+        entity_model = self.create_entity(name=f"{name} Entity")
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=assign_as_default,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def create_cash_account(self, coa_model, *, code="1010", name="API Cash Account"):
+        return coa_model.create_account(
+            code=code,
+            name=name,
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+    def create_expense_account(self, coa_model, *, code="6010", name="API Expense Account"):
+        return coa_model.create_account(
+            code=code,
+            name=name,
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+    def test_generate_slug_assigns_entity_scoped_slug_and_preserves_existing_slug(self):
+        entity_model = self.create_entity(name="API CoA Generate Slug Entity")
+        coa_model = ChartOfAccountModel(name="API Direct Slug CoA", entity=entity_model)
+
+        coa_model.generate_slug()
+        original_slug = coa_model.slug
+
+        self.assertTrue(original_slug.startswith("coa-"))
+        self.assertIn(entity_model.slug[-5:], original_slug)
+
+        coa_model.generate_slug()
+        self.assertEqual(coa_model.slug, original_slug)
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            coa_model.generate_slug(raise_exception=True)
+
+    def test_entity_slug_uses_manager_annotation_and_direct_instance_fallback(self):
+        entity_model, coa_model = self.create_coa(name="API CoA Entity Slug")
+
+        annotated_coa = ChartOfAccountModel.objects.get(uuid=coa_model.uuid)
+        direct_coa = ChartOfAccountModel(
+            name="API Direct Entity Slug CoA",
+            entity=entity_model,
+        )
+
+        self.assertEqual(annotated_coa.entity_slug, entity_model.slug)
+        self.assertEqual(direct_coa.entity_slug, entity_model.slug)
+
+    def test_validate_account_model_qs_accepts_same_coa_and_rejects_invalid_inputs(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Validate Account QS")
+        _other_entity, other_coa = self.create_coa(name="API CoA Other Validate Account QS")
+        same_coa_account = self.create_cash_account(coa_model)
+        other_coa_account = self.create_cash_account(other_coa)
+
+        same_coa_qs = AccountModel.objects.filter(uuid=same_coa_account.uuid)
+        other_coa_qs = AccountModel.objects.filter(uuid=other_coa_account.uuid)
+
+        self.assertIsNone(coa_model.validate_account_model_qs(same_coa_qs))
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            coa_model.validate_account_model_qs(other_coa_qs)
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            coa_model.validate_account_model_qs([same_coa_account])
+
+    def test_lock_all_accounts_and_unlock_all_accounts_update_non_root_accounts(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Lock Unlock")
+        cash_account = self.create_cash_account(coa_model, code="1010")
+        expense_account = self.create_expense_account(coa_model, code="6010")
+
+        coa_model.lock_all_accounts()
+
+        cash_account.refresh_from_db()
+        expense_account.refresh_from_db()
+        self.assertTrue(cash_account.locked)
+        self.assertTrue(expense_account.locked)
+
+        coa_model.unlock_all_accounts()
+
+        cash_account.refresh_from_db()
+        expense_account.refresh_from_db()
+        self.assertFalse(cash_account.locked)
+        self.assertFalse(expense_account.locked)
+
+    def test_get_coa_account_tree_returns_non_empty_serialized_tree(self):
+        _entity_model, coa_model = self.create_coa(name="API CoA Account Tree")
+        self.create_cash_account(coa_model)
+
+        account_tree = coa_model.get_coa_account_tree()
+
+        self.assertIsInstance(account_tree, list)
+        self.assertGreater(len(account_tree), 0)
+        self.assertIsInstance(account_tree[0], dict)
+
+    def test_url_helpers_return_entity_and_coa_scoped_strings(self):
+        entity_model, coa_model = self.create_coa(name="API CoA URL Helpers")
+        annotated_coa = ChartOfAccountModel.objects.get(uuid=coa_model.uuid)
+
+        for helper_name in self.COA_SCOPED_URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(annotated_coa, helper_name)()
+
+                self.assertIsInstance(url, str)
+                self.assertTrue(url)
+                self.assertIn(entity_model.slug, url)
+                self.assertIn(coa_model.slug, url)
+
+        for helper_name in self.ENTITY_SCOPED_URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(annotated_coa, helper_name)()
+
+                self.assertIsInstance(url, str)
+                self.assertTrue(url)
+                self.assertIn(entity_model.slug, url)

--- a/django_ledger/tests/api/test_chart_of_accounts_lifecycle_api.py
+++ b/django_ledger/tests/api/test_chart_of_accounts_lifecycle_api.py
@@ -1,0 +1,163 @@
+"""
+High-level API behavior tests for ChartOfAccountModel lifecycle helpers.
+
+These tests cover default/active state transitions without URL or queryset
+assertions.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.chart_of_accounts import ChartOfAccountsModelValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class ChartOfAccountsLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_coa_lifecycle_user",
+            email="api-coa-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API CoA Lifecycle Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(self, entity_model, *, name, assign_as_default=False):
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=assign_as_default,
+        )
+        entity_model.refresh_from_db()
+        return coa_model
+
+    def create_entity_with_two_coas(self, *, name="API CoA Lifecycle Entity"):
+        entity_model = self.create_entity(name=name)
+        default_coa = self.create_coa(
+            entity_model,
+            name=f"{name} Default CoA",
+            assign_as_default=True,
+        )
+        secondary_coa = self.create_coa(
+            entity_model,
+            name=f"{name} Secondary CoA",
+            assign_as_default=False,
+        )
+        return entity_model, default_coa, secondary_coa
+
+    def test_mark_as_default_commit_true_sets_entity_default_coa(self):
+        entity_model, default_coa, secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Mark Default Entity",
+        )
+
+        secondary_coa.mark_as_default(commit=True)
+
+        entity_model.refresh_from_db()
+        default_coa.refresh_from_db()
+        secondary_coa.refresh_from_db()
+
+        self.assertEqual(entity_model.default_coa_id, secondary_coa.uuid)
+        self.assertFalse(default_coa.is_default())
+        self.assertTrue(secondary_coa.is_default())
+
+    def test_default_coa_reports_is_default_true(self):
+        _entity_model, default_coa, secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Is Default Entity",
+        )
+
+        self.assertTrue(default_coa.is_default())
+        self.assertFalse(secondary_coa.is_default())
+
+    def test_inactive_coa_cannot_be_marked_as_default(self):
+        entity_model, default_coa, secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Inactive Default Entity",
+        )
+        secondary_coa.mark_as_inactive(commit=True)
+        secondary_coa.refresh_from_db()
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            secondary_coa.mark_as_default(commit=True, raise_exception=True)
+
+        entity_model.refresh_from_db()
+        self.assertEqual(entity_model.default_coa_id, default_coa.uuid)
+        self.assertFalse(secondary_coa.is_default())
+
+    def test_default_coa_cannot_be_deactivated(self):
+        _entity_model, default_coa, _secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Default Deactivate Entity",
+        )
+
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            default_coa.mark_as_inactive(commit=True)
+
+        default_coa.refresh_from_db()
+        self.assertTrue(default_coa.active)
+        self.assertTrue(default_coa.is_default())
+
+    def test_non_default_active_coa_can_be_marked_inactive(self):
+        _entity_model, _default_coa, secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Mark Inactive Entity",
+        )
+
+        secondary_coa.mark_as_inactive(commit=True)
+
+        secondary_coa.refresh_from_db()
+        self.assertFalse(secondary_coa.active)
+
+    def test_inactive_non_default_coa_can_be_marked_active(self):
+        _entity_model, _default_coa, secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Mark Active Entity",
+        )
+        secondary_coa.mark_as_inactive(commit=True)
+        secondary_coa.refresh_from_db()
+
+        secondary_coa.mark_as_active(commit=True)
+
+        secondary_coa.refresh_from_db()
+        self.assertTrue(secondary_coa.active)
+
+    def test_lifecycle_predicates_reflect_default_and_active_state(self):
+        _entity_model, default_coa, secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Predicate Entity",
+        )
+
+        self.assertFalse(default_coa.can_mark_as_default())
+        self.assertFalse(default_coa.can_activate())
+        self.assertFalse(default_coa.can_deactivate())
+
+        self.assertTrue(secondary_coa.can_mark_as_default())
+        self.assertFalse(secondary_coa.can_activate())
+        self.assertTrue(secondary_coa.can_deactivate())
+
+        secondary_coa.mark_as_inactive(commit=True)
+        secondary_coa.refresh_from_db()
+
+        self.assertFalse(secondary_coa.can_mark_as_default())
+        self.assertTrue(secondary_coa.can_activate())
+        self.assertFalse(secondary_coa.can_deactivate())
+
+    def test_invalid_lifecycle_calls_without_raise_exception_are_noops(self):
+        entity_model, default_coa, secondary_coa = self.create_entity_with_two_coas(
+            name="API CoA Noop Entity",
+        )
+        secondary_coa.mark_as_inactive(commit=True)
+        secondary_coa.refresh_from_db()
+
+        default_coa.mark_as_default(commit=True, raise_exception=False)
+        secondary_coa.mark_as_default(commit=True, raise_exception=False)
+        secondary_coa.mark_as_inactive(commit=True, raise_exception=False)
+
+        entity_model.refresh_from_db()
+        secondary_coa.refresh_from_db()
+
+        self.assertEqual(entity_model.default_coa_id, default_coa.uuid)
+        self.assertFalse(secondary_coa.active)

--- a/django_ledger/tests/api/test_chart_of_accounts_queryset_api.py
+++ b/django_ledger/tests/api/test_chart_of_accounts_queryset_api.py
@@ -1,0 +1,180 @@
+"""
+High-level API behavior tests for ChartOfAccountModel manager/queryset helpers.
+
+These tests cover entity/user scoping, active filters, and manager annotations
+without over-specifying account counts.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models import ChartOfAccountModel
+from django_ledger.models.chart_of_accounts import ChartOfAccountsModelValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class ChartOfAccountsQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_coa_queryset_admin",
+            email="api-coa-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_coa_queryset_other_admin",
+            email="api-coa-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_coa_queryset_unrelated",
+            email="api-coa-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_coa_queryset_superuser",
+            email="api-coa-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API CoA QuerySet Entity", admin=None):
+        return EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_coa(
+        self,
+        entity_model,
+        *,
+        name,
+        assign_as_default=False,
+        active=True,
+    ):
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=name,
+            commit=True,
+            assign_as_default=assign_as_default,
+        )
+        if coa_model.active != active:
+            coa_model.active = active
+            coa_model.save(update_fields=["active", "updated"])
+        entity_model.refresh_from_db()
+        return coa_model
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity(name="API CoA For Entity A")
+        other_entity = self.create_entity(
+            name="API CoA For Entity B",
+            admin=self.other_admin_user,
+        )
+        coa_model = self.create_coa(
+            entity_model,
+            name="API CoA For Entity A CoA",
+            assign_as_default=True,
+        )
+        other_coa = self.create_coa(
+            other_entity,
+            name="API CoA For Entity B CoA",
+            assign_as_default=True,
+        )
+
+        for entity_lookup in (entity_model, entity_model.slug, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                coa_qs = ChartOfAccountModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(coa_qs.filter(uuid=coa_model.uuid).exists())
+                self.assertFalse(coa_qs.filter(uuid=other_coa.uuid).exists())
+
+    def test_for_entity_rejects_invalid_entity_argument(self):
+        with self.assertRaises(ChartOfAccountsModelValidationError):
+            ChartOfAccountModel.objects.for_entity(object())
+
+    def test_active_and_not_active_filters_return_matching_coas(self):
+        entity_model = self.create_entity(name="API CoA Active Filter Entity")
+        active_coa = self.create_coa(
+            entity_model,
+            name="API CoA Active Filter Active",
+            assign_as_default=True,
+            active=True,
+        )
+        inactive_coa = self.create_coa(
+            entity_model,
+            name="API CoA Active Filter Inactive",
+            assign_as_default=False,
+            active=False,
+        )
+
+        coa_qs = ChartOfAccountModel.objects.for_entity(entity_model)
+
+        self.assertTrue(coa_qs.active().filter(uuid=active_coa.uuid).exists())
+        self.assertFalse(coa_qs.active().filter(uuid=inactive_coa.uuid).exists())
+
+        self.assertTrue(coa_qs.not_active().filter(uuid=inactive_coa.uuid).exists())
+        self.assertFalse(coa_qs.not_active().filter(uuid=active_coa.uuid).exists())
+
+    def test_for_user_scopes_coas_by_entity_access(self):
+        entity_model = self.create_entity(name="API CoA User Scope Entity")
+        other_entity = self.create_entity(
+            name="API CoA Other User Scope Entity",
+            admin=self.other_admin_user,
+        )
+        coa_model = self.create_coa(
+            entity_model,
+            name="API CoA User Scope CoA",
+            assign_as_default=True,
+        )
+        other_coa = self.create_coa(
+            other_entity,
+            name="API CoA Other User Scope CoA",
+            assign_as_default=True,
+        )
+
+        admin_qs = ChartOfAccountModel.objects.for_user(self.admin_user)
+        unrelated_qs = ChartOfAccountModel.objects.for_user(self.unrelated_user)
+        superuser_qs = ChartOfAccountModel.objects.for_user(self.superuser)
+
+        self.assertTrue(admin_qs.filter(uuid=coa_model.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_coa.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=coa_model.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_coa.uuid).exists())
+
+        self.assertTrue(superuser_qs.filter(uuid=coa_model.uuid).exists())
+        self.assertTrue(superuser_qs.filter(uuid=other_coa.uuid).exists())
+
+    def test_manager_queryset_exposes_configuration_annotations(self):
+        entity_model = self.create_entity(name="API CoA Annotation Entity")
+        coa_model = self.create_coa(
+            entity_model,
+            name="API CoA Annotation CoA",
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name="API Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+        annotated_coa = ChartOfAccountModel.objects.get(uuid=coa_model.uuid)
+
+        self.assertEqual(annotated_coa._entity_slug, entity_model.slug)
+        self.assertTrue(annotated_coa.configured)
+
+        for annotation_name in (
+            "accountmodel_total__count",
+            "accountmodel_active__count",
+            "accountmodel_locked__count",
+            "accountmodel_rootgroup__count",
+            "accountmodel_rootgroup_roles__distinct_count",
+        ):
+            with self.subTest(annotation_name=annotation_name):
+                self.assertTrue(hasattr(annotated_coa, annotation_name))
+                self.assertIsInstance(getattr(annotated_coa, annotation_name), int)

--- a/django_ledger/tests/api/test_closing_entry_api.py
+++ b/django_ledger/tests/api/test_closing_entry_api.py
@@ -1,0 +1,348 @@
+"""
+High-level API behavior tests for ClosingEntryModel and ClosingEntryTransactionModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, TransactionModel
+from django_ledger.models.closing_entry import (
+    ClosingEntryModel,
+    ClosingEntryTransactionModel,
+    ClosingEntryValidationError,
+)
+from django_ledger.models.entity import EntityModel
+
+
+class ClosingEntryHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for ClosingEntryModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic closing-entry invariants that should
+    remain true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_closing_entry_contract_user",
+            email="api-closing-entry-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Closing Entry Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        equity_account = coa_model.create_account(
+            code="3010",
+            name=f"{name} Equity Account",
+            role="eq_capital",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "equity_account": equity_account,
+        }
+
+    def create_closing_entry(self, setup, *, closing_date=date(2025, 12, 31)):
+        closing_entry = ClosingEntryModel.objects.create(
+            entity_model=setup["entity_model"],
+            closing_date=closing_date,
+        )
+
+        closing_entry.refresh_from_db()
+        return closing_entry
+
+    def create_balanced_closing_entry_transactions(self, closing_entry, setup):
+        debit_tx = ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["cash_account"],
+            tx_type=TransactionModel.DEBIT,
+            balance=Decimal("100.00"),
+        )
+
+        credit_tx = ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["equity_account"],
+            tx_type=TransactionModel.CREDIT,
+            balance=Decimal("100.00"),
+        )
+
+        return debit_tx, credit_tx
+
+    def test_closing_entry_creation_creates_hidden_posted_ledger(self):
+        setup = self.create_entity_setup()
+
+        closing_entry = self.create_closing_entry(setup)
+
+        self.assertIsInstance(closing_entry, ClosingEntryModel)
+        self.assertIsNotNone(closing_entry.uuid)
+        self.assertEqual(closing_entry.entity_model_id, setup["entity_model"].uuid)
+        self.assertEqual(closing_entry.closing_date, date(2025, 12, 31))
+        self.assertFalse(closing_entry.is_posted())
+        self.assertFalse(closing_entry.posted)
+
+        self.assertIsNotNone(closing_entry.ledger_model_id)
+        self.assertEqual(closing_entry.ledger_model.entity_id, setup["entity_model"].uuid)
+        self.assertTrue(closing_entry.ledger_model.hidden)
+        self.assertTrue(closing_entry.ledger_model.posted)
+        self.assertFalse(closing_entry.ledger_model.locked)
+
+    def test_closing_entry_for_entity_limits_queryset_to_entity_scope(self):
+        setup = self.create_entity_setup(name="API Closing Entry Entity A")
+        other_setup = self.create_entity_setup(name="API Closing Entry Entity B")
+
+        closing_entry = self.create_closing_entry(setup)
+        other_closing_entry = self.create_closing_entry(other_setup)
+
+        scoped_qs = ClosingEntryModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=closing_entry.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_closing_entry.uuid).exists())
+
+    def test_closing_entry_posted_and_not_posted_queryset_contracts(self):
+        setup = self.create_entity_setup()
+
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_entry_transactions(closing_entry, setup)
+
+        closing_entries_qs = ClosingEntryModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(closing_entries_qs.not_posted().filter(uuid=closing_entry.uuid).exists())
+        self.assertFalse(closing_entries_qs.posted().filter(uuid=closing_entry.uuid).exists())
+
+        closing_entry.mark_as_posted(
+            commit=True,
+            update_entity_meta=False,
+        )
+        closing_entry.refresh_from_db()
+
+        self.assertTrue(closing_entries_qs.posted().filter(uuid=closing_entry.uuid).exists())
+        self.assertFalse(closing_entries_qs.not_posted().filter(uuid=closing_entry.uuid).exists())
+
+    def test_closing_entry_date_is_unique_per_entity(self):
+        setup = self.create_entity_setup()
+
+        self.create_closing_entry(setup, closing_date=date(2025, 12, 31))
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                self.create_closing_entry(setup, closing_date=date(2025, 12, 31))
+
+    def test_balanced_closing_entry_can_be_posted_and_creates_locked_journal_entry(self):
+        setup = self.create_entity_setup()
+
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_entry_transactions(closing_entry, setup)
+
+        closing_entry.mark_as_posted(
+            commit=True,
+            update_entity_meta=False,
+        )
+        closing_entry.refresh_from_db()
+
+        self.assertTrue(closing_entry.is_posted())
+        self.assertFalse(closing_entry.can_post())
+        self.assertTrue(closing_entry.can_unpost())
+        self.assertFalse(closing_entry.can_update_txs())
+        self.assertFalse(closing_entry.can_delete())
+
+        journal_entries = JournalEntryModel.objects.filter(
+            ledger=closing_entry.ledger_model,
+            is_closing_entry=True,
+            origin="closing_entry",
+        )
+
+        self.assertEqual(journal_entries.count(), 1)
+
+        journal_entry = journal_entries.get()
+
+        self.assertTrue(journal_entry.posted)
+        self.assertTrue(journal_entry.locked)
+        self.assertEqual(journal_entry.timestamp, closing_entry.get_closing_date_as_timestamp())
+
+        txs = TransactionModel.objects.filter(journal_entry=journal_entry)
+
+        self.assertEqual(txs.count(), 2)
+        self.assertEqual(
+            sum(tx.amount for tx in txs if tx.tx_type == TransactionModel.DEBIT),
+            Decimal("100.00"),
+        )
+        self.assertEqual(
+            sum(tx.amount for tx in txs if tx.tx_type == TransactionModel.CREDIT),
+            Decimal("100.00"),
+        )
+
+        closing_entry.ledger_model.refresh_from_db()
+        self.assertTrue(closing_entry.ledger_model.locked)
+
+    def test_imbalanced_closing_entry_cannot_be_posted(self):
+        setup = self.create_entity_setup()
+
+        closing_entry = self.create_closing_entry(setup)
+
+        ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["cash_account"],
+            tx_type=TransactionModel.DEBIT,
+            balance=Decimal("100.00"),
+        )
+
+        ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["equity_account"],
+            tx_type=TransactionModel.CREDIT,
+            balance=Decimal("90.00"),
+        )
+
+        with self.assertRaises(ClosingEntryValidationError):
+            closing_entry.mark_as_posted(
+                commit=True,
+                update_entity_meta=False,
+            )
+
+        closing_entry.refresh_from_db()
+        self.assertFalse(closing_entry.is_posted())
+
+    def test_posted_closing_entry_can_be_unposted_and_removes_generated_entries(self):
+        setup = self.create_entity_setup()
+
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_entry_transactions(closing_entry, setup)
+
+        closing_entry.mark_as_posted(
+            commit=True,
+            update_entity_meta=False,
+        )
+        closing_entry.refresh_from_db()
+
+        self.assertTrue(
+            JournalEntryModel.objects.filter(
+                ledger=closing_entry.ledger_model,
+                is_closing_entry=True,
+            ).exists()
+        )
+
+        closing_entry.mark_as_unposted(
+            commit=True,
+            update_entity_meta=False,
+        )
+        closing_entry.refresh_from_db()
+
+        self.assertFalse(closing_entry.is_posted())
+        self.assertTrue(closing_entry.can_post())
+        self.assertTrue(closing_entry.can_update_txs())
+        self.assertTrue(closing_entry.can_delete())
+
+        self.assertFalse(
+            JournalEntryModel.objects.filter(
+                ledger=closing_entry.ledger_model,
+                is_closing_entry=True,
+            ).exists()
+        )
+
+        self.assertFalse(
+            TransactionModel.objects.filter(
+                journal_entry__ledger=closing_entry.ledger_model,
+            ).exists()
+        )
+
+        closing_entry.ledger_model.refresh_from_db()
+        self.assertFalse(closing_entry.ledger_model.locked)
+
+    def test_posted_closing_entry_cannot_be_deleted(self):
+        setup = self.create_entity_setup()
+
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_entry_transactions(closing_entry, setup)
+
+        closing_entry.mark_as_posted(
+            commit=True,
+            update_entity_meta=False,
+        )
+        closing_entry.refresh_from_db()
+
+        with self.assertRaises(ClosingEntryValidationError):
+            closing_entry.delete()
+
+    def test_closing_entry_transaction_for_closing_date_queryset_contract(self):
+        setup = self.create_entity_setup()
+        other_setup = self.create_entity_setup(name="API Other Closing Entry Entity")
+
+        closing_entry = self.create_closing_entry(setup, closing_date=date(2025, 12, 31))
+        other_closing_entry = self.create_closing_entry(other_setup, closing_date=date(2025, 12, 31))
+
+        debit_tx, _credit_tx = self.create_balanced_closing_entry_transactions(closing_entry, setup)
+        other_debit_tx, _other_credit_tx = self.create_balanced_closing_entry_transactions(
+            other_closing_entry,
+            other_setup,
+        )
+
+        closing_date_qs = ClosingEntryTransactionModel.objects.for_closing_date(
+            date(2025, 12, 31),
+        )
+
+        self.assertTrue(closing_date_qs.filter(uuid=debit_tx.uuid).exists())
+        self.assertTrue(closing_date_qs.filter(uuid=other_debit_tx.uuid).exists())
+
+    def test_closing_entry_transaction_for_entity_currently_exposes_lazy_loader_bug(self):
+        setup = self.create_entity_setup()
+        closing_entry = self.create_closing_entry(setup, closing_date=date(2025, 12, 31))
+        self.create_balanced_closing_entry_transactions(closing_entry, setup)
+
+        with self.assertRaises(AttributeError):
+            ClosingEntryTransactionModel.objects.for_entity(setup["entity_model"])
+
+    def test_closing_entry_transaction_negative_balance_flips_tx_type_and_abs_balance(self):
+        setup = self.create_entity_setup()
+        closing_entry = self.create_closing_entry(setup)
+
+        ce_tx = ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["cash_account"],
+            tx_type=TransactionModel.DEBIT,
+            balance=Decimal("-25.00"),
+        )
+
+        ce_tx.refresh_from_db()
+
+        self.assertTrue(ce_tx.is_credit())
+        self.assertFalse(ce_tx.is_debit())
+        self.assertEqual(ce_tx.balance, Decimal("25.000000"))

--- a/django_ledger/tests/api/test_closing_entry_api.py
+++ b/django_ledger/tests/api/test_closing_entry_api.py
@@ -322,13 +322,22 @@ class ClosingEntryHighLevelAPITest(TestCase):
         self.assertTrue(closing_date_qs.filter(uuid=debit_tx.uuid).exists())
         self.assertTrue(closing_date_qs.filter(uuid=other_debit_tx.uuid).exists())
 
-    def test_closing_entry_transaction_for_entity_currently_exposes_lazy_loader_bug(self):
+    def test_closing_entry_transaction_for_entity_limits_queryset_to_entity_scope(self):
         setup = self.create_entity_setup()
+        other_setup = self.create_entity_setup(name="API Other Closing Entry Transaction Entity")
         closing_entry = self.create_closing_entry(setup, closing_date=date(2025, 12, 31))
-        self.create_balanced_closing_entry_transactions(closing_entry, setup)
+        other_closing_entry = self.create_closing_entry(other_setup, closing_date=date(2025, 12, 31))
 
-        with self.assertRaises(AttributeError):
-            ClosingEntryTransactionModel.objects.for_entity(setup["entity_model"])
+        debit_tx, _credit_tx = self.create_balanced_closing_entry_transactions(closing_entry, setup)
+        other_debit_tx, _other_credit_tx = self.create_balanced_closing_entry_transactions(
+            other_closing_entry,
+            other_setup,
+        )
+
+        scoped_qs = ClosingEntryTransactionModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=debit_tx.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_debit_tx.uuid).exists())
 
     def test_closing_entry_transaction_negative_balance_flips_tx_type_and_abs_balance(self):
         setup = self.create_entity_setup()

--- a/django_ledger/tests/api/test_closing_entry_delete_url_api.py
+++ b/django_ledger/tests/api/test_closing_entry_delete_url_api.py
@@ -1,0 +1,171 @@
+"""
+High-level API tests for ClosingEntryModel delete and helper URLs.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import TransactionModel
+from django_ledger.models.closing_entry import (
+    ClosingEntryModel,
+    ClosingEntryTransactionModel,
+    ClosingEntryValidationError,
+)
+from django_ledger.models.entity import EntityModel
+
+
+class ClosingEntryDeleteURLAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_closing_entry_delete_url_user",
+            email="api-closing-entry-delete-url-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Closing Entry Delete URL Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        equity_account = coa_model.create_account(
+            code="3010",
+            name=f"{name} Equity Account",
+            role="eq_capital",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "equity_account": equity_account,
+        }
+
+    def create_closing_entry(self, setup, *, closing_date=date(2025, 12, 31)):
+        closing_entry = ClosingEntryModel.objects.create(
+            entity_model=setup["entity_model"],
+            closing_date=closing_date,
+        )
+        closing_entry.refresh_from_db()
+        return closing_entry
+
+    def create_balanced_closing_transactions(self, closing_entry, setup):
+        debit_tx = ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["cash_account"],
+            tx_type=TransactionModel.DEBIT,
+            balance=Decimal("100.00"),
+        )
+        credit_tx = ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["equity_account"],
+            tx_type=TransactionModel.CREDIT,
+            balance=Decimal("100.00"),
+        )
+        return debit_tx, credit_tx
+
+    def test_unposted_closing_entry_can_be_deleted_and_removes_related_ledger_state(self):
+        setup = self.create_entity_setup()
+        closing_entry = self.create_closing_entry(setup)
+        debit_tx, credit_tx = self.create_balanced_closing_transactions(closing_entry, setup)
+        ledger_model = closing_entry.ledger_model
+
+        self.assertTrue(closing_entry.can_delete())
+
+        closing_entry.delete()
+
+        self.assertFalse(ClosingEntryModel.objects.filter(uuid=closing_entry.uuid).exists())
+        self.assertFalse(ClosingEntryTransactionModel.objects.filter(uuid__in=[debit_tx.uuid, credit_tx.uuid]).exists())
+        self.assertFalse(ledger_model.__class__.objects.filter(uuid=ledger_model.uuid).exists())
+
+    def test_posted_closing_entry_rejects_delete_and_leaves_state_intact(self):
+        setup = self.create_entity_setup(name="API Closing Entry Delete Posted Entity")
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_transactions(closing_entry, setup)
+        closing_entry.mark_as_posted(commit=True, update_entity_meta=False)
+        closing_entry.refresh_from_db()
+
+        with self.assertRaises(ClosingEntryValidationError):
+            closing_entry.delete()
+
+        persisted_closing_entry = ClosingEntryModel.objects.get(uuid=closing_entry.uuid)
+        self.assertTrue(persisted_closing_entry.posted)
+        self.assertTrue(persisted_closing_entry.ledger_model.locked)
+
+    def test_url_helpers_return_entity_scoped_strings(self):
+        setup = self.create_entity_setup(name="API Closing Entry URL Entity")
+        closing_entry = self.create_closing_entry(setup)
+        entity_slug = setup["entity_model"].slug
+        closing_entry_uuid = str(closing_entry.uuid)
+
+        helper_names = [
+            "get_mark_as_posted_url",
+            "get_mark_as_unposted_url",
+            "get_update_transactions_url",
+            "get_delete_url",
+        ]
+
+        for helper_name in helper_names:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(closing_entry, helper_name)()
+                self.assertIsInstance(url, str)
+                self.assertTrue(url)
+                self.assertIn(entity_slug, url)
+                self.assertIn(closing_entry_uuid, url)
+
+        list_url = closing_entry.get_list_url()
+        self.assertIsInstance(list_url, str)
+        self.assertTrue(list_url)
+        self.assertIn(entity_slug, list_url)
+        self.assertNotIn(closing_entry_uuid, list_url)
+
+    def test_message_and_html_id_helpers_return_non_empty_strings(self):
+        setup = self.create_entity_setup(name="API Closing Entry Message Entity")
+        closing_entry = self.create_closing_entry(setup)
+
+        helper_names = [
+            "get_mark_as_posted_html_id",
+            "get_mark_as_unposted_html_id",
+            "get_update_transactions_html_id",
+            "get_delete_html_id",
+            "get_html_id",
+        ]
+
+        for helper_name in helper_names:
+            with self.subTest(helper_name=helper_name):
+                value = str(getattr(closing_entry, helper_name)())
+                self.assertTrue(value)
+                self.assertIn(str(closing_entry.uuid), value)
+
+        message_helper_names = [
+            "get_mark_as_posted_message",
+            "get_mark_as_unposted_message",
+            "get_update_transactions_message",
+            "get_delete_message",
+        ]
+
+        for helper_name in message_helper_names:
+            with self.subTest(helper_name=helper_name):
+                value = str(getattr(closing_entry, helper_name)())
+                self.assertTrue(value)
+                self.assertIn(str(closing_entry.closing_date), value)

--- a/django_ledger/tests/api/test_closing_entry_lifecycle_api.py
+++ b/django_ledger/tests/api/test_closing_entry_lifecycle_api.py
@@ -1,0 +1,264 @@
+"""
+High-level API tests for ClosingEntryModel lifecycle behavior.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io.roles import ASSET_CA_CASH, CREDIT, DEBIT, EXPENSE_OPERATIONAL
+from django_ledger.models import TransactionModel
+from django_ledger.models.closing_entry import (
+    ClosingEntryModel,
+    ClosingEntryTransactionModel,
+    ClosingEntryValidationError,
+)
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryModel
+
+
+class ClosingEntryLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_closing_entry_lifecycle_user",
+            email="api-closing-entry-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self, tx_date):
+        if settings.USE_TZ:
+            return datetime(tx_date.year, tx_date.month, tx_date.day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(tx_date.year, tx_date.month, tx_date.day, 12, 0)
+
+    def create_entity_setup(self, *, name="API Closing Entry Lifecycle Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+
+        cash_account = entity_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+        expense_account = entity_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+            active=True,
+        )
+        equity_account = entity_model.create_account(
+            code="3010",
+            name=f"{name} Equity Account",
+            role="eq_capital",
+            balance_type=CREDIT,
+            active=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "equity_account": equity_account,
+        }
+
+    def create_closing_entry(self, setup, *, closing_date=date(2025, 12, 31)):
+        closing_entry = ClosingEntryModel.objects.create(
+            entity_model=setup["entity_model"],
+            closing_date=closing_date,
+        )
+        closing_entry.refresh_from_db()
+        return closing_entry
+
+    def create_balanced_closing_transactions(self, closing_entry, setup):
+        ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["cash_account"],
+            tx_type=TransactionModel.DEBIT,
+            balance=Decimal("100.00"),
+        )
+        ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["equity_account"],
+            tx_type=TransactionModel.CREDIT,
+            balance=Decimal("100.00"),
+        )
+
+    def create_posted_activity(self, setup, *, tx_date=date(2025, 1, 15)):
+        entity_model = setup["entity_model"]
+        ledger_model = entity_model.create_ledger(
+            name=f"API Closing Lifecycle Activity Ledger {tx_date.isoformat()}",
+            ledger_xid=f"api-closing-lifecycle-activity-{tx_date.isoformat()}",
+            posted=True,
+        )
+        journal_entry, tx_models = entity_model.commit_txs(
+            je_timestamp=self.make_timestamp(tx_date),
+            je_ledger_model=ledger_model,
+            je_posted=True,
+            je_desc=f"API Closing Lifecycle Activity {tx_date.isoformat()}",
+            je_txs=[
+                {
+                    "account": setup["expense_account"],
+                    "amount": Decimal("100.00"),
+                    "tx_type": TransactionModel.DEBIT,
+                    "description": "API expense debit.",
+                },
+                {
+                    "account": setup["cash_account"],
+                    "amount": Decimal("100.00"),
+                    "tx_type": TransactionModel.CREDIT,
+                    "description": "API cash credit.",
+                },
+            ],
+        )
+        journal_entry.refresh_from_db()
+        ledger_model.refresh_from_db()
+        self.assertTrue(journal_entry.posted)
+        self.assertEqual(len(tx_models), 2)
+        return ledger_model, journal_entry, tx_models
+
+    def assert_generated_closing_entries(self, closing_entry):
+        journal_entries = JournalEntryModel.objects.filter(
+            ledger=closing_entry.ledger_model,
+            is_closing_entry=True,
+            origin="closing_entry",
+        )
+        self.assertEqual(journal_entries.count(), 1)
+        journal_entry = journal_entries.get()
+        self.assertTrue(journal_entry.posted)
+        self.assertTrue(journal_entry.locked)
+        self.assertEqual(journal_entry.timestamp, closing_entry.get_closing_date_as_timestamp())
+        self.assertEqual(TransactionModel.objects.filter(journal_entry=journal_entry).count(), 2)
+
+    def test_mark_as_posted_commit_true_posts_and_migrates_closing_records(self):
+        setup = self.create_entity_setup()
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_transactions(closing_entry, setup)
+
+        closing_entry.mark_as_posted(commit=True, update_entity_meta=False)
+        closing_entry.refresh_from_db()
+
+        self.assertTrue(closing_entry.posted)
+        self.assertFalse(closing_entry.can_post())
+        self.assertTrue(closing_entry.can_unpost())
+        self.assertFalse(closing_entry.can_update_txs())
+        self.assertFalse(closing_entry.can_delete())
+        self.assert_generated_closing_entries(closing_entry)
+        closing_entry.ledger_model.refresh_from_db()
+        self.assertTrue(closing_entry.ledger_model.posted)
+        self.assertTrue(closing_entry.ledger_model.locked)
+
+    def test_mark_as_posted_commit_false_still_migrates_and_locks_ledger_but_does_not_persist_entry_posted_flag(self):
+        setup = self.create_entity_setup(name="API Closing Lifecycle Post False Entity")
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_transactions(closing_entry, setup)
+
+        closing_entry.mark_as_posted(commit=False, update_entity_meta=False)
+
+        self.assertTrue(closing_entry.posted)
+        persisted_closing_entry = ClosingEntryModel.objects.get(uuid=closing_entry.uuid)
+        self.assertFalse(persisted_closing_entry.posted)
+        self.assert_generated_closing_entries(closing_entry)
+        closing_entry.ledger_model.refresh_from_db()
+        self.assertTrue(closing_entry.ledger_model.locked)
+
+    def test_mark_as_unposted_commit_true_removes_generated_records_and_unlocks_but_keeps_ledger_posted(self):
+        setup = self.create_entity_setup(name="API Closing Lifecycle Unpost True Entity")
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_transactions(closing_entry, setup)
+        closing_entry.mark_as_posted(commit=True, update_entity_meta=False)
+
+        closing_entry.mark_as_unposted(commit=True, update_entity_meta=False)
+        closing_entry.refresh_from_db()
+
+        self.assertFalse(closing_entry.posted)
+        self.assertTrue(closing_entry.can_post())
+        self.assertTrue(closing_entry.can_update_txs())
+        self.assertFalse(JournalEntryModel.objects.filter(ledger=closing_entry.ledger_model).exists())
+        self.assertFalse(TransactionModel.objects.filter(journal_entry__ledger=closing_entry.ledger_model).exists())
+        closing_entry.ledger_model.refresh_from_db()
+        self.assertTrue(closing_entry.ledger_model.posted)
+        self.assertFalse(closing_entry.ledger_model.locked)
+
+    def test_mark_as_unposted_commit_false_removes_generated_records_but_does_not_persist_entry_posted_flag(self):
+        setup = self.create_entity_setup(name="API Closing Lifecycle Unpost False Entity")
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_transactions(closing_entry, setup)
+        closing_entry.mark_as_posted(commit=True, update_entity_meta=False)
+        closing_entry.refresh_from_db()
+
+        closing_entry.mark_as_unposted(commit=False, update_entity_meta=False)
+
+        self.assertFalse(closing_entry.posted)
+        persisted_closing_entry = ClosingEntryModel.objects.get(uuid=closing_entry.uuid)
+        self.assertTrue(persisted_closing_entry.posted)
+        self.assertFalse(JournalEntryModel.objects.filter(ledger=closing_entry.ledger_model).exists())
+        closing_entry.ledger_model.refresh_from_db()
+        self.assertTrue(closing_entry.ledger_model.posted)
+        self.assertFalse(closing_entry.ledger_model.locked)
+
+    def test_direct_post_and_unpost_with_entity_meta_refreshes_last_closing_date(self):
+        setup = self.create_entity_setup(name="API Closing Lifecycle Entity Meta Entity")
+        entity_model = setup["entity_model"]
+        first_entry = self.create_closing_entry(setup, closing_date=date(2025, 6, 30))
+        second_entry = self.create_closing_entry(setup, closing_date=date(2025, 12, 31))
+        self.create_balanced_closing_transactions(first_entry, setup)
+        self.create_balanced_closing_transactions(second_entry, setup)
+
+        first_entry.mark_as_posted(commit=True, update_entity_meta=True)
+        second_entry.mark_as_posted(commit=True, update_entity_meta=True)
+        persisted_entity = EntityModel.objects.get(uuid=entity_model.uuid)
+
+        self.assertEqual(persisted_entity.last_closing_date, date(2025, 12, 31))
+        self.assertEqual(
+            persisted_entity.fetch_closing_entry_dates_meta(),
+            [date(2025, 12, 31), date(2025, 6, 30)],
+        )
+
+        second_entry.mark_as_unposted(commit=True, update_entity_meta=True)
+        persisted_entity = EntityModel.objects.get(uuid=entity_model.uuid)
+
+        self.assertEqual(persisted_entity.last_closing_date, date(2025, 6, 30))
+        self.assertEqual(persisted_entity.fetch_closing_entry_dates_meta(), [date(2025, 6, 30)])
+
+    def test_update_transactions_delegates_to_entity_close_behavior_without_posting_when_requested(self):
+        setup = self.create_entity_setup(name="API Closing Lifecycle Update Transactions Entity")
+        self.create_posted_activity(setup, tx_date=date(2025, 1, 15))
+        closing_entry = self.create_closing_entry(setup, closing_date=date(2025, 1, 31))
+
+        closing_entry.update_transactions(post_closing_entry=False)
+        closing_entry.refresh_from_db()
+
+        self.assertFalse(closing_entry.posted)
+        self.assertEqual(closing_entry.closingentrytransactionmodel_set.count(), 2)
+        self.assertFalse(JournalEntryModel.objects.filter(ledger=closing_entry.ledger_model).exists())
+
+    def test_single_sided_closing_transactions_raise_domain_validation_error(self):
+        setup = self.create_entity_setup(name="API Closing Lifecycle Single Sided Entity")
+        closing_entry = self.create_closing_entry(setup)
+        ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["cash_account"],
+            tx_type=TransactionModel.DEBIT,
+            balance=Decimal("100.00"),
+        )
+
+        with self.assertRaises(ClosingEntryValidationError):
+            closing_entry.mark_as_posted(commit=True, update_entity_meta=False)

--- a/django_ledger/tests/api/test_closing_entry_queryset_api.py
+++ b/django_ledger/tests/api/test_closing_entry_queryset_api.py
@@ -1,0 +1,245 @@
+"""
+High-level API tests for ClosingEntryModel queryset and manager behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import TransactionModel
+from django_ledger.models.closing_entry import (
+    ClosingEntryModel,
+    ClosingEntryTransactionModel,
+    ClosingEntryValidationError,
+)
+from django_ledger.models.entity import EntityModel
+
+
+class ClosingEntryQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_closing_entry_queryset_admin",
+            email="api-closing-entry-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_closing_entry_queryset_manager",
+            email="api-closing-entry-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_closing_entry_queryset_other_admin",
+            email="api-closing-entry-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_closing_entry_queryset_unrelated",
+            email="api-closing-entry-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_closing_entry_queryset_superuser",
+            email="api-closing-entry-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Closing Entry Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        equity_account = coa_model.create_account(
+            code="3010",
+            name=f"{name} Equity Account",
+            role="eq_capital",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "equity_account": equity_account,
+        }
+
+    def create_closing_entry(self, setup, *, closing_date=date(2025, 12, 31), posted=False):
+        closing_entry = ClosingEntryModel.objects.create(
+            entity_model=setup["entity_model"],
+            closing_date=closing_date,
+            posted=posted,
+        )
+        closing_entry.refresh_from_db()
+        return closing_entry
+
+    def create_balanced_closing_transactions(self, closing_entry, setup):
+        debit_tx = ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["cash_account"],
+            tx_type=TransactionModel.DEBIT,
+            balance=Decimal("100.00"),
+        )
+        credit_tx = ClosingEntryTransactionModel.objects.create(
+            closing_entry_model=closing_entry,
+            account_model=setup["equity_account"],
+            tx_type=TransactionModel.CREDIT,
+            balance=Decimal("100.00"),
+        )
+        return debit_tx, credit_tx
+
+    def assert_closing_entry_uuids(self, queryset, expected_entries):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {closing_entry.uuid for closing_entry in expected_entries},
+        )
+
+    def assert_closing_tx_uuids(self, queryset, expected_txs):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {closing_tx.uuid for closing_tx in expected_txs},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Closing Entry Queryset Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Closing Entry Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        closing_entry = self.create_closing_entry(setup)
+        self.create_closing_entry(other_setup)
+        entity_model = setup["entity_model"]
+
+        self.assert_closing_entry_uuids(ClosingEntryModel.objects.for_entity(entity_model), [closing_entry])
+        self.assert_closing_entry_uuids(ClosingEntryModel.objects.for_entity(entity_model.slug), [closing_entry])
+        self.assert_closing_entry_uuids(ClosingEntryModel.objects.for_entity(entity_model.uuid), [closing_entry])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_closing_entry(self.create_entity_setup())
+
+        with self.assertRaises(ClosingEntryValidationError):
+            ClosingEntryModel.objects.for_entity(object())
+
+        self.assertFalse(ClosingEntryModel.objects.for_entity("missing-closing-entry-entity").exists())
+
+    def test_for_user_scopes_to_authorized_users_and_superuser(self):
+        setup = self.create_entity_setup(
+            name="API Closing Entry Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API Closing Entry Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        closing_entry = self.create_closing_entry(setup)
+        other_closing_entry = self.create_closing_entry(other_setup)
+
+        self.assert_closing_entry_uuids(ClosingEntryModel.objects.all().for_user(self.admin_user), [closing_entry])
+        self.assert_closing_entry_uuids(ClosingEntryModel.objects.all().for_user(self.manager_user), [closing_entry])
+        self.assertFalse(ClosingEntryModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_closing_entry_uuids(
+            ClosingEntryModel.objects.all().for_user(self.superuser),
+            [closing_entry, other_closing_entry],
+        )
+
+    def test_posted_and_not_posted_filters_return_matching_entries(self):
+        setup = self.create_entity_setup(name="API Closing Entry Queryset Posted Entity")
+        posted_entry = self.create_closing_entry(setup, closing_date=date(2025, 12, 31), posted=True)
+        unposted_entry = self.create_closing_entry(setup, closing_date=date(2025, 11, 30), posted=False)
+
+        scoped_qs = ClosingEntryModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_closing_entry_uuids(scoped_qs.posted(), [posted_entry])
+        self.assert_closing_entry_uuids(scoped_qs.not_posted(), [unposted_entry])
+
+    def test_manager_annotation_exposes_closing_transaction_count(self):
+        setup = self.create_entity_setup(name="API Closing Entry Queryset Count Entity")
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_transactions(closing_entry, setup)
+
+        annotated_entry = ClosingEntryModel.objects.get(uuid=closing_entry.uuid)
+
+        self.assertEqual(annotated_entry.ce_txs_count, 2)
+
+    def test_closing_transaction_for_user_scopes_to_authorized_users(self):
+        setup = self.create_entity_setup(
+            name="API Closing Tx Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API Closing Tx Queryset Other Entity",
+            admin_user=self.other_admin_user,
+        )
+        closing_entry = self.create_closing_entry(setup)
+        other_closing_entry = self.create_closing_entry(other_setup)
+        debit_tx, credit_tx = self.create_balanced_closing_transactions(closing_entry, setup)
+        other_debit_tx, other_credit_tx = self.create_balanced_closing_transactions(other_closing_entry, other_setup)
+
+        self.assert_closing_tx_uuids(
+            ClosingEntryTransactionModel.objects.all().for_user(self.admin_user),
+            [debit_tx, credit_tx],
+        )
+        self.assert_closing_tx_uuids(
+            ClosingEntryTransactionModel.objects.all().for_user(self.manager_user),
+            [debit_tx, credit_tx],
+        )
+        self.assertFalse(ClosingEntryTransactionModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_closing_tx_uuids(
+            ClosingEntryTransactionModel.objects.all().for_user(self.superuser),
+            [debit_tx, credit_tx, other_debit_tx, other_credit_tx],
+        )
+
+    def test_closing_transaction_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Closing Tx Queryset Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Closing Tx Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        closing_entry = self.create_closing_entry(setup)
+        other_closing_entry = self.create_closing_entry(other_setup)
+        debit_tx, credit_tx = self.create_balanced_closing_transactions(closing_entry, setup)
+        self.create_balanced_closing_transactions(other_closing_entry, other_setup)
+        entity_model = setup["entity_model"]
+
+        self.assert_closing_tx_uuids(
+            ClosingEntryTransactionModel.objects.for_entity(entity_model),
+            [debit_tx, credit_tx],
+        )
+        self.assert_closing_tx_uuids(
+            ClosingEntryTransactionModel.objects.for_entity(entity_model.slug),
+            [debit_tx, credit_tx],
+        )
+        self.assert_closing_tx_uuids(
+            ClosingEntryTransactionModel.objects.for_entity(entity_model.uuid),
+            [debit_tx, credit_tx],
+        )
+
+    def test_closing_transaction_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        setup = self.create_entity_setup(name="API Closing Tx Queryset Invalid Entity")
+        closing_entry = self.create_closing_entry(setup)
+        self.create_balanced_closing_transactions(closing_entry, setup)
+
+        with self.assertRaises(ClosingEntryValidationError):
+            ClosingEntryTransactionModel.objects.for_entity(object())
+
+        self.assertFalse(ClosingEntryTransactionModel.objects.for_entity("missing-closing-tx-entity").exists())

--- a/django_ledger/tests/api/test_coa_default_api.py
+++ b/django_ledger/tests/api/test_coa_default_api.py
@@ -1,0 +1,89 @@
+"""
+High-level API behavior tests for bundled default Chart of Accounts data.
+
+These tests validate the shape and grouping of the packaged default CoA
+without mutating module-level data.
+"""
+
+import importlib.util
+
+from django.test import SimpleTestCase
+
+from django_ledger.io import (
+    ROOT_ASSETS,
+    ROOT_CAPITAL,
+    ROOT_COGS,
+    ROOT_EXPENSES,
+    ROOT_INCOME,
+    ROOT_LIABILITIES,
+)
+from django_ledger.models.coa_default import (
+    CHART_OF_ACCOUNTS_ROOT_MAP,
+    get_default_coa,
+    get_default_coa_rst,
+    verify_unique_code,
+)
+
+
+class CoADefaultAPITest(SimpleTestCase):
+    REQUIRED_KEYS = {
+        "code",
+        "role",
+        "balance_type",
+        "name",
+        "parent",
+        "root_group",
+    }
+    EXPECTED_ROOT_GROUPS = {
+        ROOT_ASSETS,
+        ROOT_LIABILITIES,
+        ROOT_CAPITAL,
+        ROOT_INCOME,
+        ROOT_COGS,
+        ROOT_EXPENSES,
+    }
+
+    def test_get_default_coa_returns_entries_with_required_keys(self):
+        default_coa = get_default_coa()
+
+        self.assertIsInstance(default_coa, list)
+        self.assertGreater(len(default_coa), 0)
+
+        for entry in default_coa:
+            with self.subTest(code=entry.get("code")):
+                self.assertTrue(self.REQUIRED_KEYS.issubset(entry.keys()))
+
+    def test_default_account_codes_are_unique_and_verified(self):
+        default_coa = get_default_coa()
+        code_list = [entry["code"] for entry in default_coa]
+
+        self.assertEqual(len(code_list), len(set(code_list)))
+        verify_unique_code()
+
+    def test_each_default_account_has_root_group(self):
+        for entry in get_default_coa():
+            with self.subTest(code=entry["code"]):
+                self.assertIn(entry["root_group"], self.EXPECTED_ROOT_GROUPS)
+
+    def test_root_map_groups_accounts_by_root_group(self):
+        self.assertTrue(self.EXPECTED_ROOT_GROUPS.issubset(CHART_OF_ACCOUNTS_ROOT_MAP.keys()))
+
+        grouped_codes = set()
+        for root_group, entries in CHART_OF_ACCOUNTS_ROOT_MAP.items():
+            with self.subTest(root_group=root_group):
+                self.assertGreater(len(entries), 0)
+                for entry in entries:
+                    self.assertEqual(entry["root_group"], root_group)
+                    grouped_codes.add(entry["code"])
+
+        self.assertEqual(grouped_codes, {entry["code"] for entry in get_default_coa()})
+
+    def test_get_default_coa_rst_returns_rst_table_when_tabulate_is_available(self):
+        if importlib.util.find_spec("tabulate") is None:
+            self.skipTest("tabulate is not installed.")
+
+        rst_table = get_default_coa_rst()
+
+        self.assertIsInstance(rst_table, str)
+        self.assertIn("code", rst_table)
+        self.assertIn("role", rst_table)

--- a/django_ledger/tests/api/test_customer_vendor_api.py
+++ b/django_ledger/tests/api/test_customer_vendor_api.py
@@ -1,0 +1,242 @@
+"""
+High-level API behavior tests for CustomerModel and VendorModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.vendor import VendorModel
+
+
+class CustomerVendorHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for CustomerModel and VendorModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic commercial-party API invariants that
+    should remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_customer_vendor_contract_user",
+            email="api-customer-vendor-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Customer Vendor Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        entity_model.create_chart_of_accounts(
+            coa_name="API Customer Vendor Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        entity_model.refresh_from_db()
+        return entity_model
+
+    def create_customer(self, entity_model, *, name="API Contract Customer"):
+        customer_model = CustomerModel(
+            customer_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_vendor(self, entity_model, *, name="API Contract Vendor"):
+        vendor_model = VendorModel(
+            vendor_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        return vendor_model
+
+    def test_customer_is_created_under_entity_context(self):
+        entity_model = self.create_entity()
+
+        customer_model = self.create_customer(entity_model)
+
+        self.assertIsNotNone(customer_model.uuid)
+        self.assertEqual(customer_model.entity_model_id, entity_model.uuid)
+        self.assertEqual(customer_model.customer_name, "API Contract Customer")
+        self.assertTrue(customer_model.active)
+        self.assertFalse(customer_model.hidden)
+
+    def test_customer_number_is_generated_on_save(self):
+        entity_model = self.create_entity()
+
+        customer_model = self.create_customer(entity_model)
+
+        self.assertTrue(customer_model.customer_number)
+        self.assertIsInstance(customer_model.customer_number, str)
+
+    def test_customer_for_entity_limits_queryset_to_entity_scope(self):
+        entity_model = self.create_entity(name="API Customer Entity A")
+        other_entity_model = self.create_entity(name="API Customer Entity B")
+
+        customer_model = self.create_customer(
+            entity_model,
+            name="API Contract Customer A",
+        )
+        other_customer_model = self.create_customer(
+            other_entity_model,
+            name="API Contract Customer B",
+        )
+
+        scoped_qs = CustomerModel.objects.for_entity(entity_model)
+
+        self.assertTrue(scoped_qs.filter(uuid=customer_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_customer_model.uuid).exists())
+
+    def test_customer_active_inactive_queryset_helpers(self):
+        entity_model = self.create_entity()
+
+        active_customer = self.create_customer(
+            entity_model,
+            name="API Active Customer",
+        )
+
+        inactive_customer = self.create_customer(
+            entity_model,
+            name="API Inactive Customer",
+        )
+        inactive_customer.active = False
+        inactive_customer.save(update_fields=["active"])
+
+        customers_qs = CustomerModel.objects.for_entity(entity_model)
+
+        self.assertTrue(customers_qs.active().filter(uuid=active_customer.uuid).exists())
+        self.assertFalse(customers_qs.active().filter(uuid=inactive_customer.uuid).exists())
+
+        self.assertTrue(customers_qs.inactive().filter(uuid=inactive_customer.uuid).exists())
+        self.assertFalse(customers_qs.inactive().filter(uuid=active_customer.uuid).exists())
+
+    def test_customer_visible_hidden_queryset_helpers(self):
+        entity_model = self.create_entity()
+
+        visible_customer = self.create_customer(
+            entity_model,
+            name="API Visible Customer",
+        )
+
+        hidden_customer = self.create_customer(
+            entity_model,
+            name="API Hidden Customer",
+        )
+        hidden_customer.hidden = True
+        hidden_customer.save(update_fields=["hidden"])
+
+        customers_qs = CustomerModel.objects.for_entity(entity_model)
+
+        self.assertTrue(customers_qs.visible().filter(uuid=visible_customer.uuid).exists())
+        self.assertFalse(customers_qs.visible().filter(uuid=hidden_customer.uuid).exists())
+
+        self.assertTrue(customers_qs.hidden().filter(uuid=hidden_customer.uuid).exists())
+        self.assertFalse(customers_qs.hidden().filter(uuid=visible_customer.uuid).exists())
+
+    def test_vendor_is_created_under_entity_context(self):
+        entity_model = self.create_entity()
+
+        vendor_model = self.create_vendor(entity_model)
+
+        self.assertIsNotNone(vendor_model.uuid)
+        self.assertEqual(vendor_model.entity_model_id, entity_model.uuid)
+        self.assertEqual(vendor_model.vendor_name, "API Contract Vendor")
+        self.assertTrue(vendor_model.active)
+        self.assertFalse(vendor_model.hidden)
+
+    def test_vendor_number_is_generated_on_save(self):
+        entity_model = self.create_entity()
+
+        vendor_model = self.create_vendor(entity_model)
+
+        self.assertTrue(vendor_model.vendor_number)
+        self.assertIsInstance(vendor_model.vendor_number, str)
+
+    def test_vendor_for_entity_limits_queryset_to_entity_scope(self):
+        entity_model = self.create_entity(name="API Vendor Entity A")
+        other_entity_model = self.create_entity(name="API Vendor Entity B")
+
+        vendor_model = self.create_vendor(
+            entity_model,
+            name="API Contract Vendor A",
+        )
+        other_vendor_model = self.create_vendor(
+            other_entity_model,
+            name="API Contract Vendor B",
+        )
+
+        scoped_qs = VendorModel.objects.for_entity(entity_model)
+
+        self.assertTrue(scoped_qs.filter(uuid=vendor_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_vendor_model.uuid).exists())
+
+    def test_vendor_active_inactive_queryset_helpers(self):
+        entity_model = self.create_entity()
+
+        active_vendor = self.create_vendor(
+            entity_model,
+            name="API Active Vendor",
+        )
+
+        inactive_vendor = self.create_vendor(
+            entity_model,
+            name="API Inactive Vendor",
+        )
+        inactive_vendor.active = False
+        inactive_vendor.save(update_fields=["active"])
+
+        vendors_qs = VendorModel.objects.for_entity(entity_model)
+
+        self.assertTrue(vendors_qs.active().filter(uuid=active_vendor.uuid).exists())
+        self.assertFalse(vendors_qs.active().filter(uuid=inactive_vendor.uuid).exists())
+
+        self.assertTrue(vendors_qs.inactive().filter(uuid=inactive_vendor.uuid).exists())
+        self.assertFalse(vendors_qs.inactive().filter(uuid=active_vendor.uuid).exists())
+
+    def test_vendor_visible_hidden_queryset_helpers(self):
+        entity_model = self.create_entity()
+
+        visible_vendor = self.create_vendor(
+            entity_model,
+            name="API Visible Vendor",
+        )
+
+        hidden_vendor = self.create_vendor(
+            entity_model,
+            name="API Hidden Vendor",
+        )
+        hidden_vendor.hidden = True
+        hidden_vendor.save(update_fields=["hidden"])
+
+        vendors_qs = VendorModel.objects.for_entity(entity_model)
+
+        self.assertTrue(vendors_qs.visible().filter(uuid=visible_vendor.uuid).exists())
+        self.assertFalse(vendors_qs.visible().filter(uuid=hidden_vendor.uuid).exists())
+
+        self.assertTrue(vendors_qs.hidden().filter(uuid=hidden_vendor.uuid).exists())
+        self.assertFalse(vendors_qs.hidden().filter(uuid=visible_vendor.uuid).exists())

--- a/django_ledger/tests/api/test_customer_vendor_display_url_api.py
+++ b/django_ledger/tests/api/test_customer_vendor_display_url_api.py
@@ -1,0 +1,145 @@
+"""
+High-level API tests for CustomerModel and VendorModel display, URL, and upload helpers.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.customer import CustomerModel, customer_picture_upload_to
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.vendor import VendorModel, vendor_picture_upload_to
+
+
+class CustomerVendorDisplayURLAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_customer_vendor_display_admin",
+            email="api-customer-vendor-display-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Customer Vendor Display Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_customer(self, entity_model, *, name="API Display Customer"):
+        customer_model = CustomerModel(
+            customer_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_vendor(self, entity_model, *, name="API Display Vendor"):
+        vendor_model = VendorModel(
+            vendor_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        return vendor_model
+
+    def assert_entity_and_party_identifiers_in_url(self, url, entity_model, party_model):
+        self.assertIsInstance(url, str)
+        self.assertIn(entity_model.slug, url)
+        self.assertIn(str(party_model.uuid), url)
+
+    def test_customer_and_vendor_str_include_number_and_name(self):
+        entity_model = self.create_entity()
+        customer_model = self.create_customer(entity_model, name="API String Customer")
+        vendor_model = self.create_vendor(entity_model, name="API String Vendor")
+
+        customer_text = str(customer_model)
+        vendor_text = str(vendor_model)
+
+        self.assertIn(customer_model.customer_number, customer_text)
+        self.assertIn(customer_model.customer_name, customer_text)
+        self.assertIn(vendor_model.vendor_number, vendor_text)
+        self.assertIn(vendor_model.vendor_name, vendor_text)
+
+    def test_unknown_number_str_still_returns_party_context(self):
+        entity_model = self.create_entity()
+        customer_model = CustomerModel(
+            customer_name="API Unknown Customer",
+            entity_model=entity_model,
+            description="API Unknown Customer description",
+        )
+        vendor_model = VendorModel(
+            vendor_name="API Unknown Vendor",
+            entity_model=entity_model,
+            description="API Unknown Vendor description",
+        )
+
+        self.assertIn(customer_model.customer_name, str(customer_model))
+        self.assertIn(vendor_model.vendor_name, str(vendor_model))
+
+    def test_customer_url_helpers_return_entity_scoped_strings(self):
+        entity_model = self.create_entity()
+        customer_model = self.create_customer(entity_model)
+
+        absolute_url = customer_model.get_absolute_url()
+        detail_url = customer_model.get_detail_url()
+        update_url = customer_model.get_update_url()
+
+        self.assertEqual(absolute_url, detail_url)
+        self.assert_entity_and_party_identifiers_in_url(absolute_url, entity_model, customer_model)
+        self.assert_entity_and_party_identifiers_in_url(update_url, entity_model, customer_model)
+
+    def test_vendor_url_helpers_return_entity_scoped_strings(self):
+        entity_model = self.create_entity()
+        vendor_model = self.create_vendor(entity_model)
+
+        absolute_url = vendor_model.get_absolute_url()
+        detail_url = vendor_model.get_detail_url()
+        update_url = vendor_model.get_update_url()
+
+        self.assertEqual(absolute_url, detail_url)
+        self.assert_entity_and_party_identifiers_in_url(absolute_url, entity_model, vendor_model)
+        self.assert_entity_and_party_identifiers_in_url(update_url, entity_model, vendor_model)
+
+    def test_picture_upload_paths_use_party_number_and_sanitized_extension(self):
+        entity_model = self.create_entity()
+        customer_model = self.create_customer(entity_model)
+        vendor_model = self.create_vendor(entity_model)
+
+        customer_path = customer_picture_upload_to(customer_model, "Customer Logo.PNG")
+        vendor_path = vendor_picture_upload_to(vendor_model, "Vendor Logo.PNG")
+
+        self.assertTrue(customer_path.startswith("customer_pictures/"))
+        self.assertIn(customer_model.customer_number, customer_path)
+        self.assertTrue(customer_path.endswith("/customer-logo.png"))
+        self.assertTrue(vendor_path.startswith("vendor_pictures/"))
+        self.assertIn(vendor_model.vendor_number, vendor_path)
+        self.assertTrue(vendor_path.endswith("/vendor-logo.png"))
+
+    def test_picture_upload_paths_generate_missing_party_numbers_in_memory(self):
+        entity_model = self.create_entity()
+        customer_model = CustomerModel(
+            customer_name="API Upload Customer",
+            entity_model=entity_model,
+            description="API Upload Customer description",
+        )
+        vendor_model = VendorModel(
+            vendor_name="API Upload Vendor",
+            entity_model=entity_model,
+            description="API Upload Vendor description",
+        )
+
+        customer_path = customer_picture_upload_to(customer_model, "receipt.JPG")
+        vendor_path = vendor_picture_upload_to(vendor_model, "bill.JPG")
+
+        self.assertTrue(customer_model.customer_number)
+        self.assertTrue(vendor_model.vendor_number)
+        self.assertIn(customer_model.customer_number, customer_path)
+        self.assertIn(vendor_model.vendor_number, vendor_path)
+        self.assertFalse(CustomerModel.objects.filter(uuid=customer_model.uuid).exists())
+        self.assertFalse(VendorModel.objects.filter(uuid=vendor_model.uuid).exists())

--- a/django_ledger/tests/api/test_customer_vendor_factory_api.py
+++ b/django_ledger/tests/api/test_customer_vendor_factory_api.py
@@ -1,0 +1,121 @@
+"""
+High-level API tests for EntityModel customer and vendor factory helpers.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.vendor import VendorModel
+from django_ledger.settings import (
+    DJANGO_LEDGER_CUSTOMER_NUMBER_PREFIX,
+    DJANGO_LEDGER_VENDOR_NUMBER_PREFIX,
+)
+
+
+class CustomerVendorFactoryAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_customer_vendor_factory_admin",
+            email="api-customer-vendor-factory-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Customer Vendor Factory Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def customer_kwargs(self, *, name="API Factory Customer"):
+        return {
+            "customer_name": name,
+            "description": f"{name} description",
+        }
+
+    def vendor_kwargs(self, *, name="API Factory Vendor"):
+        return {
+            "vendor_name": name,
+            "description": f"{name} description",
+        }
+
+    def assert_number_present(self, number, prefix):
+        self.assertTrue(number)
+        self.assertTrue(number.startswith(f"{prefix}-"))
+
+    def test_create_customer_commit_false_returns_unsaved_configured_customer(self):
+        entity_model = self.create_entity()
+
+        customer_model = entity_model.create_customer(
+            self.customer_kwargs(),
+            commit=False,
+        )
+
+        self.assertIsInstance(customer_model, CustomerModel)
+        self.assertEqual(customer_model.entity_model_id, entity_model.uuid)
+        self.assert_number_present(
+            customer_model.customer_number,
+            DJANGO_LEDGER_CUSTOMER_NUMBER_PREFIX,
+        )
+        self.assertTrue(customer_model.active)
+        self.assertFalse(customer_model.hidden)
+        self.assertFalse(CustomerModel.objects.filter(uuid=customer_model.uuid).exists())
+
+    def test_create_vendor_commit_false_returns_unsaved_configured_vendor(self):
+        entity_model = self.create_entity()
+
+        vendor_model = entity_model.create_vendor(
+            self.vendor_kwargs(),
+            commit=False,
+        )
+
+        self.assertIsInstance(vendor_model, VendorModel)
+        self.assertEqual(vendor_model.entity_model_id, entity_model.uuid)
+        self.assert_number_present(
+            vendor_model.vendor_number,
+            DJANGO_LEDGER_VENDOR_NUMBER_PREFIX,
+        )
+        self.assertTrue(vendor_model.active)
+        self.assertFalse(vendor_model.hidden)
+        self.assertFalse(VendorModel.objects.filter(uuid=vendor_model.uuid).exists())
+
+    def test_create_customer_commit_true_persists_customer(self):
+        entity_model = self.create_entity()
+
+        customer_model = entity_model.create_customer(
+            self.customer_kwargs(name="API Persisted Factory Customer"),
+            commit=True,
+        )
+
+        customer_model.refresh_from_db()
+        self.assertEqual(customer_model.entity_model_id, entity_model.uuid)
+        self.assert_number_present(
+            customer_model.customer_number,
+            DJANGO_LEDGER_CUSTOMER_NUMBER_PREFIX,
+        )
+        self.assertTrue(customer_model.active)
+        self.assertFalse(customer_model.hidden)
+        self.assertTrue(CustomerModel.objects.filter(uuid=customer_model.uuid).exists())
+
+    def test_create_vendor_commit_true_persists_vendor(self):
+        entity_model = self.create_entity()
+
+        vendor_model = entity_model.create_vendor(
+            self.vendor_kwargs(name="API Persisted Factory Vendor"),
+            commit=True,
+        )
+
+        vendor_model.refresh_from_db()
+        self.assertEqual(vendor_model.entity_model_id, entity_model.uuid)
+        self.assert_number_present(
+            vendor_model.vendor_number,
+            DJANGO_LEDGER_VENDOR_NUMBER_PREFIX,
+        )
+        self.assertTrue(vendor_model.active)
+        self.assertFalse(vendor_model.hidden)
+        self.assertTrue(VendorModel.objects.filter(uuid=vendor_model.uuid).exists())

--- a/django_ledger/tests/api/test_customer_vendor_numbering_api.py
+++ b/django_ledger/tests/api/test_customer_vendor_numbering_api.py
@@ -1,0 +1,210 @@
+"""
+High-level API tests for CustomerModel and VendorModel numbering behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.vendor import VendorModel
+from django_ledger.settings import (
+    DJANGO_LEDGER_CUSTOMER_NUMBER_PREFIX,
+    DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING,
+    DJANGO_LEDGER_VENDOR_NUMBER_PREFIX,
+)
+
+
+class CustomerVendorNumberingAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_customer_vendor_numbering_admin",
+            email="api-customer-vendor-numbering-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Customer Vendor Numbering Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def make_customer(self, entity_model, *, name="API Numbering Customer"):
+        return CustomerModel(
+            customer_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+        )
+
+    def make_vendor(self, entity_model, *, name="API Numbering Vendor"):
+        return VendorModel(
+            vendor_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+        )
+
+    def create_customer(self, entity_model, *, name="API Numbering Customer"):
+        customer_model = self.make_customer(entity_model, name=name)
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_vendor(self, entity_model, *, name="API Numbering Vendor"):
+        vendor_model = self.make_vendor(entity_model, name=name)
+        vendor_model.full_clean()
+        vendor_model.save()
+        return vendor_model
+
+    def assert_number_shape(self, number, prefix):
+        self.assertTrue(number)
+        self.assertTrue(number.startswith(f"{prefix}-"))
+        suffix = number.rsplit("-", maxsplit=1)[-1]
+        self.assertEqual(len(suffix), DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING)
+        self.assertTrue(suffix.isdigit())
+
+    def assert_number_sequence(self, number, sequence):
+        self.assertTrue(
+            number.endswith(str(sequence).zfill(DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING))
+        )
+
+    def get_number_sequence(self, number):
+        return int(number.rsplit("-", maxsplit=1)[-1])
+
+    def test_customer_generate_commit_false_sets_number_in_memory_without_saving(self):
+        entity_model = self.create_entity()
+        customer_model = self.make_customer(entity_model)
+
+        self.assertTrue(customer_model.can_generate_customer_number())
+
+        generated_number = customer_model.generate_customer_number(commit=False)
+
+        self.assertEqual(customer_model.customer_number, generated_number)
+        self.assert_number_shape(generated_number, DJANGO_LEDGER_CUSTOMER_NUMBER_PREFIX)
+        self.assertFalse(CustomerModel.objects.filter(uuid=customer_model.uuid).exists())
+        self.assertFalse(customer_model.can_generate_customer_number())
+
+        next_customer = self.create_customer(entity_model, name="API Next Numbering Customer")
+        self.assertEqual(
+            self.get_number_sequence(next_customer.customer_number),
+            self.get_number_sequence(generated_number) + 1,
+        )
+
+    def test_vendor_generate_commit_false_sets_number_in_memory_without_saving(self):
+        entity_model = self.create_entity()
+        vendor_model = self.make_vendor(entity_model)
+
+        self.assertTrue(vendor_model.can_generate_vendor_number())
+
+        generated_number = vendor_model.generate_vendor_number(commit=False)
+
+        self.assertEqual(vendor_model.vendor_number, generated_number)
+        self.assert_number_shape(generated_number, DJANGO_LEDGER_VENDOR_NUMBER_PREFIX)
+        self.assertFalse(VendorModel.objects.filter(uuid=vendor_model.uuid).exists())
+        self.assertFalse(vendor_model.can_generate_vendor_number())
+
+        next_vendor = self.create_vendor(entity_model, name="API Next Numbering Vendor")
+        self.assertEqual(
+            self.get_number_sequence(next_vendor.vendor_number),
+            self.get_number_sequence(generated_number) + 1,
+        )
+
+    def test_customer_generate_commit_true_persists_number_for_saved_customer(self):
+        entity_model = self.create_entity()
+        customer_model = self.create_customer(entity_model)
+        CustomerModel.objects.filter(uuid=customer_model.uuid).update(customer_number="")
+        customer_model.customer_number = ""
+
+        self.assertTrue(customer_model.can_generate_customer_number())
+
+        generated_number = customer_model.generate_customer_number(commit=True)
+
+        customer_model.refresh_from_db()
+        self.assertEqual(customer_model.customer_number, generated_number)
+        self.assert_number_shape(generated_number, DJANGO_LEDGER_CUSTOMER_NUMBER_PREFIX)
+
+    def test_vendor_generate_commit_true_persists_number_for_saved_vendor(self):
+        entity_model = self.create_entity()
+        vendor_model = self.create_vendor(entity_model)
+        VendorModel.objects.filter(uuid=vendor_model.uuid).update(vendor_number=None)
+        vendor_model.vendor_number = None
+
+        self.assertTrue(vendor_model.can_generate_vendor_number())
+
+        generated_number = vendor_model.generate_vendor_number(commit=True)
+
+        vendor_model.refresh_from_db()
+        self.assertEqual(vendor_model.vendor_number, generated_number)
+        self.assert_number_shape(generated_number, DJANGO_LEDGER_VENDOR_NUMBER_PREFIX)
+
+    def test_clean_and_save_generate_numbers_for_customer_and_vendor(self):
+        entity_model = self.create_entity()
+        customer_model = self.make_customer(entity_model)
+        vendor_model = self.make_vendor(entity_model)
+
+        customer_model.clean()
+        vendor_model.clean()
+
+        self.assert_number_shape(
+            customer_model.customer_number,
+            DJANGO_LEDGER_CUSTOMER_NUMBER_PREFIX,
+        )
+        self.assert_number_shape(
+            vendor_model.vendor_number,
+            DJANGO_LEDGER_VENDOR_NUMBER_PREFIX,
+        )
+        self.assertFalse(CustomerModel.objects.filter(uuid=customer_model.uuid).exists())
+        self.assertFalse(VendorModel.objects.filter(uuid=vendor_model.uuid).exists())
+
+        customer_number = customer_model.customer_number
+        vendor_number = vendor_model.vendor_number
+        customer_model.save()
+        vendor_model.save()
+
+        customer_model.refresh_from_db()
+        vendor_model.refresh_from_db()
+        self.assertEqual(customer_model.customer_number, customer_number)
+        self.assertEqual(vendor_model.vendor_number, vendor_number)
+
+    def test_customer_and_vendor_sequences_are_entity_scoped(self):
+        entity_a = self.create_entity(name="API Numbering Entity A")
+        entity_b = self.create_entity(name="API Numbering Entity B")
+
+        customer_a1 = self.create_customer(entity_a, name="API Entity A Customer 1")
+        customer_a2 = self.create_customer(entity_a, name="API Entity A Customer 2")
+        customer_b1 = self.create_customer(entity_b, name="API Entity B Customer 1")
+        vendor_a1 = self.create_vendor(entity_a, name="API Entity A Vendor 1")
+        vendor_a2 = self.create_vendor(entity_a, name="API Entity A Vendor 2")
+        vendor_b1 = self.create_vendor(entity_b, name="API Entity B Vendor 1")
+
+        self.assert_number_sequence(customer_a1.customer_number, 1)
+        self.assert_number_sequence(customer_a2.customer_number, 2)
+        self.assert_number_sequence(customer_b1.customer_number, 1)
+        self.assert_number_sequence(vendor_a1.vendor_number, 1)
+        self.assert_number_sequence(vendor_a2.vendor_number, 2)
+        self.assert_number_sequence(vendor_b1.vendor_number, 1)
+
+    def test_existing_customer_number_prevents_regeneration(self):
+        customer_model = self.create_customer(self.create_entity())
+        original_number = customer_model.customer_number
+
+        self.assertFalse(customer_model.can_generate_customer_number())
+
+        generated_number = customer_model.generate_customer_number(commit=False)
+
+        self.assertEqual(generated_number, original_number)
+        self.assertEqual(customer_model.customer_number, original_number)
+
+    def test_existing_vendor_number_prevents_regeneration(self):
+        vendor_model = self.create_vendor(self.create_entity())
+        original_number = vendor_model.vendor_number
+
+        self.assertFalse(vendor_model.can_generate_vendor_number())
+
+        generated_number = vendor_model.generate_vendor_number(commit=False)
+
+        self.assertEqual(generated_number, original_number)
+        self.assertEqual(vendor_model.vendor_number, original_number)

--- a/django_ledger/tests/api/test_customer_vendor_queryset_api.py
+++ b/django_ledger/tests/api/test_customer_vendor_queryset_api.py
@@ -1,0 +1,247 @@
+"""
+High-level API tests for CustomerModel and VendorModel queryset behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.customer import CustomerModel, CustomerModelValidationError
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.vendor import VendorModel, VendorModelValidationError
+
+
+class CustomerVendorQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_customer_vendor_queryset_admin",
+            email="api-customer-vendor-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_customer_vendor_queryset_manager",
+            email="api-customer-vendor-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_customer_vendor_queryset_other_admin",
+            email="api-customer-vendor-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_customer_vendor_queryset_unrelated",
+            email="api-customer-vendor-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_customer_vendor_queryset_superuser",
+            email="api-customer-vendor-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Customer Vendor Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+        return entity_model
+
+    def create_customer(
+        self,
+        entity_model,
+        *,
+        name="API Queryset Customer",
+        active=True,
+        hidden=False,
+    ):
+        customer_model = CustomerModel(
+            customer_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+            active=active,
+            hidden=hidden,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_vendor(
+        self,
+        entity_model,
+        *,
+        name="API Queryset Vendor",
+        active=True,
+        hidden=False,
+    ):
+        vendor_model = VendorModel(
+            vendor_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+            active=active,
+            hidden=hidden,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        return vendor_model
+
+    def assert_customer_uuids(self, queryset, expected_customers):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {customer_model.uuid for customer_model in expected_customers},
+        )
+
+    def assert_vendor_uuids(self, queryset, expected_vendors):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {vendor_model.uuid for vendor_model in expected_vendors},
+        )
+
+    def test_customer_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity(name="API Customer Queryset Entity A")
+        other_entity_model = self.create_entity(
+            name="API Customer Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        customer_model = self.create_customer(entity_model, name="API Entity A Customer")
+        self.create_customer(other_entity_model, name="API Entity B Customer")
+
+        self.assert_customer_uuids(CustomerModel.objects.for_entity(entity_model), [customer_model])
+        self.assert_customer_uuids(CustomerModel.objects.for_entity(entity_model.slug), [customer_model])
+        self.assert_customer_uuids(CustomerModel.objects.for_entity(entity_model.uuid), [customer_model])
+
+    def test_customer_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_customer(self.create_entity())
+
+        with self.assertRaises(CustomerModelValidationError):
+            CustomerModel.objects.for_entity(object())
+
+        self.assertFalse(CustomerModel.objects.for_entity("missing-customer-entity-slug").exists())
+
+    def test_vendor_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity(name="API Vendor Queryset Entity A")
+        other_entity_model = self.create_entity(
+            name="API Vendor Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        vendor_model = self.create_vendor(entity_model, name="API Entity A Vendor")
+        self.create_vendor(other_entity_model, name="API Entity B Vendor")
+
+        self.assert_vendor_uuids(VendorModel.objects.for_entity(entity_model), [vendor_model])
+        self.assert_vendor_uuids(VendorModel.objects.for_entity(entity_model.slug), [vendor_model])
+        self.assert_vendor_uuids(VendorModel.objects.for_entity(entity_model.uuid), [vendor_model])
+
+    def test_vendor_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_vendor(self.create_entity())
+
+        with self.assertRaises(VendorModelValidationError):
+            VendorModel.objects.for_entity(object())
+
+        self.assertFalse(VendorModel.objects.for_entity("missing-vendor-entity-slug").exists())
+
+    def test_customer_for_user_scopes_to_authorized_users_and_superuser(self):
+        entity_model = self.create_entity(
+            name="API Customer Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_entity_model = self.create_entity(
+            name="API Customer Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        customer_model = self.create_customer(entity_model, name="API Access Customer")
+        other_customer_model = self.create_customer(other_entity_model, name="API Other Access Customer")
+
+        self.assert_customer_uuids(CustomerModel.objects.all().for_user(self.admin_user), [customer_model])
+        self.assert_customer_uuids(CustomerModel.objects.all().for_user(self.manager_user), [customer_model])
+        self.assertFalse(CustomerModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_customer_uuids(
+            CustomerModel.objects.all().for_user(self.superuser),
+            [customer_model, other_customer_model],
+        )
+
+    def test_vendor_for_user_scopes_to_authorized_users_and_superuser(self):
+        entity_model = self.create_entity(
+            name="API Vendor Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_entity_model = self.create_entity(
+            name="API Vendor Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        vendor_model = self.create_vendor(entity_model, name="API Access Vendor")
+        other_vendor_model = self.create_vendor(other_entity_model, name="API Other Access Vendor")
+
+        self.assert_vendor_uuids(VendorModel.objects.all().for_user(self.admin_user), [vendor_model])
+        self.assert_vendor_uuids(VendorModel.objects.all().for_user(self.manager_user), [vendor_model])
+        self.assertFalse(VendorModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_vendor_uuids(
+            VendorModel.objects.all().for_user(self.superuser),
+            [vendor_model, other_vendor_model],
+        )
+
+    def test_customer_state_filters_return_active_inactive_hidden_and_visible_parties(self):
+        entity_model = self.create_entity()
+        active_customer = self.create_customer(entity_model, name="API Active Customer")
+        inactive_customer = self.create_customer(
+            entity_model,
+            name="API Inactive Customer",
+            active=False,
+        )
+        hidden_customer = self.create_customer(
+            entity_model,
+            name="API Hidden Customer",
+            hidden=True,
+        )
+        customer_qs = CustomerModel.objects.for_entity(entity_model)
+
+        self.assert_customer_uuids(customer_qs.active(), [active_customer, hidden_customer])
+        self.assert_customer_uuids(customer_qs.inactive(), [inactive_customer])
+        self.assert_customer_uuids(customer_qs.hidden(), [hidden_customer])
+        self.assert_customer_uuids(customer_qs.visible(), [active_customer])
+
+    def test_vendor_state_filters_return_active_inactive_hidden_and_visible_parties(self):
+        entity_model = self.create_entity()
+        active_vendor = self.create_vendor(entity_model, name="API Active Vendor")
+        inactive_vendor = self.create_vendor(
+            entity_model,
+            name="API Inactive Vendor",
+            active=False,
+        )
+        hidden_vendor = self.create_vendor(
+            entity_model,
+            name="API Hidden Vendor",
+            hidden=True,
+        )
+        vendor_qs = VendorModel.objects.for_entity(entity_model)
+
+        self.assert_vendor_uuids(vendor_qs.active(), [active_vendor, hidden_vendor])
+        self.assert_vendor_uuids(vendor_qs.inactive(), [inactive_vendor])
+        self.assert_vendor_uuids(vendor_qs.hidden(), [hidden_vendor])
+        self.assert_vendor_uuids(vendor_qs.visible(), [active_vendor])
+
+    def test_entity_slug_property_uses_queryset_annotation_or_direct_fallback(self):
+        entity_model = self.create_entity()
+        customer_model = self.create_customer(entity_model)
+        vendor_model = self.create_vendor(entity_model)
+
+        annotated_customer = CustomerModel.objects.get(uuid=customer_model.uuid)
+        annotated_vendor = VendorModel.objects.get(uuid=vendor_model.uuid)
+        direct_customer = CustomerModel(
+            customer_name="API Direct Customer",
+            entity_model=entity_model,
+            description="API Direct Customer description",
+        )
+        direct_vendor = VendorModel(
+            vendor_name="API Direct Vendor",
+            entity_model=entity_model,
+            description="API Direct Vendor description",
+        )
+
+        self.assertEqual(annotated_customer.entity_slug, entity_model.slug)
+        self.assertEqual(annotated_vendor.entity_slug, entity_model.slug)
+        self.assertEqual(direct_customer.entity_slug, entity_model.slug)
+        self.assertEqual(direct_vendor.entity_slug, entity_model.slug)

--- a/django_ledger/tests/api/test_customer_vendor_validation_api.py
+++ b/django_ledger/tests/api/test_customer_vendor_validation_api.py
@@ -1,0 +1,155 @@
+"""
+High-level API tests for CustomerModel and VendorModel validation behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from django_ledger.models.customer import CustomerModel, CustomerModelValidationError
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.vendor import VendorModel, VendorModelValidationError
+
+
+class CustomerVendorValidationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_customer_vendor_validation_admin",
+            email="api-customer-vendor-validation-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Customer Vendor Validation Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def make_customer(self, entity_model, *, name="API Validation Customer", **kwargs):
+        return CustomerModel(
+            customer_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+            **kwargs,
+        )
+
+    def make_vendor(self, entity_model, *, name="API Validation Vendor", **kwargs):
+        return VendorModel(
+            vendor_name=name,
+            entity_model=entity_model,
+            description=f"{name} description",
+            **kwargs,
+        )
+
+    def create_customer(self, entity_model, *, name="API Validation Customer", **kwargs):
+        customer_model = self.make_customer(entity_model, name=name, **kwargs)
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_vendor(self, entity_model, *, name="API Validation Vendor", **kwargs):
+        vendor_model = self.make_vendor(entity_model, name=name, **kwargs)
+        vendor_model.full_clean()
+        vendor_model.save()
+        return vendor_model
+
+    def test_customer_validate_for_entity_accepts_same_entity_and_rejects_other_entity(self):
+        entity_model = self.create_entity(name="API Customer Validation Entity A")
+        other_entity_model = self.create_entity(name="API Customer Validation Entity B")
+        customer_model = self.create_customer(entity_model)
+
+        self.assertIsNone(customer_model.validate_for_entity(entity_model))
+
+        with self.assertRaises(CustomerModelValidationError):
+            customer_model.validate_for_entity(other_entity_model)
+
+    def test_customer_validate_for_entity_rejects_invalid_input(self):
+        customer_model = self.create_customer(self.create_entity())
+
+        with self.assertRaises(CustomerModelValidationError):
+            customer_model.validate_for_entity(object())
+
+    def test_vendor_validate_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity()
+        vendor_model = self.create_vendor(entity_model)
+
+        self.assertIsNone(vendor_model.validate_for_entity(entity_model))
+        self.assertIsNone(vendor_model.validate_for_entity(entity_model.slug))
+        self.assertIsNone(vendor_model.validate_for_entity(entity_model.uuid))
+
+    def test_vendor_validate_for_entity_rejects_other_entity_and_invalid_input(self):
+        entity_model = self.create_entity(name="API Vendor Validation Entity A")
+        other_entity_model = self.create_entity(name="API Vendor Validation Entity B")
+        vendor_model = self.create_vendor(entity_model)
+
+        with self.assertRaises(VendorModelValidationError):
+            vendor_model.validate_for_entity(other_entity_model)
+        with self.assertRaises(VendorModelValidationError):
+            vendor_model.validate_for_entity(other_entity_model.slug)
+        with self.assertRaises(VendorModelValidationError):
+            vendor_model.validate_for_entity(other_entity_model.uuid)
+        with self.assertRaises(VendorModelValidationError):
+            vendor_model.validate_for_entity(object())
+
+    def test_customer_and_vendor_reject_address_line_two_without_address_line_one(self):
+        entity_model = self.create_entity()
+        customer_model = self.make_customer(entity_model, address_2="Suite 200")
+        vendor_model = self.make_vendor(entity_model, address_2="Suite 300")
+
+        with self.assertRaises(ValidationError):
+            customer_model.full_clean()
+        with self.assertRaises(ValidationError):
+            vendor_model.full_clean()
+
+    def test_customer_and_vendor_accept_complete_address_lines(self):
+        entity_model = self.create_entity()
+        customer_model = self.make_customer(
+            entity_model,
+            address_1="123 Customer Street",
+            address_2="Suite 200",
+        )
+        vendor_model = self.make_vendor(
+            entity_model,
+            address_1="456 Vendor Avenue",
+            address_2="Suite 300",
+        )
+
+        customer_model.full_clean()
+        vendor_model.full_clean()
+
+        self.assertTrue(customer_model.customer_number)
+        self.assertTrue(vendor_model.vendor_number)
+
+    def test_customer_sales_tax_rate_validation_accepts_valid_and_rejects_out_of_range(self):
+        entity_model = self.create_entity()
+
+        self.make_customer(entity_model, sales_tax_rate=0.25).full_clean()
+
+        with self.assertRaises(ValidationError):
+            self.make_customer(entity_model, sales_tax_rate=-0.01).full_clean()
+        with self.assertRaises(ValidationError):
+            self.make_customer(entity_model, sales_tax_rate=1.01).full_clean()
+
+    def test_vendor_tax_and_financial_account_info_smoke_behavior(self):
+        entity_model = self.create_entity()
+        vendor_model = self.make_vendor(
+            entity_model,
+            tax_id_number="TAX-12345",
+            account_number="000123456789",
+            routing_number="000111222",
+            account_type=VendorModel.ACCOUNT_CHECKING,
+        )
+
+        vendor_model.full_clean()
+
+        self.assertEqual(vendor_model.tax_id_number, "TAX-12345")
+        self.assertEqual(vendor_model.get_account_last_digits(), "*6789")
+        self.assertEqual(vendor_model.get_routing_last_digits(), "*1222")
+        self.assertEqual(vendor_model.get_account_type_display(), "Checking")
+
+        with self.assertRaises(ValidationError):
+            self.make_vendor(entity_model, account_number="12-34").full_clean()

--- a/django_ledger/tests/api/test_data_import_api.py
+++ b/django_ledger/tests/api/test_data_import_api.py
@@ -1,0 +1,574 @@
+"""
+High-level API behavior tests for ImportJobModel and StagedTransactionModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import BankAccountModel, JournalEntryModel, TransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.data_import import (
+    ImportJobModel,
+    ImportJobModelValidationError,
+    StagedTransactionModel,
+    StagedTransactionModelValidationError,
+)
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.receipt import ReceiptModel
+from django_ledger.models.unit import EntityUnitModel
+from django_ledger.models.vendor import VendorModel
+
+
+class DataImportHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for data import and staged transaction contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic import/staging invariants that should
+    remain true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_data_import_contract_user",
+            email="api-data-import-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Data Import Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+            hidden=False,
+        )
+        bank_account.configure(
+            entity_slug=entity_model,
+            user_model=self.user,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        unit_model = EntityUnitModel.add_root(
+            name=f"{name} Unit",
+            slug="api-data-import-unit",
+            entity=entity_model,
+            document_prefix="DIU",
+            active=True,
+            hidden=False,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "bank_account": bank_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "unit_model": unit_model,
+        }
+
+    def create_import_job(self, setup, *, description="API Data Import Job"):
+        import_job = ImportJobModel.objects.create(
+            description=description,
+            bank_account_model=setup["bank_account"],
+        )
+
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+
+        return import_job
+
+    def create_staged_transaction(
+        self,
+        import_job,
+        *,
+        fit_id="FIT-001",
+        amount="125.00",
+        date_posted=date(2026, 1, 15),
+        name="API Staged Transaction",
+        memo="API staged transaction memo",
+        account_model=None,
+        unit_model=None,
+        receipt_type=None,
+        customer_model=None,
+        vendor_model=None,
+        bundle_split=True,
+    ):
+        staged_tx = StagedTransactionModel.objects.create(
+            import_job=import_job,
+            fit_id=fit_id,
+            date_posted=date_posted,
+            amount=Decimal(amount),
+            name=name,
+            memo=memo,
+            account_model=account_model,
+            unit_model=unit_model,
+            receipt_type=receipt_type,
+            customer_model=customer_model,
+            vendor_model=vendor_model,
+            bundle_split=bundle_split,
+        )
+
+        staged_tx.refresh_from_db()
+        return staged_tx
+
+    def get_annotated_staged_transaction(self, staged_tx):
+        return StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+    def test_import_job_configure_creates_ledger_for_bank_account_entity(self):
+        setup = self.create_entity_setup()
+
+        import_job = self.create_import_job(setup)
+
+        self.assertIsInstance(import_job, ImportJobModel)
+        self.assertIsNotNone(import_job.uuid)
+        self.assertEqual(import_job.bank_account_model_id, setup["bank_account"].uuid)
+        self.assertTrue(import_job.is_configured())
+        self.assertIsNotNone(import_job.ledger_model_id)
+        self.assertEqual(import_job.ledger_model.entity_id, setup["entity_model"].uuid)
+        self.assertEqual(import_job.entity_uuid, setup["entity_model"].uuid)
+        self.assertEqual(import_job.entity_slug, setup["entity_model"].slug)
+
+    def test_import_job_for_entity_limits_queryset_to_entity_scope(self):
+        setup = self.create_entity_setup(name="API Import Entity A")
+        other_setup = self.create_entity_setup(name="API Import Entity B")
+
+        import_job = self.create_import_job(setup)
+        other_import_job = self.create_import_job(other_setup)
+
+        scoped_qs = ImportJobModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=import_job.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_import_job.uuid).exists())
+
+    def test_import_job_annotations_reflect_pending_root_transactions(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-PENDING-001",
+            amount="125.00",
+        )
+
+        annotated_job = ImportJobModel.objects.get(uuid=import_job.uuid)
+
+        self.assertEqual(annotated_job.txs_count, 1)
+        self.assertEqual(annotated_job.txs_imported_count, 0)
+        self.assertEqual(annotated_job.txs_pending, 1)
+        self.assertFalse(annotated_job.is_complete)
+
+    def test_staged_transaction_for_entity_and_import_job_querysets(self):
+        setup = self.create_entity_setup()
+        other_setup = self.create_entity_setup(name="API Other Import Entity")
+
+        import_job = self.create_import_job(setup)
+        other_import_job = self.create_import_job(other_setup)
+
+        staged_tx = self.create_staged_transaction(import_job, fit_id="FIT-A")
+        other_staged_tx = self.create_staged_transaction(other_import_job, fit_id="FIT-B")
+
+        entity_qs = StagedTransactionModel.objects.for_entity(setup["entity_model"])
+        import_job_qs = StagedTransactionModel.objects.for_import_job(import_job)
+
+        self.assertTrue(entity_qs.filter(uuid=staged_tx.uuid).exists())
+        self.assertFalse(entity_qs.filter(uuid=other_staged_tx.uuid).exists())
+
+        self.assertTrue(import_job_qs.filter(uuid=staged_tx.uuid).exists())
+        self.assertFalse(import_job_qs.filter(uuid=other_staged_tx.uuid).exists())
+
+    def test_single_mapped_non_receipt_staged_transaction_is_ready_to_import(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-READY-001",
+            amount="125.00",
+            account_model=setup["income_account"],
+            unit_model=setup["unit_model"],
+            receipt_type=None,
+            customer_model=None,
+            vendor_model=None,
+        )
+
+        staged_tx = StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+        self.assertTrue(staged_tx.is_single())
+        self.assertTrue(staged_tx.is_parent())
+        self.assertFalse(staged_tx.is_children())
+        self.assertFalse(staged_tx.has_receipt())
+        self.assertTrue(staged_tx.is_mapped())
+        self.assertTrue(staged_tx.ready_to_import)
+        self.assertTrue(staged_tx.can_import())
+
+    def test_sales_staged_transaction_clears_vendor_on_clean(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = StagedTransactionModel(
+            import_job=import_job,
+            fit_id="FIT-SALES-001",
+            date_posted=date(2026, 1, 15),
+            amount=Decimal("125.00"),
+            account_model=setup["income_account"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            customer_model=setup["customer_model"],
+            vendor_model=setup["vendor_model"],
+        )
+
+        staged_tx.clean()
+
+        self.assertTrue(staged_tx.is_sales())
+        self.assertEqual(staged_tx.customer_model_id, setup["customer_model"].uuid)
+        self.assertIsNone(staged_tx.vendor_model)
+
+    def test_expense_staged_transaction_clears_customer_on_clean(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = StagedTransactionModel(
+            import_job=import_job,
+            fit_id="FIT-EXPENSE-001",
+            date_posted=date(2026, 1, 15),
+            amount=Decimal("-75.00"),
+            account_model=setup["expense_account"],
+            receipt_type=ReceiptModel.EXPENSE_RECEIPT,
+            vendor_model=setup["vendor_model"],
+            customer_model=setup["customer_model"],
+        )
+
+        staged_tx.clean()
+
+        self.assertTrue(staged_tx.is_expense())
+        self.assertEqual(staged_tx.vendor_model_id, setup["vendor_model"].uuid)
+        self.assertIsNone(staged_tx.customer_model)
+
+    def test_transfer_staged_transaction_clears_customer_and_vendor_on_clean(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = StagedTransactionModel(
+            import_job=import_job,
+            fit_id="FIT-TRANSFER-001",
+            date_posted=date(2026, 1, 15),
+            amount=Decimal("50.00"),
+            account_model=setup["cash_account"],
+            receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+            customer_model=setup["customer_model"],
+            vendor_model=setup["vendor_model"],
+        )
+
+        staged_tx.clean()
+
+        self.assertTrue(staged_tx.is_transfer())
+        self.assertIsNone(staged_tx.customer_model)
+        self.assertIsNone(staged_tx.vendor_model)
+
+    def test_staged_transaction_presave_rejects_customer_and_vendor_together(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        with self.assertRaises(StagedTransactionModelValidationError):
+            self.create_staged_transaction(
+                import_job,
+                fit_id="FIT-BOTH-PARTIES-001",
+                amount="125.00",
+                account_model=setup["income_account"],
+                receipt_type=ReceiptModel.SALES_RECEIPT,
+                customer_model=setup["customer_model"],
+                vendor_model=setup["vendor_model"],
+            )
+
+    def test_staged_transaction_add_split_creates_children(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-SPLIT-001",
+            amount="100.00",
+            account_model=setup["income_account"],
+        )
+
+        staged_tx = self.get_annotated_staged_transaction(staged_tx)
+        children = staged_tx.add_split(n=1, commit=True)
+
+        staged_tx = StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+        self.assertEqual(len(children), 2)
+        self.assertTrue(staged_tx.has_children())
+        self.assertFalse(staged_tx.is_single())
+
+        child_qs = StagedTransactionModel.objects.filter(parent=staged_tx)
+
+        self.assertEqual(child_qs.count(), 2)
+
+        for child in child_qs:
+            self.assertTrue(child.is_children())
+            self.assertFalse(child.is_parent())
+            self.assertEqual(child.import_job_id, import_job.uuid)
+            self.assertEqual(child.fit_id, staged_tx.fit_id)
+            self.assertEqual(child.amount_split, Decimal("0.00"))
+
+    def test_parent_staged_transaction_cannot_be_deleted(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-DELETE-PARENT-001",
+            amount="100.00",
+        )
+
+        with self.assertRaises(StagedTransactionModelValidationError):
+            staged_tx.delete()
+
+    def test_child_staged_transaction_can_be_deleted(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-DELETE-CHILD-001",
+            amount="100.00",
+        )
+        staged_tx = self.get_annotated_staged_transaction(staged_tx)
+        children = staged_tx.add_split(n=1, commit=True)
+
+        child = children[0]
+        child_uuid = child.uuid
+
+        child.delete()
+
+        self.assertFalse(StagedTransactionModel.objects.filter(uuid=child_uuid).exists())
+
+    def test_staged_transaction_migrate_transactions_creates_unposted_journal_entry_and_links_transaction(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-MIGRATE-JE-001",
+            amount="125.00",
+            account_model=setup["income_account"],
+            unit_model=setup["unit_model"],
+            receipt_type=None,
+            customer_model=None,
+            vendor_model=None,
+        )
+
+        staged_tx = self.get_annotated_staged_transaction(staged_tx)
+
+        self.assertTrue(staged_tx.ready_to_import)
+        self.assertTrue(staged_tx.can_import())
+
+        staged_tx.migrate_transactions()
+
+        staged_tx.refresh_from_db()
+
+        self.assertIsNotNone(staged_tx.transaction_model_id)
+
+        journal_entries = JournalEntryModel.objects.filter(
+            ledger=import_job.ledger_model,
+        )
+
+        self.assertEqual(journal_entries.count(), 1)
+
+        journal_entry = journal_entries.get()
+
+        self.assertFalse(journal_entry.posted)
+        self.assertEqual(journal_entry.entity_unit_id, setup["unit_model"].uuid)
+
+        txs = TransactionModel.objects.filter(journal_entry=journal_entry)
+
+        self.assertEqual(txs.count(), 2)
+        self.assertEqual(
+            sum(tx.amount for tx in txs if tx.tx_type == TransactionModel.DEBIT),
+            Decimal("125.00"),
+        )
+        self.assertEqual(
+            sum(tx.amount for tx in txs if tx.tx_type == TransactionModel.CREDIT),
+            Decimal("125.00"),
+        )
+
+    def test_staged_transaction_migrate_transactions_rejects_receipt_transaction(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-MIGRATE-JE-RECEIPT-001",
+            amount="125.00",
+            account_model=setup["income_account"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            customer_model=setup["customer_model"],
+        )
+
+        staged_tx = self.get_annotated_staged_transaction(staged_tx)
+
+        with self.assertRaises(StagedTransactionModelValidationError):
+            staged_tx.migrate_transactions()
+
+    def test_staged_transaction_migrate_receipt_creates_receipt_and_posted_journal_entry(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-MIGRATE-RECEIPT-001",
+            amount="125.00",
+            account_model=setup["income_account"],
+            unit_model=setup["unit_model"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            customer_model=setup["customer_model"],
+        )
+
+        staged_tx = self.get_annotated_staged_transaction(staged_tx)
+
+        self.assertTrue(staged_tx.ready_to_import)
+        self.assertTrue(staged_tx.can_migrate_receipt())
+
+        staged_tx.migrate_receipt(
+            receipt_date=date(2026, 1, 15),
+            split_amount=False,
+        )
+
+        staged_tx.refresh_from_db()
+
+        receipt_model = ReceiptModel.objects.get(
+            staged_transaction_model=staged_tx,
+        )
+
+        self.assertEqual(receipt_model.receipt_type, ReceiptModel.SALES_RECEIPT)
+        self.assertEqual(receipt_model.amount, Decimal("125.00"))
+        self.assertEqual(receipt_model.customer_model_id, setup["customer_model"].uuid)
+        self.assertIsNone(receipt_model.vendor_model_id)
+        self.assertEqual(receipt_model.charge_account_id, setup["cash_account"].uuid)
+        self.assertEqual(receipt_model.receipt_account_id, setup["income_account"].uuid)
+        self.assertEqual(receipt_model.unit_model_id, setup["unit_model"].uuid)
+        self.assertTrue(receipt_model.receipt_number)
+
+        self.assertTrue(receipt_model.ledger_model.is_posted())
+
+        journal_entries = JournalEntryModel.objects.filter(
+            ledger=receipt_model.ledger_model,
+        )
+
+        self.assertEqual(journal_entries.count(), 1)
+
+        journal_entry = journal_entries.get()
+
+        self.assertTrue(journal_entry.posted)
+        self.assertEqual(journal_entry.entity_unit_id, setup["unit_model"].uuid)
+
+        txs = TransactionModel.objects.filter(journal_entry=journal_entry)
+
+        self.assertEqual(txs.count(), 2)
+        self.assertEqual(
+            sum(tx.amount for tx in txs if tx.tx_type == TransactionModel.DEBIT),
+            Decimal("125.00"),
+        )
+        self.assertEqual(
+            sum(tx.amount for tx in txs if tx.tx_type == TransactionModel.CREDIT),
+            Decimal("125.00"),
+        )
+
+        self.assertIsNotNone(staged_tx.transaction_model_id)
+
+    def test_staged_transaction_migrate_receipt_rejects_non_receipt_transaction(self):
+        setup = self.create_entity_setup()
+        import_job = self.create_import_job(setup)
+
+        staged_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-MIGRATE-RECEIPT-NON-RECEIPT-001",
+            amount="125.00",
+            account_model=setup["income_account"],
+            receipt_type=None,
+            customer_model=None,
+            vendor_model=None,
+        )
+
+        staged_tx = self.get_annotated_staged_transaction(staged_tx)
+
+        with self.assertRaises(StagedTransactionModelValidationError):
+            staged_tx.migrate_receipt(
+                receipt_date=date(2026, 1, 15),
+            )
+

--- a/django_ledger/tests/api/test_data_import_url_display_api.py
+++ b/django_ledger/tests/api/test_data_import_url_display_api.py
@@ -1,0 +1,144 @@
+"""
+High-level API smoke tests for data import URL and display helpers.
+
+ImportJobModel URL helpers are covered in the dedicated import job helper
+suite; this file focuses on the remaining StagedTransactionModel helpers.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, CREDIT, DEBIT
+from django_ledger.models import BankAccountModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.data_import import ImportJobModel, StagedTransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.receipt import ReceiptModel
+
+
+class DataImportURLDisplayAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_data_import_url_admin",
+            email="api-data-import-url-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Data Import URL Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income",
+            role="in_operational",
+            balance_type=CREDIT,
+            active=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+        )
+        bank_account.configure(entity_slug=entity_model, user_model=self.admin_user, commit=True)
+        customer_model = CustomerModel.objects.create(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            active=True,
+        )
+        import_job = ImportJobModel.objects.create(
+            description=f"{name} Import Job",
+            bank_account_model=bank_account,
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "customer_model": customer_model,
+            "import_job": import_job,
+        }
+
+    def create_staged_transaction(self, setup, *, fit_id="FIT-URL", amount="125.00"):
+        staged_tx = StagedTransactionModel.objects.create(
+            import_job=setup["import_job"],
+            fit_id=fit_id,
+            date_posted=date(2026, 1, 15),
+            amount=Decimal(amount),
+            name=f"API Staged Transaction {fit_id}",
+            memo=f"API staged transaction memo {fit_id}",
+            account_model=setup["income_account"],
+        )
+        return StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+    def test_staged_transaction_get_update_url_contains_entity_job_and_staged_transaction_ids(self):
+        setup = self.create_entity_setup()
+        staged_tx = self.create_staged_transaction(setup)
+
+        url = staged_tx.get_update_url()
+
+        self.assertIsInstance(url, str)
+        self.assertTrue(url)
+        self.assertIn(setup["entity_model"].slug, url)
+        self.assertIn(str(setup["import_job"].uuid), url)
+        self.assertIn(str(staged_tx.uuid), url)
+
+    def test_staged_transaction_str_includes_amount_context(self):
+        setup = self.create_entity_setup(name="API Data Import String Entity")
+        staged_tx = self.create_staged_transaction(setup, amount="-75.00")
+
+        display_value = str(staged_tx)
+
+        self.assertIsInstance(display_value, str)
+        self.assertTrue(display_value)
+        self.assertIn("StagedTransactionModel", display_value)
+        self.assertIn("-75.00", display_value)
+
+    def test_entity_slug_annotation_and_get_entity_slug_helper(self):
+        setup = self.create_entity_setup(name="API Data Import Entity Slug Entity")
+        staged_tx = self.create_staged_transaction(setup)
+
+        self.assertEqual(staged_tx.entity_slug, setup["entity_model"].slug)
+        self.assertEqual(staged_tx.get_entity_slug(), setup["entity_model"].slug)
+
+    def test_receipt_uuid_annotation_and_fallback_behavior(self):
+        setup = self.create_entity_setup(name="API Data Import Receipt UUID Entity")
+        staged_tx = self.create_staged_transaction(setup)
+
+        self.assertIsNone(staged_tx.receipt_uuid)
+
+        staged_tx.receipt_type = ReceiptModel.SALES_RECEIPT
+        staged_tx.customer_model = setup["customer_model"]
+        staged_tx.save(update_fields=["receipt_type", "customer_model", "updated"])
+        staged_tx = StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+        receipt_model = staged_tx.generate_receipt_model(
+            receipt_date=date(2026, 1, 15),
+            commit=True,
+        )
+        staged_tx = StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+        self.assertEqual(staged_tx.receipt_uuid, receipt_model.uuid)

--- a/django_ledger/tests/api/test_deprecated_entity_slug_api.py
+++ b/django_ledger/tests/api/test_deprecated_entity_slug_api.py
@@ -1,0 +1,76 @@
+"""
+Smoke-level compatibility tests for the deprecated entity_slug shim.
+"""
+
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import AccountModel
+from django_ledger.models.accounts import AccountModelValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class DeprecatedEntitySlugAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_deprecated_entity_slug_admin",
+            email="api-deprecated-entity-slug-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Deprecated Entity Slug Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        account_model = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        return entity_model, account_model
+
+    def test_entity_slug_kwarg_warns_and_maps_when_deprecated_behavior_enabled(self):
+        entity_model, account_model = self.create_entity_setup(
+            name="API Deprecated Entity Slug Enabled"
+        )
+
+        with patch("django_ledger.models.deprecations.DJANGO_LEDGER_USE_DEPRECATED_BEHAVIOR", True):
+            with self.assertWarns(DeprecationWarning):
+                account_qs = AccountModel.objects.for_entity(entity_slug=entity_model.slug)
+
+        self.assertTrue(account_qs.filter(uuid=account_model.uuid).exists())
+
+    def test_entity_slug_kwarg_warns_and_uses_current_disabled_behavior(self):
+        entity_model, _account_model = self.create_entity_setup(
+            name="API Deprecated Entity Slug Disabled"
+        )
+
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(AccountModelValidationError):
+                AccountModel.objects.for_entity(entity_slug=entity_model.slug)
+
+    def test_entity_model_and_entity_slug_conflict_is_rejected(self):
+        entity_model, _account_model = self.create_entity_setup(
+            name="API Deprecated Entity Slug Conflict"
+        )
+
+        with self.assertWarns(DeprecationWarning):
+            with self.assertRaises(ValueError):
+                AccountModel.objects.for_entity(
+                    entity_model=entity_model,
+                    entity_slug=entity_model.slug,
+                )

--- a/django_ledger/tests/api/test_document_numbering_api.py
+++ b/django_ledger/tests/api/test_document_numbering_api.py
@@ -1,0 +1,385 @@
+"""
+High-level API behavior tests for document and catalog numbering contracts.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import (
+    BillModel,
+    EstimateModel,
+    InvoiceModel,
+    PurchaseOrderModel,
+)
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class DocumentNumberingHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for entity-scoped number generation.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic numbering contracts that should remain
+    true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_document_numbering_contract_user",
+            email="api-document-numbering-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_numbering_setup(self, *, name="API Numbering Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        accounts_payable = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        unearned_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Unearned Revenue Account",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr="num",
+            active=True,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "prepaid_account": prepaid_account,
+            "inventory_account": inventory_account,
+            "accounts_payable": accounts_payable,
+            "unearned_account": unearned_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "service_item": service_item,
+            "expense_item": expense_item,
+            "inventory_item": inventory_item,
+        }
+
+    def create_customer(self, setup, *, suffix):
+        customer_model = CustomerModel(
+            customer_name=f"API Numbering Customer {suffix}",
+            entity_model=setup["entity_model"],
+            description=f"API Numbering Customer {suffix} description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_vendor(self, setup, *, suffix):
+        vendor_model = VendorModel(
+            vendor_name=f"API Numbering Vendor {suffix}",
+            entity_model=setup["entity_model"],
+            description=f"API Numbering Vendor {suffix} description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        return vendor_model
+
+    def create_service_item(self, setup, *, suffix):
+        return setup["entity_model"].create_item_service(
+            name=f"API Numbering Service Item {suffix}",
+            uom_model=setup["uom_model"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+    def create_bill(self, setup):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["accounts_payable"],
+        )
+
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return bill_model
+
+    def create_invoice(self, setup):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["unearned_account"],
+        )
+
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return invoice_model
+
+    def create_estimate(self, setup):
+        estimate_model = EstimateModel(
+            terms=EstimateModel.CONTRACT_TERMS_FIXED,
+        )
+
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            estimate_title="API Numbering Estimate",
+            commit=True,
+        )
+
+        return estimate_model
+
+    def create_purchase_order(self, setup):
+        po_model = PurchaseOrderModel()
+
+        po_model.configure(
+            entity_slug=setup["entity_model"],
+            po_title="API Numbering Purchase Order",
+            user_model=self.user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return po_model
+
+    def test_customer_vendor_and_item_numbers_are_generated(self):
+        setup = self.create_entity_with_numbering_setup()
+
+        self.assertTrue(setup["customer_model"].customer_number)
+        self.assertTrue(setup["vendor_model"].vendor_number)
+        self.assertTrue(setup["service_item"].item_number)
+        self.assertTrue(setup["expense_item"].item_number)
+        self.assertTrue(setup["inventory_item"].item_number)
+
+    def test_customer_vendor_and_item_numbers_are_unique_within_entity(self):
+        setup = self.create_entity_with_numbering_setup()
+
+        customer_a = self.create_customer(setup, suffix="A")
+        customer_b = self.create_customer(setup, suffix="B")
+
+        vendor_a = self.create_vendor(setup, suffix="A")
+        vendor_b = self.create_vendor(setup, suffix="B")
+
+        item_a = self.create_service_item(setup, suffix="A")
+        item_b = self.create_service_item(setup, suffix="B")
+
+        self.assertNotEqual(customer_a.customer_number, customer_b.customer_number)
+        self.assertNotEqual(vendor_a.vendor_number, vendor_b.vendor_number)
+        self.assertNotEqual(item_a.item_number, item_b.item_number)
+
+    def test_bill_invoice_estimate_and_po_numbers_are_generated_on_configure(self):
+        setup = self.create_entity_with_numbering_setup()
+
+        bill_model = self.create_bill(setup)
+        invoice_model = self.create_invoice(setup)
+        estimate_model = self.create_estimate(setup)
+        po_model = self.create_purchase_order(setup)
+
+        self.assertTrue(bill_model.bill_number)
+        self.assertTrue(invoice_model.invoice_number)
+        self.assertTrue(estimate_model.estimate_number)
+        self.assertTrue(po_model.po_number)
+
+    def test_document_numbers_are_unique_within_entity(self):
+        setup = self.create_entity_with_numbering_setup()
+
+        bill_a = self.create_bill(setup)
+        bill_b = self.create_bill(setup)
+
+        invoice_a = self.create_invoice(setup)
+        invoice_b = self.create_invoice(setup)
+
+        estimate_a = self.create_estimate(setup)
+        estimate_b = self.create_estimate(setup)
+
+        po_a = self.create_purchase_order(setup)
+        po_b = self.create_purchase_order(setup)
+
+        self.assertNotEqual(bill_a.bill_number, bill_b.bill_number)
+        self.assertNotEqual(invoice_a.invoice_number, invoice_b.invoice_number)
+        self.assertNotEqual(estimate_a.estimate_number, estimate_b.estimate_number)
+        self.assertNotEqual(po_a.po_number, po_b.po_number)
+
+    def test_number_generation_is_scoped_by_entity(self):
+        setup_a = self.create_entity_with_numbering_setup(name="API Numbering Entity A")
+        setup_b = self.create_entity_with_numbering_setup(name="API Numbering Entity B")
+
+        bill_a = self.create_bill(setup_a)
+        bill_b = self.create_bill(setup_b)
+
+        invoice_a = self.create_invoice(setup_a)
+        invoice_b = self.create_invoice(setup_b)
+
+        estimate_a = self.create_estimate(setup_a)
+        estimate_b = self.create_estimate(setup_b)
+
+        po_a = self.create_purchase_order(setup_a)
+        po_b = self.create_purchase_order(setup_b)
+
+        self.assertEqual(bill_a.bill_number, bill_b.bill_number)
+        self.assertEqual(invoice_a.invoice_number, invoice_b.invoice_number)
+        self.assertEqual(estimate_a.estimate_number, estimate_b.estimate_number)
+        self.assertEqual(po_a.po_number, po_b.po_number)

--- a/django_ledger/tests/api/test_entity_bank_account_api.py
+++ b/django_ledger/tests/api/test_entity_bank_account_api.py
@@ -1,0 +1,204 @@
+"""
+High-level API behavior tests for EntityModel bank account wrappers.
+
+These tests cover entity-scoped bank account creation, default account
+selection, explicit account selection, and active filtering.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.bank_account import BankAccountModel
+from django_ledger.models.entity import EntityModel, EntityModelValidationError
+
+
+class EntityBankAccountAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_entity_bank_account_admin",
+            email="api-entity-bank-account-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_entity_bank_account_other_admin",
+            email="api-entity-bank-account-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_bank_account_setup(
+        self,
+        *,
+        name="API Entity Bank Account Entity",
+        admin=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_role = BankAccountModel.ACCOUNT_TYPE_DEFAULT_ROLE_MAPPING[
+            BankAccountModel.ACCOUNT_CHECKING
+        ]
+        default_cash_account = entity_model.create_account(
+            code="1010",
+            role=cash_role,
+            name=f"{name} Default Cash",
+            balance_type="debit",
+            active=True,
+            coa_model=coa_model,
+            is_role_default=True,
+        )
+        explicit_cash_account = entity_model.create_account(
+            code="1020",
+            role=cash_role,
+            name=f"{name} Explicit Cash",
+            balance_type="debit",
+            active=True,
+            coa_model=coa_model,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "default_cash_account": default_cash_account,
+            "explicit_cash_account": explicit_cash_account,
+        }
+
+    def create_bank_account(
+        self,
+        entity_model,
+        *,
+        name="API Entity Bank Account",
+        account_number="000000001",
+        routing_number="000000101",
+        active=True,
+        account_model=None,
+    ):
+        return entity_model.create_bank_account(
+            name=name,
+            account_type=BankAccountModel.ACCOUNT_CHECKING,
+            active=active,
+            account_model=account_model,
+            bank_account_model_kwargs={
+                "account_number": account_number,
+                "routing_number": routing_number,
+            },
+        )
+
+    def test_create_bank_account_creates_account_under_entity(self):
+        setup = self.create_entity_with_bank_account_setup()
+        entity_model = setup["entity_model"]
+
+        bank_account = self.create_bank_account(entity_model)
+
+        self.assertIsInstance(bank_account, BankAccountModel)
+        self.assertEqual(bank_account.entity_model_id, entity_model.uuid)
+        self.assertEqual(bank_account.name, "API Entity Bank Account")
+        self.assertEqual(bank_account.account_type, BankAccountModel.ACCOUNT_CHECKING)
+        self.assertEqual(bank_account.account_number, "000000001")
+        self.assertEqual(bank_account.routing_number, "000000101")
+        self.assertTrue(bank_account.active)
+
+    def test_create_bank_account_uses_default_account_for_account_type(self):
+        setup = self.create_entity_with_bank_account_setup()
+        entity_model = setup["entity_model"]
+
+        bank_account = self.create_bank_account(entity_model)
+
+        self.assertEqual(
+            bank_account.account_model_id,
+            setup["default_cash_account"].uuid,
+        )
+
+    def test_create_bank_account_respects_explicit_account_model(self):
+        setup = self.create_entity_with_bank_account_setup()
+        entity_model = setup["entity_model"]
+
+        bank_account = self.create_bank_account(
+            entity_model,
+            account_model=setup["explicit_cash_account"],
+        )
+
+        self.assertEqual(
+            bank_account.account_model_id,
+            setup["explicit_cash_account"].uuid,
+        )
+
+    def test_create_bank_account_rejects_invalid_account_type(self):
+        setup = self.create_entity_with_bank_account_setup()
+
+        with self.assertRaises(EntityModelValidationError):
+            setup["entity_model"].create_bank_account(
+                name="API Invalid Bank Account",
+                account_type="not-a-bank-account-type",
+                active=True,
+                bank_account_model_kwargs={
+                    "account_number": "000000001",
+                    "routing_number": "000000101",
+                },
+            )
+
+    def test_get_bank_accounts_is_entity_scoped_and_filters_inactive_by_default(self):
+        setup = self.create_entity_with_bank_account_setup(
+            name="API Bank Account Scoped Entity"
+        )
+        other_setup = self.create_entity_with_bank_account_setup(
+            name="API Other Bank Account Scoped Entity",
+            admin=self.other_admin_user,
+        )
+        entity_model = setup["entity_model"]
+        other_entity = other_setup["entity_model"]
+
+        active_bank_account = self.create_bank_account(
+            entity_model,
+            name="API Active Entity Bank Account",
+            account_number="000000001",
+            routing_number="000000101",
+            active=True,
+        )
+        inactive_bank_account = self.create_bank_account(
+            entity_model,
+            name="API Inactive Entity Bank Account",
+            account_number="000000002",
+            routing_number="000000102",
+            active=False,
+        )
+        other_bank_account = self.create_bank_account(
+            other_entity,
+            name="API Other Entity Bank Account",
+            account_number="000000001",
+            routing_number="000000101",
+            active=True,
+        )
+
+        default_bank_account_qs = entity_model.get_bank_accounts()
+        all_bank_account_qs = entity_model.get_bank_accounts(active=False)
+
+        self.assertTrue(
+            default_bank_account_qs.filter(uuid=active_bank_account.uuid).exists()
+        )
+        self.assertFalse(
+            default_bank_account_qs.filter(uuid=inactive_bank_account.uuid).exists()
+        )
+        self.assertFalse(
+            default_bank_account_qs.filter(uuid=other_bank_account.uuid).exists()
+        )
+
+        self.assertTrue(
+            all_bank_account_qs.filter(uuid=active_bank_account.uuid).exists()
+        )
+        self.assertTrue(
+            all_bank_account_qs.filter(uuid=inactive_bank_account.uuid).exists()
+        )
+        self.assertFalse(
+            all_bank_account_qs.filter(uuid=other_bank_account.uuid).exists()
+        )

--- a/django_ledger/tests/api/test_entity_bank_account_api.py
+++ b/django_ledger/tests/api/test_entity_bank_account_api.py
@@ -133,6 +133,33 @@ class EntityBankAccountAPITest(TestCase):
             setup["explicit_cash_account"].uuid,
         )
 
+    def test_create_bank_account_rejects_cross_entity_explicit_account_model_without_side_effect(self):
+        setup = self.create_entity_with_bank_account_setup(
+            name="API Bank Account Explicit Account Entity"
+        )
+        other_setup = self.create_entity_with_bank_account_setup(
+            name="API Other Bank Account Explicit Account Entity",
+            admin=self.other_admin_user,
+        )
+        bank_account_count = BankAccountModel.objects.count()
+
+        with self.assertRaises(EntityModelValidationError):
+            self.create_bank_account(
+                setup["entity_model"],
+                name="API Cross Entity Explicit Account Bank Account",
+                account_number="000000099",
+                routing_number="000000199",
+                account_model=other_setup["explicit_cash_account"],
+            )
+
+        self.assertEqual(BankAccountModel.objects.count(), bank_account_count)
+        self.assertFalse(
+            setup["entity_model"]
+            .get_bank_accounts(active=False)
+            .filter(name="API Cross Entity Explicit Account Bank Account")
+            .exists()
+        )
+
     def test_create_bank_account_rejects_invalid_account_type(self):
         setup = self.create_entity_with_bank_account_setup()
 

--- a/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
+++ b/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
@@ -474,3 +474,129 @@ class EntityChartOfAccountsHighLevelAPITest(TestCase):
         self.assertTrue(
             entity_model.get_default_coa_accounts().filter(uuid=account_model.uuid).exists()
         )
+
+    def test_create_account_accepts_explicit_coa_uuid(self):
+        entity_model, _default_coa = self.create_entity_with_default_coa(
+            entity_name="API Explicit UUID Account Entity",
+            coa_name="API Explicit UUID Default CoA",
+        )
+        explicit_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Explicit UUID CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        account_model = entity_model.create_account(
+            code="1030",
+            name="API Explicit UUID Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            coa_model=explicit_coa.uuid,
+        )
+
+        self.assertEqual(account_model.coa_model_id, explicit_coa.uuid)
+        self.assertTrue(
+            entity_model.get_coa_accounts(coa_model=explicit_coa)
+            .filter(uuid=account_model.uuid)
+            .exists()
+        )
+        self.assertFalse(
+            entity_model.get_default_coa_accounts().filter(uuid=account_model.uuid).exists()
+        )
+
+    def test_create_account_accepts_explicit_coa_slug(self):
+        entity_model, _default_coa = self.create_entity_with_default_coa(
+            entity_name="API Explicit Slug Account Entity",
+            coa_name="API Explicit Slug Default CoA",
+        )
+        explicit_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Explicit Slug CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        account_model = entity_model.create_account(
+            code="1040",
+            name="API Explicit Slug Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            coa_model=explicit_coa.slug,
+        )
+
+        self.assertEqual(account_model.coa_model_id, explicit_coa.uuid)
+        self.assertTrue(
+            entity_model.get_coa_accounts(coa_model=explicit_coa)
+            .filter(uuid=account_model.uuid)
+            .exists()
+        )
+        self.assertFalse(
+            entity_model.get_default_coa_accounts().filter(uuid=account_model.uuid).exists()
+        )
+
+    def test_create_account_by_kwargs_accepts_explicit_coa_uuid(self):
+        entity_model, _default_coa = self.create_entity_with_default_coa(
+            entity_name="API Explicit UUID Kwargs Account Entity",
+            coa_name="API Explicit UUID Kwargs Default CoA",
+        )
+        explicit_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Explicit UUID Kwargs CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        returned_coa, account_model = entity_model.create_account_by_kwargs(
+            {
+                "code": "1050",
+                "name": "API Explicit UUID Kwargs Cash Account",
+                "role": ASSET_CA_CASH,
+                "balance_type": DEBIT,
+                "active": True,
+            },
+            coa_model=explicit_coa.uuid,
+        )
+
+        self.assertEqual(returned_coa, explicit_coa)
+        self.assertEqual(account_model.coa_model_id, explicit_coa.uuid)
+        self.assertTrue(
+            entity_model.get_coa_accounts(coa_model=explicit_coa)
+            .filter(uuid=account_model.uuid)
+            .exists()
+        )
+        self.assertFalse(
+            entity_model.get_default_coa_accounts().filter(uuid=account_model.uuid).exists()
+        )
+
+    def test_create_account_by_kwargs_accepts_explicit_coa_slug(self):
+        entity_model, _default_coa = self.create_entity_with_default_coa(
+            entity_name="API Explicit Slug Kwargs Account Entity",
+            coa_name="API Explicit Slug Kwargs Default CoA",
+        )
+        explicit_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Explicit Slug Kwargs CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        returned_coa, account_model = entity_model.create_account_by_kwargs(
+            {
+                "code": "1060",
+                "name": "API Explicit Slug Kwargs Cash Account",
+                "role": ASSET_CA_CASH,
+                "balance_type": DEBIT,
+                "active": True,
+            },
+            coa_model=explicit_coa.slug,
+        )
+
+        self.assertEqual(returned_coa, explicit_coa)
+        self.assertEqual(account_model.coa_model_id, explicit_coa.uuid)
+        self.assertTrue(
+            entity_model.get_coa_accounts(coa_model=explicit_coa)
+            .filter(uuid=account_model.uuid)
+            .exists()
+        )
+        self.assertFalse(
+            entity_model.get_default_coa_accounts().filter(uuid=account_model.uuid).exists()
+        )

--- a/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
+++ b/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
@@ -1,17 +1,11 @@
-"""
-High-level API behavior tests for EntityModel and ChartOfAccountModel.
-
-This file is part of a human-reviewed, AI-assisted contribution using
-OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
-coverage around Django Ledger's public/high-level API contracts without
-replacing or reorganizing the existing test suite.
-"""
+"""High-level API behavior tests for EntityModel chart of accounts APIs."""
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
+from django_ledger.io.roles import ASSET_CA_CASH, DEBIT, EXPENSE_OPERATIONAL
 from django_ledger.models import AccountModel
-from django_ledger.models.entity import EntityModel
+from django_ledger.models.entity import EntityModel, EntityModelValidationError
 
 
 class EntityChartOfAccountsHighLevelAPITest(TestCase):
@@ -39,6 +33,61 @@ class EntityChartOfAccountsHighLevelAPITest(TestCase):
             admin=self.user,
             use_accrual_method=True,
             fy_start_month=1,
+        )
+
+    def create_entity_with_default_coa(
+        self,
+        *,
+        entity_name="API Contract Entity",
+        coa_name="API Contract CoA",
+    ):
+        entity_model = self.create_entity(name=entity_name)
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=coa_name,
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model, coa_model
+
+    def create_cash_account(
+        self,
+        entity_model,
+        *,
+        code="1010",
+        name="API Contract Cash Account",
+        coa_model=None,
+        active=True,
+        is_role_default=False,
+        force_role_default=False,
+    ):
+        return entity_model.create_account(
+            code=code,
+            name=name,
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=active,
+            coa_model=coa_model,
+            is_role_default=is_role_default,
+            force_role_default=force_role_default,
+        )
+
+    def create_expense_account(
+        self,
+        entity_model,
+        *,
+        code="6010",
+        name="API Contract Expense Account",
+        coa_model=None,
+        active=True,
+    ):
+        return entity_model.create_account(
+            code=code,
+            name=name,
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+            active=active,
+            coa_model=coa_model,
         )
 
     def test_create_entity_produces_usable_accounting_entity(self):
@@ -96,19 +145,13 @@ class EntityChartOfAccountsHighLevelAPITest(TestCase):
             self.assertTrue(root_account.role_default)
 
     def test_create_account_adds_real_account_to_default_coa(self):
-        entity_model = self.create_entity()
+        entity_model, coa_model = self.create_entity_with_default_coa()
 
-        coa_model = entity_model.create_chart_of_accounts(
-            coa_name="API Contract CoA",
-            commit=True,
-            assign_as_default=True,
-        )
-
-        account_model = coa_model.create_account(
+        account_model = entity_model.create_account(
             code="1010",
             name="API Contract Cash Account",
-            role="asset_ca_cash",
-            balance_type="debit",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
             active=True,
         )
 
@@ -117,40 +160,317 @@ class EntityChartOfAccountsHighLevelAPITest(TestCase):
         self.assertEqual(account_model.coa_model_id, coa_model.uuid)
         self.assertEqual(account_model.code, "1010")
         self.assertEqual(account_model.name, "API Contract Cash Account")
-        self.assertEqual(account_model.role, "asset_ca_cash")
-        self.assertEqual(account_model.balance_type, "debit")
+        self.assertEqual(account_model.role, ASSET_CA_CASH)
+        self.assertEqual(account_model.balance_type, DEBIT)
         self.assertTrue(account_model.active)
         self.assertFalse(account_model.locked)
         self.assertFalse(account_model.is_root_account())
         self.assertTrue(account_model.can_transact())
 
     def test_default_entity_account_queryset_exposes_created_real_account(self):
-        entity_model = self.create_entity()
+        entity_model, _coa_model = self.create_entity_with_default_coa()
 
-        coa_model = entity_model.create_chart_of_accounts(
-            coa_name="API Contract CoA",
-            commit=True,
-            assign_as_default=True,
-        )
-
-        account_model = coa_model.create_account(
+        account_model = entity_model.create_account(
             code="1020",
             name="API Contract Bank Account",
-            role="asset_ca_cash",
-            balance_type="debit",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
             active=True,
         )
 
-        default_coa_accounts = AccountModel.objects.for_entity(entity_model)
+        default_coa_accounts = entity_model.get_default_coa_accounts()
 
         self.assertTrue(
             default_coa_accounts.filter(uuid=account_model.uuid).exists(),
-            "AccountModel.objects.for_entity(entity) should expose accounts "
+            "EntityModel.get_default_coa_accounts() should expose accounts "
             "from the entity default CoA.",
         )
 
-        self.assertTrue(
-            default_coa_accounts.not_coa_root().filter(uuid=account_model.uuid).exists(),
-            "A real account created via the CoA API should not be treated as "
+        self.assertFalse(
+            AccountModel.objects.for_entity(entity_model)
+            .is_coa_root()
+            .filter(uuid=account_model.uuid)
+            .exists(),
+            "A real account created via the entity API should not be treated as "
             "a technical CoA root account.",
+        )
+
+    def test_default_coa_can_be_read_and_switched_by_model_or_slug(self):
+        entity_model = self.create_entity()
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.get_default_coa()
+
+        self.assertIsNone(entity_model.get_default_coa(raise_exception=False))
+
+        first_coa = entity_model.create_chart_of_accounts(
+            coa_name="API First CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        second_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Second CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        entity_model.refresh_from_db()
+        self.assertEqual(entity_model.get_default_coa(), first_coa)
+        self.assertTrue(first_coa.is_default())
+        self.assertFalse(second_coa.is_default())
+
+        entity_model.set_default_coa(second_coa, commit=True)
+        entity_model.refresh_from_db()
+        second_coa.refresh_from_db()
+        self.assertEqual(entity_model.get_default_coa(), second_coa)
+        self.assertTrue(second_coa.is_default())
+
+        entity_model.set_default_coa(first_coa.slug, commit=True)
+        entity_model.refresh_from_db()
+        first_coa.refresh_from_db()
+        self.assertEqual(entity_model.get_default_coa(), first_coa)
+        self.assertTrue(first_coa.is_default())
+
+    def test_get_coa_model_qs_filters_by_entity_and_active_status(self):
+        entity_model, active_coa = self.create_entity_with_default_coa(
+            entity_name="API CoA Query Entity",
+            coa_name="API Active CoA",
+        )
+        inactive_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Inactive CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+        inactive_coa.active = False
+        inactive_coa.save(update_fields=["active"])
+
+        other_entity, other_coa = self.create_entity_with_default_coa(
+            entity_name="API Other CoA Query Entity",
+            coa_name="API Other Active CoA",
+        )
+
+        active_qs = entity_model.get_coa_model_qs(active=True)
+        all_qs = entity_model.get_coa_model_qs(active=False)
+
+        self.assertTrue(active_qs.filter(uuid=active_coa.uuid).exists())
+        self.assertFalse(active_qs.filter(uuid=inactive_coa.uuid).exists())
+        self.assertFalse(active_qs.filter(uuid=other_coa.uuid).exists())
+
+        self.assertTrue(all_qs.filter(uuid=active_coa.uuid).exists())
+        self.assertTrue(all_qs.filter(uuid=inactive_coa.uuid).exists())
+        self.assertFalse(all_qs.filter(entity=other_entity).exists())
+
+    def test_populate_default_coa_creates_default_accounts_once(self):
+        entity_model = self.create_entity(name="API Populated Default CoA Entity")
+
+        entity_model.populate_default_coa(activate_accounts=True)
+        entity_model.refresh_from_db()
+
+        coa_model = entity_model.get_default_coa()
+        default_accounts = entity_model.get_default_coa_accounts(active=True)
+        account_uuids = set(default_accounts.values_list("uuid", flat=True))
+
+        self.assertIsNotNone(coa_model)
+        self.assertTrue(coa_model.is_configured())
+        self.assertGreater(len(account_uuids), 0)
+
+        cash_account = entity_model.get_default_account_for_role(ASSET_CA_CASH)
+        self.assertEqual(cash_account.coa_model_id, coa_model.uuid)
+        self.assertEqual(cash_account.role, ASSET_CA_CASH)
+        self.assertTrue(cash_account.role_default)
+        self.assertTrue(cash_account.active)
+
+        entity_model.populate_default_coa(activate_accounts=True)
+        default_accounts_after_second_call = entity_model.get_default_coa_accounts(active=True)
+        account_uuids_after_second_call = set(
+            default_accounts_after_second_call.values_list("uuid", flat=True)
+        )
+
+        self.assertEqual(account_uuids_after_second_call, account_uuids)
+
+    def test_entity_account_query_helpers_scope_accounts_by_default_and_explicit_coa(self):
+        entity_model, default_coa = self.create_entity_with_default_coa(
+            entity_name="API Account Scope Entity",
+            coa_name="API Default Scope CoA",
+        )
+        default_account = self.create_cash_account(
+            entity_model,
+            code="1010",
+            name="API Default Cash Account",
+        )
+
+        second_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Secondary Scope CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+        second_account = self.create_cash_account(
+            entity_model,
+            code="1020",
+            name="API Secondary Cash Account",
+            coa_model=second_coa,
+        )
+
+        other_entity, _other_coa = self.create_entity_with_default_coa(
+            entity_name="API Other Account Scope Entity",
+            coa_name="API Other Scope CoA",
+        )
+        other_account = self.create_cash_account(
+            other_entity,
+            code="1010",
+            name="API Other Cash Account",
+        )
+
+        default_accounts = entity_model.get_default_coa_accounts()
+        self.assertTrue(default_accounts.filter(uuid=default_account.uuid).exists())
+        self.assertFalse(default_accounts.filter(uuid=second_account.uuid).exists())
+        self.assertFalse(default_accounts.filter(uuid=other_account.uuid).exists())
+
+        second_coa_model, second_coa_accounts = entity_model.get_coa_accounts(
+            coa_model=second_coa,
+            return_coa_model=True,
+        )
+        self.assertEqual(second_coa_model, second_coa)
+        self.assertTrue(second_coa_accounts.filter(uuid=second_account.uuid).exists())
+        self.assertFalse(second_coa_accounts.filter(uuid=default_account.uuid).exists())
+
+        all_entity_accounts = entity_model.get_all_accounts()
+        self.assertTrue(all_entity_accounts.filter(uuid=default_account.uuid).exists())
+        self.assertTrue(all_entity_accounts.filter(uuid=second_account.uuid).exists())
+        self.assertFalse(all_entity_accounts.filter(uuid=other_account.uuid).exists())
+
+        coa_qs, accounts_by_coa = entity_model.get_all_coa_accounts()
+        self.assertTrue(coa_qs.filter(uuid=default_coa.uuid).exists())
+        self.assertTrue(coa_qs.filter(uuid=second_coa.uuid).exists())
+        self.assertFalse(coa_qs.filter(entity=other_entity).exists())
+        self.assertTrue(accounts_by_coa[default_coa].filter(uuid=default_account.uuid).exists())
+        self.assertTrue(accounts_by_coa[second_coa].filter(uuid=second_account.uuid).exists())
+
+    def test_get_accounts_with_codes_accepts_string_list_and_set(self):
+        entity_model, _coa_model = self.create_entity_with_default_coa(
+            entity_name="API Account Codes Entity",
+            coa_name="API Account Codes CoA",
+        )
+        cash_account = self.create_cash_account(
+            entity_model,
+            code="1010",
+            name="API Cash Code Account",
+        )
+        expense_account = self.create_expense_account(
+            entity_model,
+            code="6010",
+            name="API Expense Code Account",
+        )
+
+        account_from_string = entity_model.get_accounts_with_codes("1010")
+        accounts_from_list = entity_model.get_accounts_with_codes(["1010", "6010"])
+        accounts_from_set = entity_model.get_accounts_with_codes({"1010", "6010"})
+
+        self.assertEqual(list(account_from_string), [cash_account])
+        self.assertEqual(
+            set(accounts_from_list.values_list("uuid", flat=True)),
+            {cash_account.uuid, expense_account.uuid},
+        )
+        self.assertEqual(
+            set(accounts_from_set.values_list("uuid", flat=True)),
+            {cash_account.uuid, expense_account.uuid},
+        )
+
+    def test_get_default_account_for_role_returns_populated_role_default_account(self):
+        entity_model = self.create_entity(name="API Role Default Entity")
+        entity_model.populate_default_coa(activate_accounts=True)
+
+        account_model = entity_model.get_default_account_for_role(ASSET_CA_CASH)
+
+        self.assertEqual(account_model.role, ASSET_CA_CASH)
+        self.assertTrue(account_model.role_default)
+        self.assertEqual(account_model.coa_model_id, entity_model.default_coa_id)
+
+    def test_validate_chart_of_accounts_for_entity_rejects_other_entity_coa(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            entity_name="API CoA Validation Entity",
+            coa_name="API Valid CoA",
+        )
+        _other_entity, other_coa = self.create_entity_with_default_coa(
+            entity_name="API Other CoA Validation Entity",
+            coa_name="API Other CoA",
+        )
+
+        self.assertTrue(entity_model.validate_chart_of_accounts_for_entity(coa_model))
+        self.assertFalse(
+            entity_model.validate_chart_of_accounts_for_entity(
+                other_coa,
+                raise_exception=False,
+            )
+        )
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.validate_chart_of_accounts_for_entity(other_coa)
+
+    def test_validate_account_model_for_coa_rejects_account_from_other_coa(self):
+        entity_model, default_coa = self.create_entity_with_default_coa(
+            entity_name="API Account Validation Entity",
+            coa_name="API Valid Account CoA",
+        )
+        default_account = self.create_cash_account(
+            entity_model,
+            code="1010",
+            name="API Valid Account",
+        )
+        second_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Other Account CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+        other_account = self.create_cash_account(
+            entity_model,
+            code="1020",
+            name="API Other CoA Account",
+            coa_model=second_coa,
+        )
+
+        self.assertTrue(
+            entity_model.validate_account_model_for_coa(
+                account_model=default_account,
+                coa_model=default_coa,
+            )
+        )
+        self.assertFalse(
+            entity_model.validate_account_model_for_coa(
+                account_model=other_account,
+                coa_model=default_coa,
+                raise_exception=False,
+            )
+        )
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.validate_account_model_for_coa(
+                account_model=other_account,
+                coa_model=default_coa,
+            )
+
+    def test_create_account_by_kwargs_uses_default_coa(self):
+        entity_model, default_coa = self.create_entity_with_default_coa(
+            entity_name="API Kwargs Account Entity",
+            coa_name="API Kwargs Account CoA",
+        )
+
+        returned_coa, account_model = entity_model.create_account_by_kwargs(
+            {
+                "code": "1010",
+                "name": "API Kwargs Cash Account",
+                "role": ASSET_CA_CASH,
+                "balance_type": DEBIT,
+                "active": True,
+            }
+        )
+
+        self.assertEqual(returned_coa, default_coa)
+        self.assertEqual(account_model.coa_model_id, default_coa.uuid)
+        self.assertEqual(account_model.code, "1010")
+        self.assertEqual(account_model.name, "API Kwargs Cash Account")
+        self.assertEqual(account_model.role, ASSET_CA_CASH)
+        self.assertTrue(account_model.active)
+        self.assertTrue(
+            entity_model.get_default_coa_accounts().filter(uuid=account_model.uuid).exists()
         )

--- a/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
+++ b/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
@@ -1,0 +1,156 @@
+"""
+High-level API behavior tests for EntityModel and ChartOfAccountModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import AccountModel
+from django_ledger.models.entity import EntityModel
+
+
+class EntityChartOfAccountsHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for the public Entity -> CoA -> Account setup API.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document small, deterministic business contracts that should
+    remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_contract_user",
+            email="api-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Contract Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def test_create_entity_produces_usable_accounting_entity(self):
+        entity_model = self.create_entity()
+
+        self.assertIsNotNone(entity_model.uuid)
+        self.assertEqual(entity_model.name, "API Contract Entity")
+        self.assertEqual(entity_model.admin, self.user)
+        self.assertTrue(entity_model.accrual_method)
+        self.assertEqual(entity_model.fy_start_month, 1)
+
+    def test_create_chart_of_accounts_can_assign_default_coa(self):
+        entity_model = self.create_entity()
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        entity_model.refresh_from_db()
+
+        self.assertIsNotNone(coa_model.uuid)
+        self.assertEqual(coa_model.name, "API Contract CoA")
+        self.assertEqual(coa_model.entity_id, entity_model.uuid)
+        self.assertTrue(coa_model.active)
+        self.assertEqual(entity_model.default_coa_id, coa_model.uuid)
+
+    def test_create_chart_of_accounts_configures_root_account_tree(self):
+        entity_model = self.create_entity()
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        self.assertTrue(
+            coa_model.is_configured(),
+            "A CoA created through the high-level API should be configured.",
+        )
+
+        accounts_qs = AccountModel.objects.for_entity(entity_model)
+        root_accounts_qs = accounts_qs.is_coa_root()
+
+        self.assertGreater(
+            root_accounts_qs.count(),
+            0,
+            "A configured CoA should include technical root accounts.",
+        )
+
+        for root_account in root_accounts_qs:
+            self.assertTrue(root_account.locked)
+            self.assertFalse(root_account.active)
+            self.assertTrue(root_account.role_default)
+
+    def test_create_account_adds_real_account_to_default_coa(self):
+        entity_model = self.create_entity()
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        account_model = coa_model.create_account(
+            code="1010",
+            name="API Contract Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        account_model.refresh_from_db()
+
+        self.assertEqual(account_model.coa_model_id, coa_model.uuid)
+        self.assertEqual(account_model.code, "1010")
+        self.assertEqual(account_model.name, "API Contract Cash Account")
+        self.assertEqual(account_model.role, "asset_ca_cash")
+        self.assertEqual(account_model.balance_type, "debit")
+        self.assertTrue(account_model.active)
+        self.assertFalse(account_model.locked)
+        self.assertFalse(account_model.is_root_account())
+        self.assertTrue(account_model.can_transact())
+
+    def test_default_entity_account_queryset_exposes_created_real_account(self):
+        entity_model = self.create_entity()
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        account_model = coa_model.create_account(
+            code="1020",
+            name="API Contract Bank Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        default_coa_accounts = AccountModel.objects.for_entity(entity_model)
+
+        self.assertTrue(
+            default_coa_accounts.filter(uuid=account_model.uuid).exists(),
+            "AccountModel.objects.for_entity(entity) should expose accounts "
+            "from the entity default CoA.",
+        )
+
+        self.assertTrue(
+            default_coa_accounts.not_coa_root().filter(uuid=account_model.uuid).exists(),
+            "A real account created via the CoA API should not be treated as "
+            "a technical CoA root account.",
+        )

--- a/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
+++ b/django_ledger/tests/api/test_entity_chart_of_accounts_api.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from django_ledger.io.roles import ASSET_CA_CASH, DEBIT, EXPENSE_OPERATIONAL
-from django_ledger.models import AccountModel
+from django_ledger.models import AccountModel, ChartOfAccountModel
 from django_ledger.models.entity import EntityModel, EntityModelValidationError
 
 
@@ -24,6 +24,11 @@ class EntityChartOfAccountsHighLevelAPITest(TestCase):
         cls.user = user_model.objects.create_user(
             username="api_contract_user",
             email="api-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_contract_unrelated_user",
+            email="api-contract-unrelated-user@example.com",
             password="NeverUseThisPassword12345",
         )
 
@@ -115,6 +120,28 @@ class EntityChartOfAccountsHighLevelAPITest(TestCase):
         self.assertEqual(coa_model.entity_id, entity_model.uuid)
         self.assertTrue(coa_model.active)
         self.assertEqual(entity_model.default_coa_id, coa_model.uuid)
+
+    def test_create_chart_of_accounts_returns_configured_chart_with_root_structure(self):
+        entity_model = self.create_entity(name="API Entity CoA Orchestration Entity")
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Entity Orchestrated CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        self.assertIsInstance(coa_model, ChartOfAccountModel)
+        self.assertEqual(coa_model.entity_id, entity_model.uuid)
+        self.assertEqual(coa_model.name, "API Entity Orchestrated CoA")
+        self.assertTrue(coa_model.slug)
+        self.assertTrue(coa_model.is_configured())
+
+        root_node = coa_model.get_coa_root_node()
+        root_accounts_qs = coa_model.get_coa_root_accounts_qs()
+
+        self.assertTrue(root_node.is_coa_root())
+        self.assertTrue(root_accounts_qs.exists())
+        self.assertTrue(all(account.is_root_account() for account in root_accounts_qs))
 
     def test_create_chart_of_accounts_configures_root_account_tree(self):
         entity_model = self.create_entity()
@@ -448,6 +475,77 @@ class EntityChartOfAccountsHighLevelAPITest(TestCase):
                 account_model=other_account,
                 coa_model=default_coa,
             )
+
+    def test_create_chart_of_accounts_without_default_does_not_replace_existing_default(self):
+        entity_model, first_coa = self.create_entity_with_default_coa(
+            entity_name="API Entity Preserve Default CoA Entity",
+            coa_name="API Entity Preserve Default First CoA",
+        )
+
+        second_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Entity Preserve Default Second CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        entity_model.refresh_from_db()
+        first_coa.refresh_from_db()
+        second_coa.refresh_from_db()
+
+        self.assertEqual(entity_model.default_coa_id, first_coa.uuid)
+        self.assertTrue(first_coa.is_default())
+        self.assertFalse(second_coa.is_default())
+
+    def test_entity_can_own_multiple_coas_and_queryset_exposes_each(self):
+        entity_model, default_coa = self.create_entity_with_default_coa(
+            entity_name="API Entity Multiple CoA Entity",
+            coa_name="API Entity Multiple Default CoA",
+        )
+        second_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Entity Multiple Second CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        entity_coa_qs = ChartOfAccountModel.objects.for_entity(entity_model)
+
+        self.assertTrue(entity_coa_qs.filter(uuid=default_coa.uuid).exists())
+        self.assertTrue(entity_coa_qs.filter(uuid=second_coa.uuid).exists())
+        self.assertEqual(
+            [coa.uuid for coa in (default_coa, second_coa) if coa.is_default()],
+            [default_coa.uuid],
+        )
+
+    def test_populate_default_coa_creates_known_default_accounts(self):
+        entity_model = self.create_entity(name="API Entity Known Default CoA Entity")
+
+        entity_model.populate_default_coa(activate_accounts=True)
+        entity_model.refresh_from_db()
+
+        default_accounts_qs = entity_model.get_default_coa_accounts(active=True)
+        cash_account = default_accounts_qs.get(code="1010")
+        expense_account = default_accounts_qs.get(code="6190")
+
+        self.assertEqual(cash_account.role, ASSET_CA_CASH)
+        self.assertEqual(cash_account.name, "Cash")
+        self.assertEqual(cash_account.coa_model_id, entity_model.default_coa_id)
+
+        self.assertEqual(expense_account.role, EXPENSE_OPERATIONAL)
+        self.assertEqual(expense_account.name, "Office Expense")
+        self.assertEqual(expense_account.coa_model_id, entity_model.default_coa_id)
+
+    def test_entity_created_coa_is_visible_through_user_scoped_queryset(self):
+        entity_model, coa_model = self.create_entity_with_default_coa(
+            entity_name="API Entity CoA User Scope Entity",
+            coa_name="API Entity CoA User Scope CoA",
+        )
+
+        entity_coa_qs = ChartOfAccountModel.objects.for_entity(entity_model)
+        admin_qs = entity_coa_qs.for_user(self.user)
+        unrelated_qs = entity_coa_qs.for_user(self.unrelated_user)
+
+        self.assertTrue(admin_qs.filter(uuid=coa_model.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=coa_model.uuid).exists())
 
     def test_create_account_by_kwargs_uses_default_coa(self):
         entity_model, default_coa = self.create_entity_with_default_coa(

--- a/django_ledger/tests/api/test_entity_closing_entry_api.py
+++ b/django_ledger/tests/api/test_entity_closing_entry_api.py
@@ -1,0 +1,323 @@
+"""High-level API behavior tests for EntityModel closing entry wrappers."""
+
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io.io_core import get_localdate
+from django_ledger.io.roles import ASSET_CA_CASH, CREDIT, DEBIT, EXPENSE_OPERATIONAL
+from django_ledger.models import ClosingEntryModel, TransactionModel
+from django_ledger.models.entity import EntityModel, EntityModelValidationError
+
+
+class EntityClosingEntryHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for EntityModel closing-entry APIs.
+
+    These tests keep setup deterministic and avoid cache/queryset helpers that
+    currently depend on separately characterized closing-entry transaction bugs.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_entity_closing_entry_user",
+            email="api-entity-closing-entry-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Entity Closing Entry Contract Entity",
+        fy_start_month=1,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=fy_start_month,
+        )
+
+        entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+
+        cash_account = entity_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+        )
+        expense_account = entity_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+            active=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+        }
+
+    def make_timestamp(self, tx_date):
+        if settings.USE_TZ:
+            return datetime(tx_date.year, tx_date.month, tx_date.day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(tx_date.year, tx_date.month, tx_date.day, 12, 0)
+
+    def create_posted_activity(self, setup, *, tx_date=date(2025, 1, 15)):
+        entity_model = setup["entity_model"]
+        ledger_model = entity_model.create_ledger(
+            name=f"API Closing Activity Ledger {tx_date.isoformat()}",
+            ledger_xid=f"api-closing-activity-{tx_date.isoformat()}",
+            posted=True,
+        )
+
+        journal_entry, tx_models = entity_model.commit_txs(
+            je_timestamp=self.make_timestamp(tx_date),
+            je_ledger_model=ledger_model,
+            je_posted=True,
+            je_desc=f"API Closing Activity {tx_date.isoformat()}",
+            je_txs=[
+                {
+                    "account": setup["expense_account"],
+                    "amount": Decimal("100.00"),
+                    "tx_type": TransactionModel.DEBIT,
+                    "description": "API expense debit.",
+                },
+                {
+                    "account": setup["cash_account"],
+                    "amount": Decimal("100.00"),
+                    "tx_type": TransactionModel.CREDIT,
+                    "description": "API cash credit.",
+                },
+            ],
+        )
+
+        journal_entry.refresh_from_db()
+        ledger_model.refresh_from_db()
+
+        self.assertTrue(ledger_model.posted)
+        self.assertTrue(journal_entry.posted)
+        self.assertEqual(len(tx_models), 2)
+
+        return ledger_model, journal_entry, tx_models
+
+    def create_posted_closing_entry(self, entity_model, closing_date):
+        closing_entry = ClosingEntryModel.objects.create(
+            entity_model=entity_model,
+            closing_date=closing_date,
+            posted=True,
+        )
+        closing_entry.refresh_from_db()
+        return closing_entry
+
+    def assert_closing_transactions_match_activity(self, ce_txs, setup):
+        self.assertEqual(len(ce_txs), 2)
+        self.assertEqual(
+            {ce_tx.account_model_id for ce_tx in ce_txs},
+            {setup["cash_account"].uuid, setup["expense_account"].uuid},
+        )
+
+        cash_tx = next(ce_tx for ce_tx in ce_txs if ce_tx.account_model_id == setup["cash_account"].uuid)
+        expense_tx = next(ce_tx for ce_tx in ce_txs if ce_tx.account_model_id == setup["expense_account"].uuid)
+
+        self.assertEqual(cash_tx.tx_type, CREDIT)
+        self.assertEqual(cash_tx.balance, Decimal("100.00"))
+        self.assertEqual(expense_tx.tx_type, DEBIT)
+        self.assertEqual(expense_tx.balance, Decimal("100.00"))
+
+    def test_get_closing_entry_digest_for_date_builds_transactions_from_posted_activity(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 1, 15))
+
+        closing_entry, ce_txs = entity_model.get_closing_entry_digest_for_date(
+            closing_date=date(2025, 1, 31),
+        )
+
+        self.assertEqual(closing_entry.entity_model_id, entity_model.uuid)
+        self.assertEqual(closing_entry.closing_date, date(2025, 1, 31))
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_get_closing_entry_digest_for_month_uses_calendar_month_end(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 2, 15))
+
+        closing_entry, ce_txs = entity_model.get_closing_entry_digest_for_month(
+            year=2025,
+            month=2,
+        )
+
+        self.assertEqual(closing_entry.closing_date, date(2025, 2, 28))
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_create_closing_entry_for_date_persists_entry_and_transactions(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 1, 15))
+
+        closing_entry, ce_txs = entity_model.create_closing_entry_for_date(
+            closing_date=date(2025, 1, 31),
+        )
+        closing_entry.refresh_from_db()
+
+        self.assertEqual(closing_entry.entity_model_id, entity_model.uuid)
+        self.assertEqual(closing_entry.closing_date, date(2025, 1, 31))
+        self.assertFalse(closing_entry.posted)
+        self.assertIsNotNone(closing_entry.ledger_model_id)
+        self.assertEqual(closing_entry.closingentrytransactionmodel_set.count(), 2)
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_create_closing_entry_for_month_uses_month_end_date(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 2, 15))
+
+        closing_entry, ce_txs = entity_model.create_closing_entry_for_month(
+            year=2025,
+            month=2,
+        )
+
+        self.assertEqual(closing_entry.closing_date, date(2025, 2, 28))
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_create_closing_entry_for_fiscal_year_uses_entity_fiscal_year_end(self):
+        setup = self.create_entity_setup(
+            name="API Entity Closing Entry Fiscal Year Entity",
+            fy_start_month=4,
+        )
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 3, 15))
+
+        closing_entry, ce_txs = entity_model.create_closing_entry_for_fiscal_year(
+            fiscal_year=2024,
+        )
+
+        self.assertEqual(closing_entry.closing_date, date(2025, 3, 31))
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_close_entity_books_posts_entry_and_updates_closing_metadata(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 1, 15))
+
+        closing_entry, ce_txs = entity_model.close_entity_books(
+            closing_date=date(2025, 1, 31),
+        )
+        persisted_entity = EntityModel.objects.get(uuid=entity_model.uuid)
+        closing_entry.refresh_from_db()
+
+        self.assertTrue(closing_entry.posted)
+        self.assertEqual(closing_entry.closing_date, date(2025, 1, 31))
+        self.assertEqual(persisted_entity.last_closing_date, date(2025, 1, 31))
+        self.assertEqual(persisted_entity.fetch_closing_entry_dates_meta(), [date(2025, 1, 31)])
+        self.assertEqual(persisted_entity.fetch_closing_entry_dates_meta(as_date=False), ["2025-01-31"])
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_close_books_for_month_uses_month_end(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 2, 15))
+
+        closing_entry, ce_txs = entity_model.close_books_for_month(
+            year=2025,
+            month=2,
+        )
+
+        self.assertTrue(closing_entry.posted)
+        self.assertEqual(closing_entry.closing_date, date(2025, 2, 28))
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_close_books_for_fiscal_year_uses_non_calendar_fiscal_year_end(self):
+        setup = self.create_entity_setup(
+            name="API Entity Close Books Fiscal Year Entity",
+            fy_start_month=4,
+        )
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 3, 15))
+
+        closing_entry, ce_txs = entity_model.close_books_for_fiscal_year(
+            fiscal_year=2024,
+        )
+
+        self.assertTrue(closing_entry.posted)
+        self.assertEqual(closing_entry.closing_date, date(2025, 3, 31))
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
+    def test_closing_entry_date_lookup_helpers_use_saved_metadata(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        self.create_posted_closing_entry(entity_model, closing_date=date(2025, 6, 30))
+        self.create_posted_closing_entry(entity_model, closing_date=date(2025, 12, 31))
+
+        saved_dates = entity_model.save_closing_entry_dates_meta(commit=True)
+        entity_model.refresh_from_db()
+
+        self.assertEqual(saved_dates, [date(2025, 12, 31), date(2025, 6, 30)])
+        self.assertEqual(entity_model.last_closing_date, date(2025, 12, 31))
+        self.assertEqual(
+            entity_model.fetch_closing_entry_dates_meta(),
+            [date(2025, 12, 31), date(2025, 6, 30)],
+        )
+        self.assertEqual(
+            entity_model.fetch_closing_entry_dates_meta(as_date=False),
+            ["2025-12-31", "2025-06-30"],
+        )
+        self.assertEqual(
+            entity_model.get_closing_entry_for_date(date(2025, 12, 31)),
+            date(2025, 12, 31),
+        )
+        self.assertEqual(
+            entity_model.get_closing_entry_for_date(datetime(2025, 7, 1, 9, 0), inclusive=False),
+            date(2025, 6, 30),
+        )
+        self.assertEqual(
+            entity_model.get_nearest_next_closing_entry(date(2026, 1, 15)),
+            date(2025, 12, 31),
+        )
+        self.assertEqual(
+            entity_model.get_nearest_next_closing_entry(date(2025, 9, 1)),
+            date(2025, 6, 30),
+        )
+
+    def test_close_entity_books_validates_required_arguments(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        closing_entry = ClosingEntryModel(
+            entity_model=entity_model,
+            closing_date=date(2025, 1, 31),
+        )
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.close_entity_books()
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.close_entity_books(
+                closing_date=date(2025, 1, 31),
+                closing_entry_model=closing_entry,
+            )
+
+    def test_create_closing_entry_for_date_rejects_future_date(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.create_closing_entry_for_date(
+                closing_date=get_localdate() + timedelta(days=1),
+            )

--- a/django_ledger/tests/api/test_entity_closing_entry_api.py
+++ b/django_ledger/tests/api/test_entity_closing_entry_api.py
@@ -166,6 +166,21 @@ class EntityClosingEntryHighLevelAPITest(TestCase):
         self.assertEqual(closing_entry.closing_date, date(2025, 2, 28))
         self.assert_closing_transactions_match_activity(ce_txs, setup)
 
+    def test_get_closing_entry_digest_for_fiscal_year_uses_entity_fiscal_year_end(self):
+        setup = self.create_entity_setup(
+            name="API Entity Closing Entry Fiscal Digest Entity",
+            fy_start_month=4,
+        )
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2026, 3, 15))
+
+        closing_entry, ce_txs = entity_model.get_closing_entry_digest_for_fiscal_year(
+            fiscal_year=2025,
+        )
+
+        self.assertEqual(closing_entry.closing_date, date(2026, 3, 31))
+        self.assert_closing_transactions_match_activity(ce_txs, setup)
+
     def test_create_closing_entry_for_date_persists_entry_and_transactions(self):
         setup = self.create_entity_setup()
         entity_model = setup["entity_model"]

--- a/django_ledger/tests/api/test_entity_closing_entry_api.py
+++ b/django_ledger/tests/api/test_entity_closing_entry_api.py
@@ -244,6 +244,26 @@ class EntityClosingEntryHighLevelAPITest(TestCase):
         self.assertEqual(persisted_entity.fetch_closing_entry_dates_meta(as_date=False), ["2025-01-31"])
         self.assert_closing_transactions_match_activity(ce_txs, setup)
 
+    def test_close_entity_books_refreshes_same_instance_closing_date_cache(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        self.create_posted_activity(setup, tx_date=date(2025, 1, 15))
+
+        self.assertEqual(entity_model.fetch_closing_entry_dates_meta(), [])
+
+        closing_entry, _ce_txs = entity_model.close_entity_books(
+            closing_date=date(2025, 1, 31),
+        )
+        closing_entry.refresh_from_db()
+
+        self.assertTrue(closing_entry.posted)
+        self.assertEqual(entity_model.last_closing_date, date(2025, 1, 31))
+        self.assertEqual(
+            entity_model.meta[entity_model.META_KEY_CLOSING_ENTRY_DATES],
+            ["2025-01-31"],
+        )
+        self.assertEqual(entity_model.fetch_closing_entry_dates_meta(), [date(2025, 1, 31)])
+
     def test_close_books_for_month_uses_month_end(self):
         setup = self.create_entity_setup()
         entity_model = setup["entity_model"]

--- a/django_ledger/tests/api/test_entity_creation_api.py
+++ b/django_ledger/tests/api/test_entity_creation_api.py
@@ -14,6 +14,7 @@ from django.test import TestCase
 from django_ledger.models.entity import (
     EntityManagementModel,
     EntityModel,
+    EntityModelValidationError,
 )
 
 
@@ -68,6 +69,14 @@ class EntityCreationAPITest(TestCase):
     def assert_is_slug_with_random_suffix(self, slug, base_slug):
         self.assertRegex(slug, rf"^{re.escape(base_slug)}-[a-z0-9]{{8}}$")
 
+    def assert_entity_is_child_of_parent(self, child_entity, parent_entity):
+        child_entity.refresh_from_db()
+        parent_entity.refresh_from_db()
+
+        self.assertFalse(child_entity.is_root())
+        self.assertTrue(child_entity.is_child_of(parent_entity))
+        self.assertEqual(child_entity.get_parent().uuid, parent_entity.uuid)
+
     def test_create_root_entity_assigns_public_fields_and_tree_root(self):
         entity_model = self.create_entity(
             name="API Root Entity",
@@ -102,6 +111,63 @@ class EntityCreationAPITest(TestCase):
         self.assertTrue(cash_entity.is_cash_method())
         self.assertFalse(cash_entity.is_accrual_method())
         self.assertEqual(cash_entity.get_accrual_method(), EntityModel.CASH_METHOD)
+
+    def test_create_child_entity_accepts_parent_model_instance(self):
+        parent_entity = self.create_entity(name="API Parent Model Entity")
+
+        child_entity = self.create_entity(
+            name="API Child From Parent Model Entity",
+            parent_entity=parent_entity,
+        )
+
+        self.assert_entity_is_child_of_parent(child_entity, parent_entity)
+
+    def test_create_child_entity_accepts_parent_slug(self):
+        parent_entity = self.create_entity(name="API Parent Slug Entity")
+
+        child_entity = self.create_entity(
+            name="API Child From Parent Slug Entity",
+            parent_entity=parent_entity.slug,
+        )
+
+        self.assert_entity_is_child_of_parent(child_entity, parent_entity)
+
+    def test_create_child_entity_accepts_parent_uuid(self):
+        parent_entity = self.create_entity(name="API Parent UUID Entity")
+
+        child_entity = self.create_entity(
+            name="API Child From Parent UUID Entity",
+            parent_entity=parent_entity.uuid,
+        )
+
+        self.assert_entity_is_child_of_parent(child_entity, parent_entity)
+
+    def test_create_child_entity_rejects_parent_administered_by_other_user_without_side_effect(self):
+        parent_entity = self.create_entity(
+            name="API Other Admin Parent Entity",
+            admin=self.other_admin_user,
+        )
+
+        with self.assertRaises(EntityModelValidationError):
+            self.create_entity(
+                name="API Rejected Other Admin Child Entity",
+                parent_entity=parent_entity,
+            )
+
+        self.assertFalse(
+            EntityModel.objects.filter(name="API Rejected Other Admin Child Entity").exists()
+        )
+
+    def test_create_child_entity_rejects_invalid_parent_type_without_side_effect(self):
+        with self.assertRaises(EntityModelValidationError):
+            self.create_entity(
+                name="API Invalid Parent Type Child Entity",
+                parent_entity=object(),
+            )
+
+        self.assertFalse(
+            EntityModel.objects.filter(name="API Invalid Parent Type Child Entity").exists()
+        )
 
     def test_for_user_includes_admin_and_manager_entities_only(self):
         entity_model = self.create_entity(name="API Scoped Entity")

--- a/django_ledger/tests/api/test_entity_creation_api.py
+++ b/django_ledger/tests/api/test_entity_creation_api.py
@@ -1,0 +1,168 @@
+"""
+High-level API behavior tests for EntityModel creation and user scoping.
+
+These tests document deterministic entity creation, slug, accounting method,
+and access-scope behavior without requiring accounting fixtures.
+"""
+
+import re
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from django_ledger.models.entity import (
+    EntityManagementModel,
+    EntityModel,
+)
+
+
+class EntityCreationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_entity_creation_admin",
+            email="api-entity-creation-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_entity_creation_other_admin",
+            email="api-entity-creation-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_entity_creation_manager",
+            email="api-entity-creation-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_entity_creation_unrelated",
+            email="api-entity-creation-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_entity_creation_superuser",
+            email="api-entity-creation-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(
+        self,
+        *,
+        name="API Entity Creation Entity",
+        admin=None,
+        use_accrual_method=True,
+        fy_start_month=1,
+        parent_entity=None,
+    ):
+        return EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=use_accrual_method,
+            fy_start_month=fy_start_month,
+            parent_entity=parent_entity,
+        )
+
+    def assert_is_slug_with_random_suffix(self, slug, base_slug):
+        self.assertRegex(slug, rf"^{re.escape(base_slug)}-[a-z0-9]{{8}}$")
+
+    def test_create_root_entity_assigns_public_fields_and_tree_root(self):
+        entity_model = self.create_entity(
+            name="API Root Entity",
+            use_accrual_method=True,
+            fy_start_month=4,
+        )
+
+        self.assertIsNotNone(entity_model.uuid)
+        self.assertEqual(entity_model.name, "API Root Entity")
+        self.assertEqual(entity_model.admin_id, self.admin_user.id)
+        self.assertEqual(entity_model.fy_start_month, 4)
+        self.assertTrue(entity_model.accrual_method)
+        self.assert_is_slug_with_random_suffix(entity_model.slug, "api-root-entity")
+
+        self.assertTrue(entity_model.is_root())
+        self.assertEqual(entity_model.depth, 1)
+
+    def test_accrual_and_cash_method_helpers_reflect_entity_setting(self):
+        accrual_entity = self.create_entity(
+            name="API Accrual Entity",
+            use_accrual_method=True,
+        )
+        cash_entity = self.create_entity(
+            name="API Cash Entity",
+            use_accrual_method=False,
+        )
+
+        self.assertTrue(accrual_entity.is_accrual_method())
+        self.assertFalse(accrual_entity.is_cash_method())
+        self.assertEqual(accrual_entity.get_accrual_method(), EntityModel.ACCRUAL_METHOD)
+
+        self.assertTrue(cash_entity.is_cash_method())
+        self.assertFalse(cash_entity.is_accrual_method())
+        self.assertEqual(cash_entity.get_accrual_method(), EntityModel.CASH_METHOD)
+
+    def test_for_user_includes_admin_and_manager_entities_only(self):
+        entity_model = self.create_entity(name="API Scoped Entity")
+        other_entity = self.create_entity(
+            name="API Other Scoped Entity",
+            admin=self.other_admin_user,
+        )
+
+        EntityManagementModel.objects.create(
+            entity=entity_model,
+            user=self.manager_user,
+            permission_level="read",
+        )
+
+        admin_qs = EntityModel.objects.for_user(self.admin_user)
+        manager_qs = EntityModel.objects.for_user(self.manager_user)
+        unrelated_qs = EntityModel.objects.for_user(self.unrelated_user)
+
+        self.assertTrue(admin_qs.filter(uuid=entity_model.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_entity.uuid).exists())
+
+        self.assertTrue(manager_qs.filter(uuid=entity_model.uuid).exists())
+        self.assertFalse(manager_qs.filter(uuid=other_entity.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=entity_model.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_entity.uuid).exists())
+
+    def test_for_user_authorized_superuser_can_see_all_entities(self):
+        entity_model = self.create_entity(name="API Superuser Entity")
+        other_entity = self.create_entity(
+            name="API Other Superuser Entity",
+            admin=self.other_admin_user,
+        )
+
+        default_superuser_qs = EntityModel.objects.for_user(self.superuser)
+        authorized_superuser_qs = EntityModel.objects.for_user(
+            self.superuser,
+            authorized_superuser=True,
+        )
+
+        self.assertFalse(default_superuser_qs.filter(uuid=entity_model.uuid).exists())
+        self.assertFalse(default_superuser_qs.filter(uuid=other_entity.uuid).exists())
+
+        self.assertTrue(authorized_superuser_qs.filter(uuid=entity_model.uuid).exists())
+        self.assertTrue(authorized_superuser_qs.filter(uuid=other_entity.uuid).exists())
+
+    def test_generate_slug_from_name_slugifies_name_and_adds_suffix(self):
+        slug = EntityModel.generate_slug_from_name("API Slug Contract Entity")
+
+        self.assert_is_slug_with_random_suffix(slug, "api-slug-contract-entity")
+
+    def test_generate_slug_refuses_existing_slug_unless_forced(self):
+        entity_model = self.create_entity(name="API Force Slug Entity")
+        original_slug = entity_model.slug
+
+        with self.assertRaises(ValidationError):
+            entity_model.generate_slug()
+
+        self.assertEqual(entity_model.slug, original_slug)
+
+        forced_slug = entity_model.generate_slug(force_update=True)
+
+        self.assertEqual(entity_model.slug, forced_slug)
+        self.assert_is_slug_with_random_suffix(forced_slug, "api-force-slug-entity")

--- a/django_ledger/tests/api/test_entity_customer_vendor_api.py
+++ b/django_ledger/tests/api/test_entity_customer_vendor_api.py
@@ -1,0 +1,211 @@
+"""
+High-level API behavior tests for EntityModel customer and vendor wrappers.
+
+These tests cover entity-scoped commercial-party creation, lookup, active
+filtering, and customer validation without requiring accounting fixtures.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.entity import EntityModel, EntityModelValidationError
+
+
+class EntityCustomerVendorAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_entity_customer_vendor_admin",
+            email="api-entity-customer-vendor-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_entity_customer_vendor_other_admin",
+            email="api-entity-customer-vendor-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Entity Customer Vendor Entity", admin=None):
+        return EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_customer(self, entity_model, *, name="API Entity Customer", active=True):
+        return entity_model.create_customer(
+            {
+                "customer_name": name,
+                "description": f"{name} description",
+                "active": active,
+                "hidden": False,
+            }
+        )
+
+    def create_vendor(self, entity_model, *, name="API Entity Vendor", active=True):
+        return entity_model.create_vendor(
+            {
+                "vendor_name": name,
+                "description": f"{name} description",
+                "active": active,
+                "hidden": False,
+            }
+        )
+
+    def test_create_customer_creates_active_customer_with_generated_number(self):
+        entity_model = self.create_entity()
+
+        customer_model = self.create_customer(entity_model)
+
+        self.assertEqual(customer_model.entity_model_id, entity_model.uuid)
+        self.assertTrue(customer_model.active)
+        self.assertTrue(customer_model.customer_number)
+        self.assertIsInstance(customer_model.customer_number, str)
+
+    def test_create_vendor_creates_active_vendor_with_generated_number(self):
+        entity_model = self.create_entity()
+
+        vendor_model = self.create_vendor(entity_model)
+
+        self.assertEqual(vendor_model.entity_model_id, entity_model.uuid)
+        self.assertTrue(vendor_model.active)
+        self.assertTrue(vendor_model.vendor_number)
+        self.assertIsInstance(vendor_model.vendor_number, str)
+
+    def test_get_customers_is_entity_scoped_and_filters_inactive_by_default(self):
+        entity_model = self.create_entity(name="API Customer Scoped Entity")
+        other_entity = self.create_entity(
+            name="API Other Customer Scoped Entity",
+            admin=self.other_admin_user,
+        )
+
+        active_customer = self.create_customer(
+            entity_model,
+            name="API Active Entity Customer",
+        )
+        inactive_customer = self.create_customer(
+            entity_model,
+            name="API Inactive Entity Customer",
+            active=False,
+        )
+        other_customer = self.create_customer(
+            other_entity,
+            name="API Other Entity Customer",
+        )
+
+        default_customer_qs = entity_model.get_customers()
+        all_customer_qs = entity_model.get_customers(active=False)
+
+        self.assertTrue(default_customer_qs.filter(uuid=active_customer.uuid).exists())
+        self.assertFalse(default_customer_qs.filter(uuid=inactive_customer.uuid).exists())
+        self.assertFalse(default_customer_qs.filter(uuid=other_customer.uuid).exists())
+
+        self.assertTrue(all_customer_qs.filter(uuid=active_customer.uuid).exists())
+        self.assertTrue(all_customer_qs.filter(uuid=inactive_customer.uuid).exists())
+        self.assertFalse(all_customer_qs.filter(uuid=other_customer.uuid).exists())
+
+    def test_get_vendors_is_entity_scoped_and_filters_inactive_by_default(self):
+        entity_model = self.create_entity(name="API Vendor Scoped Entity")
+        other_entity = self.create_entity(
+            name="API Other Vendor Scoped Entity",
+            admin=self.other_admin_user,
+        )
+
+        active_vendor = self.create_vendor(
+            entity_model,
+            name="API Active Entity Vendor",
+        )
+        inactive_vendor = self.create_vendor(
+            entity_model,
+            name="API Inactive Entity Vendor",
+            active=False,
+        )
+        other_vendor = self.create_vendor(
+            other_entity,
+            name="API Other Entity Vendor",
+        )
+
+        default_vendor_qs = entity_model.get_vendors()
+        all_vendor_qs = entity_model.get_vendors(active=False)
+
+        self.assertTrue(default_vendor_qs.filter(uuid=active_vendor.uuid).exists())
+        self.assertFalse(default_vendor_qs.filter(uuid=inactive_vendor.uuid).exists())
+        self.assertFalse(default_vendor_qs.filter(uuid=other_vendor.uuid).exists())
+
+        self.assertTrue(all_vendor_qs.filter(uuid=active_vendor.uuid).exists())
+        self.assertTrue(all_vendor_qs.filter(uuid=inactive_vendor.uuid).exists())
+        self.assertFalse(all_vendor_qs.filter(uuid=other_vendor.uuid).exists())
+
+    def test_get_customer_by_number_and_uuid_return_expected_customer(self):
+        entity_model = self.create_entity(name="API Customer Lookup Entity")
+        other_entity = self.create_entity(
+            name="API Other Customer Lookup Entity",
+            admin=self.other_admin_user,
+        )
+
+        customer_model = self.create_customer(
+            entity_model,
+            name="API Lookup Entity Customer",
+        )
+        other_customer = self.create_customer(
+            other_entity,
+            name="API Other Lookup Entity Customer",
+        )
+
+        by_number = entity_model.get_customer_by_number(customer_model.customer_number)
+        by_uuid = entity_model.get_customer_by_uuid(str(customer_model.uuid))
+
+        self.assertEqual(by_number.uuid, customer_model.uuid)
+        self.assertEqual(by_uuid.uuid, customer_model.uuid)
+        self.assertFalse(
+            entity_model.get_customers().filter(uuid=other_customer.uuid).exists()
+        )
+
+    def test_get_vendor_by_number_and_uuid_return_expected_vendor(self):
+        entity_model = self.create_entity(name="API Vendor Lookup Entity")
+        other_entity = self.create_entity(
+            name="API Other Vendor Lookup Entity",
+            admin=self.other_admin_user,
+        )
+
+        vendor_model = self.create_vendor(
+            entity_model,
+            name="API Lookup Entity Vendor",
+        )
+        other_vendor = self.create_vendor(
+            other_entity,
+            name="API Other Lookup Entity Vendor",
+        )
+
+        by_number = entity_model.get_vendor_by_number(vendor_model.vendor_number)
+        by_uuid = entity_model.get_vendor_by_uuid(str(vendor_model.uuid))
+
+        self.assertEqual(by_number.uuid, vendor_model.uuid)
+        self.assertEqual(by_uuid.uuid, vendor_model.uuid)
+        self.assertFalse(
+            entity_model.get_vendors().filter(uuid=other_vendor.uuid).exists()
+        )
+
+    def test_validate_customer_accepts_same_entity_and_rejects_other_entity_customer(self):
+        entity_model = self.create_entity(name="API Customer Validation Entity")
+        other_entity = self.create_entity(
+            name="API Other Customer Validation Entity",
+            admin=self.other_admin_user,
+        )
+
+        customer_model = self.create_customer(
+            entity_model,
+            name="API Validated Entity Customer",
+        )
+        other_customer = self.create_customer(
+            other_entity,
+            name="API Rejected Entity Customer",
+        )
+
+        self.assertIsNone(entity_model.validate_customer(customer_model))
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.validate_customer(other_customer)

--- a/django_ledger/tests/api/test_entity_default_coa_helpers_api.py
+++ b/django_ledger/tests/api/test_entity_default_coa_helpers_api.py
@@ -1,0 +1,120 @@
+"""
+High-level API behavior tests for EntityModel default CoA helpers.
+
+These tests focus on EntityModel's public default Chart of Accounts helper
+behavior without re-testing CoA tree internals.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH
+from django_ledger.models.entity import EntityModel, EntityModelValidationError
+
+
+class EntityDefaultCoAHelpersAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_entity_default_coa_user",
+            email="api-entity-default-coa-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Entity Default CoA Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def test_entity_without_default_coa_reports_no_default(self):
+        entity_model = self.create_entity(name="API Entity Without Default CoA")
+
+        self.assertFalse(entity_model.has_default_coa())
+        self.assertIsNone(entity_model.get_default_coa(raise_exception=False))
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.get_default_coa()
+
+    def test_entity_with_assigned_default_coa_reports_default(self):
+        entity_model = self.create_entity(name="API Entity With Default CoA")
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Assigned Default CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        entity_model.refresh_from_db()
+        coa_model.refresh_from_db()
+
+        self.assertTrue(entity_model.has_default_coa())
+        self.assertEqual(entity_model.default_coa_id, coa_model.uuid)
+        self.assertEqual(entity_model.get_default_coa(), coa_model)
+        self.assertTrue(coa_model.is_default())
+
+    def test_non_default_coa_creation_does_not_change_default_helper_result(self):
+        entity_model = self.create_entity(name="API Entity Preserve Default CoA")
+        first_coa = entity_model.create_chart_of_accounts(
+            coa_name="API First Default CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        second_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Second Non Default CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        entity_model.refresh_from_db()
+        first_coa.refresh_from_db()
+        second_coa.refresh_from_db()
+
+        self.assertTrue(entity_model.has_default_coa())
+        self.assertEqual(entity_model.default_coa_id, first_coa.uuid)
+        self.assertEqual(entity_model.get_default_coa(), first_coa)
+        self.assertTrue(first_coa.is_default())
+        self.assertFalse(second_coa.is_default())
+
+    def test_get_default_coa_returns_current_default_after_default_changes(self):
+        entity_model = self.create_entity(name="API Entity Switch Default CoA")
+        first_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Switch First CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        second_coa = entity_model.create_chart_of_accounts(
+            coa_name="API Switch Second CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+
+        second_coa.mark_as_default(commit=True)
+
+        entity_model.refresh_from_db()
+        first_coa.refresh_from_db()
+        second_coa.refresh_from_db()
+
+        self.assertTrue(entity_model.has_default_coa())
+        self.assertEqual(entity_model.get_default_coa(), second_coa)
+        self.assertFalse(first_coa.is_default())
+        self.assertTrue(second_coa.is_default())
+
+    def test_default_coa_helpers_work_after_default_coa_population(self):
+        entity_model = self.create_entity(name="API Entity Populated Default CoA")
+
+        entity_model.populate_default_coa(activate_accounts=True)
+        entity_model.refresh_from_db()
+
+        coa_model = entity_model.get_default_coa()
+        cash_account = entity_model.get_default_coa_accounts(active=True).get(code="1010")
+
+        self.assertTrue(entity_model.has_default_coa())
+        self.assertTrue(coa_model.is_configured())
+        self.assertEqual(cash_account.role, ASSET_CA_CASH)
+        self.assertEqual(cash_account.coa_model_id, coa_model.uuid)

--- a/django_ledger/tests/api/test_entity_factory_api.py
+++ b/django_ledger/tests/api/test_entity_factory_api.py
@@ -1,0 +1,389 @@
+"""
+High-level API behavior tests for EntityModel document factories.
+
+These tests exercise EntityModel.create_* convenience APIs directly, rather
+than lower-level document configure hooks.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import BillModel, EstimateModel, InvoiceModel, PurchaseOrderModel
+from django_ledger.models.entity import EntityModel, EntityModelValidationError
+
+
+class EntityFactoryAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_entity_factory_user",
+            email="api-entity-factory-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Entity Factory Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        deferred_revenue_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        customer_model = entity_model.create_customer(
+            {
+                "customer_name": f"{name} Customer",
+                "description": f"{name} customer",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "payable_account": payable_account,
+            "receivable_account": receivable_account,
+            "deferred_revenue_account": deferred_revenue_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+        }
+
+    def test_document_factories_create_draft_documents_for_entity(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        bill_model = entity_model.create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            date_draft=date(2026, 1, 15),
+            ledger_name="API Factory Bill Ledger",
+            commit=True,
+        )
+        invoice_model = entity_model.create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            date_draft=date(2026, 1, 15),
+            ledger_name="API Factory Invoice Ledger",
+            commit=True,
+        )
+        estimate_model = entity_model.create_estimate(
+            estimate_title="API Factory Estimate",
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=setup["customer_model"],
+            commit=True,
+        )
+        po_model = entity_model.create_purchase_order(
+            po_title="API Factory Purchase Order",
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        self.assertTrue(bill_model.is_draft())
+        self.assertEqual(bill_model.vendor_id, setup["vendor_model"].uuid)
+        self.assertEqual(bill_model.ledger.entity_id, entity_model.uuid)
+        self.assertEqual(bill_model.ledger.name, "API Factory Bill Ledger")
+        self.assertEqual(bill_model.cash_account_id, setup["cash_account"].uuid)
+        self.assertEqual(bill_model.prepaid_account_id, setup["prepaid_account"].uuid)
+        self.assertEqual(bill_model.unearned_account_id, setup["payable_account"].uuid)
+        self.assertTrue(bill_model.bill_number)
+
+        self.assertTrue(invoice_model.is_draft())
+        self.assertEqual(invoice_model.customer_id, setup["customer_model"].uuid)
+        self.assertEqual(invoice_model.ledger.entity_id, entity_model.uuid)
+        self.assertEqual(invoice_model.ledger.name, "API Factory Invoice Ledger")
+        self.assertEqual(invoice_model.cash_account_id, setup["cash_account"].uuid)
+        self.assertEqual(invoice_model.prepaid_account_id, setup["receivable_account"].uuid)
+        self.assertEqual(invoice_model.unearned_account_id, setup["deferred_revenue_account"].uuid)
+        self.assertTrue(invoice_model.invoice_number)
+
+        self.assertTrue(estimate_model.is_draft())
+        self.assertEqual(estimate_model.entity_id, entity_model.uuid)
+        self.assertEqual(estimate_model.customer_id, setup["customer_model"].uuid)
+        self.assertEqual(estimate_model.title, "API Factory Estimate")
+        self.assertTrue(estimate_model.estimate_number)
+
+        self.assertTrue(po_model.is_draft())
+        self.assertEqual(po_model.entity_id, entity_model.uuid)
+        self.assertEqual(po_model.po_title, "API Factory Purchase Order")
+        self.assertEqual(po_model.date_draft, date(2026, 1, 15))
+        self.assertTrue(po_model.po_number)
+
+    def test_bill_factory_accepts_vendor_uuid_and_number(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        vendor_model = setup["vendor_model"]
+
+        bill_from_uuid = entity_model.create_bill(
+            vendor_model=vendor_model.uuid,
+            terms=BillModel.TERMS_NET_30,
+            commit=True,
+        )
+        bill_from_number = entity_model.create_bill(
+            vendor_model=vendor_model.vendor_number,
+            terms=BillModel.TERMS_NET_30,
+            commit=True,
+        )
+
+        self.assertEqual(bill_from_uuid.vendor_id, vendor_model.uuid)
+        self.assertEqual(bill_from_number.vendor_id, vendor_model.uuid)
+        self.assertTrue(bill_from_uuid.bill_number)
+        self.assertTrue(bill_from_number.bill_number)
+
+    def test_invoice_and_estimate_factories_accept_customer_uuid_and_number(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        customer_model = setup["customer_model"]
+
+        invoice_from_uuid = entity_model.create_invoice(
+            customer_model=customer_model.uuid,
+            terms=InvoiceModel.TERMS_NET_30,
+            commit=True,
+        )
+        invoice_from_number = entity_model.create_invoice(
+            customer_model=customer_model.customer_number,
+            terms=InvoiceModel.TERMS_NET_30,
+            commit=True,
+        )
+        estimate_from_uuid = entity_model.create_estimate(
+            estimate_title="API Estimate From UUID",
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=customer_model.uuid,
+            commit=True,
+        )
+        estimate_from_number = entity_model.create_estimate(
+            estimate_title="API Estimate From Number",
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=customer_model.customer_number,
+            commit=True,
+        )
+
+        self.assertEqual(invoice_from_uuid.customer_id, customer_model.uuid)
+        self.assertEqual(invoice_from_number.customer_id, customer_model.uuid)
+        self.assertTrue(invoice_from_uuid.invoice_number)
+        self.assertTrue(invoice_from_number.invoice_number)
+
+        self.assertEqual(estimate_from_uuid.customer_id, customer_model.uuid)
+        self.assertEqual(estimate_from_number.customer_id, customer_model.uuid)
+        self.assertTrue(estimate_from_uuid.estimate_number)
+        self.assertTrue(estimate_from_number.estimate_number)
+
+    def test_bill_and_invoice_factories_respect_explicit_account_arguments(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        coa_model = setup["coa_model"]
+
+        explicit_bill_cash = coa_model.create_account(
+            code="1020",
+            name="API Explicit Bill Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        explicit_bill_prepaid = coa_model.create_account(
+            code="1320",
+            name="API Explicit Bill Prepaid",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+        )
+        explicit_bill_payable = coa_model.create_account(
+            code="2020",
+            name="API Explicit Bill Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+        )
+        explicit_invoice_cash = coa_model.create_account(
+            code="1030",
+            name="API Explicit Invoice Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        explicit_invoice_receivable = coa_model.create_account(
+            code="1220",
+            name="API Explicit Invoice Receivable",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+        )
+        explicit_invoice_deferred = coa_model.create_account(
+            code="2320",
+            name="API Explicit Invoice Deferred",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+        )
+
+        bill_model = entity_model.create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            cash_account=explicit_bill_cash,
+            prepaid_account=explicit_bill_prepaid,
+            payable_account=explicit_bill_payable,
+            commit=True,
+        )
+        invoice_model = entity_model.create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            cash_account=explicit_invoice_cash,
+            prepaid_account=explicit_invoice_receivable,
+            payable_account=explicit_invoice_deferred,
+            commit=True,
+        )
+
+        self.assertEqual(bill_model.cash_account_id, explicit_bill_cash.uuid)
+        self.assertEqual(bill_model.prepaid_account_id, explicit_bill_prepaid.uuid)
+        self.assertEqual(bill_model.unearned_account_id, explicit_bill_payable.uuid)
+
+        self.assertEqual(invoice_model.cash_account_id, explicit_invoice_cash.uuid)
+        self.assertEqual(invoice_model.prepaid_account_id, explicit_invoice_receivable.uuid)
+        self.assertEqual(invoice_model.unearned_account_id, explicit_invoice_deferred.uuid)
+
+    def test_document_factories_reject_cross_entity_parties(self):
+        setup = self.create_entity_setup(name="API Factory Entity A")
+        other_setup = self.create_entity_setup(name="API Factory Entity B")
+        entity_model = setup["entity_model"]
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.create_bill(
+                vendor_model=other_setup["vendor_model"],
+                terms=BillModel.TERMS_NET_30,
+                commit=True,
+            )
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.create_invoice(
+                customer_model=other_setup["customer_model"],
+                terms=InvoiceModel.TERMS_NET_30,
+                commit=True,
+            )
+
+        with self.assertRaises(EntityModelValidationError):
+            entity_model.create_estimate(
+                estimate_title="API Cross Entity Estimate",
+                contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+                customer_model=other_setup["customer_model"],
+                commit=True,
+            )
+
+    def test_document_getters_are_entity_scoped(self):
+        setup = self.create_entity_setup(name="API Factory Getter Entity A")
+        other_setup = self.create_entity_setup(name="API Factory Getter Entity B")
+
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            commit=True,
+        )
+        other_bill_model = other_setup["entity_model"].create_bill(
+            vendor_model=other_setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            commit=True,
+        )
+
+        invoice_model = setup["entity_model"].create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            commit=True,
+        )
+        other_invoice_model = other_setup["entity_model"].create_invoice(
+            customer_model=other_setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            commit=True,
+        )
+
+        estimate_model = setup["entity_model"].create_estimate(
+            estimate_title="API Getter Estimate",
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=setup["customer_model"],
+            commit=True,
+        )
+        other_estimate_model = other_setup["entity_model"].create_estimate(
+            estimate_title="API Other Getter Estimate",
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=other_setup["customer_model"],
+            commit=True,
+        )
+
+        po_model = setup["entity_model"].create_purchase_order(
+            po_title="API Getter PO",
+            commit=True,
+        )
+        other_po_model = other_setup["entity_model"].create_purchase_order(
+            po_title="API Other Getter PO",
+            commit=True,
+        )
+
+        self.assertTrue(setup["entity_model"].get_bills().filter(uuid=bill_model.uuid).exists())
+        self.assertFalse(setup["entity_model"].get_bills().filter(uuid=other_bill_model.uuid).exists())
+
+        self.assertTrue(setup["entity_model"].get_invoices().filter(uuid=invoice_model.uuid).exists())
+        self.assertFalse(setup["entity_model"].get_invoices().filter(uuid=other_invoice_model.uuid).exists())
+
+        self.assertTrue(setup["entity_model"].get_estimates().filter(uuid=estimate_model.uuid).exists())
+        self.assertFalse(setup["entity_model"].get_estimates().filter(uuid=other_estimate_model.uuid).exists())
+
+        self.assertTrue(setup["entity_model"].get_purchase_orders().filter(uuid=po_model.uuid).exists())
+        self.assertFalse(setup["entity_model"].get_purchase_orders().filter(uuid=other_po_model.uuid).exists())

--- a/django_ledger/tests/api/test_entity_fiscal_period_api.py
+++ b/django_ledger/tests/api/test_entity_fiscal_period_api.py
@@ -1,0 +1,123 @@
+"""
+High-level API behavior tests for EntityModel fiscal period helpers.
+
+These tests document deterministic fiscal-year and fiscal-quarter behavior
+without requiring accounting fixtures.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from django_ledger.models.entity import EntityModel
+
+
+class EntityFiscalPeriodAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_entity_fiscal_period_user",
+            email="api-entity-fiscal-period-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Fiscal Period Entity", fy_start_month=1):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=fy_start_month,
+        )
+
+    def test_get_fy_start_month_returns_entity_setting(self):
+        entity_model = self.create_entity(fy_start_month=4)
+
+        self.assertEqual(entity_model.get_fy_start_month(), 4)
+
+    def test_calendar_fiscal_year_start_end_and_date_lookup(self):
+        entity_model = self.create_entity(fy_start_month=1)
+
+        self.assertEqual(entity_model.get_fy_start(2026), date(2026, 1, 1))
+        self.assertEqual(entity_model.get_fy_end(2026), date(2026, 12, 31))
+
+        self.assertEqual(entity_model.get_fy_for_date(date(2026, 1, 1)), 2026)
+        self.assertEqual(entity_model.get_fy_for_date(date(2026, 12, 31)), 2026)
+        self.assertEqual(entity_model.get_fy_for_date(date(2026, 6, 15), as_str=True), "2026")
+
+    def test_april_fiscal_year_start_end_and_date_lookup(self):
+        entity_model = self.create_entity(fy_start_month=4)
+
+        self.assertEqual(entity_model.get_fy_start(2026), date(2026, 4, 1))
+        self.assertEqual(entity_model.get_fy_end(2026), date(2027, 3, 31))
+
+        self.assertEqual(entity_model.get_fy_for_date(date(2026, 3, 31)), 2025)
+        self.assertEqual(entity_model.get_fy_for_date(date(2026, 4, 1)), 2026)
+        self.assertEqual(entity_model.get_fy_for_date(date(2027, 3, 31)), 2026)
+        self.assertEqual(entity_model.get_fy_for_date(date(2026, 4, 1), as_str=True), "2026")
+
+    def test_explicit_fiscal_year_start_month_override_uses_requested_calendar(self):
+        entity_model = self.create_entity(fy_start_month=4)
+
+        self.assertEqual(entity_model.get_fy_start(2026, fy_start_month=1), date(2026, 1, 1))
+        self.assertEqual(entity_model.get_fy_end(2026, fy_start_month=1), date(2026, 12, 31))
+        self.assertEqual(
+            entity_model.get_fiscal_year_dates(2026, fy_start_month=1),
+            (date(2026, 1, 1), date(2026, 12, 31)),
+        )
+
+    def test_fiscal_year_end_uses_last_day_of_leap_year_february(self):
+        entity_model = self.create_entity(fy_start_month=3)
+
+        self.assertEqual(entity_model.get_fy_start(2023), date(2023, 3, 1))
+        self.assertEqual(entity_model.get_fy_end(2023), date(2024, 2, 29))
+
+    def test_april_fiscal_quarters_roll_across_calendar_year(self):
+        entity_model = self.create_entity(fy_start_month=4)
+
+        self.assertEqual(entity_model.get_quarter_start(2026, 1), date(2026, 4, 1))
+        self.assertEqual(entity_model.get_quarter_end(2026, 1), date(2026, 6, 30))
+
+        self.assertEqual(entity_model.get_quarter_start(2026, 2), date(2026, 7, 1))
+        self.assertEqual(entity_model.get_quarter_end(2026, 2), date(2026, 9, 30))
+
+        self.assertEqual(entity_model.get_quarter_start(2026, 3), date(2026, 10, 1))
+        self.assertEqual(entity_model.get_quarter_end(2026, 3), date(2026, 12, 31))
+
+        self.assertEqual(entity_model.get_quarter_start(2026, 4), date(2027, 1, 1))
+        self.assertEqual(entity_model.get_quarter_end(2026, 4), date(2027, 3, 31))
+
+    def test_fiscal_year_and_quarter_date_helpers_return_ranges(self):
+        entity_model = self.create_entity(fy_start_month=4)
+
+        self.assertEqual(
+            entity_model.get_fiscal_year_dates(2026),
+            (date(2026, 4, 1), date(2027, 3, 31)),
+        )
+        self.assertEqual(
+            entity_model.get_fiscal_quarter_dates(2026, 4),
+            (date(2027, 1, 1), date(2027, 3, 31)),
+        )
+
+    def test_invalid_month_and_quarter_raise_validation_error(self):
+        entity_model = self.create_entity(fy_start_month=4)
+
+        with self.assertRaises(ValidationError):
+            entity_model.validate_month(0)
+
+        with self.assertRaises(ValidationError):
+            entity_model.validate_month(13)
+
+        with self.assertRaises(ValidationError):
+            entity_model.validate_quarter(0)
+
+        with self.assertRaises(ValidationError):
+            entity_model.validate_quarter(5)
+
+        with self.assertRaises(ValidationError):
+            entity_model.get_fy_start(2026, fy_start_month=13)
+
+        with self.assertRaises(ValidationError):
+            entity_model.get_fiscal_quarter_dates(2026, 5)

--- a/django_ledger/tests/api/test_entity_inventory_api.py
+++ b/django_ledger/tests/api/test_entity_inventory_api.py
@@ -1,0 +1,388 @@
+"""High-level API behavior tests for EntityModel inventory helpers."""
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io.roles import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    COGS,
+    CREDIT,
+    DEBIT,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel, ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.entity import EntityModel, EntityModelValidationError
+from django_ledger.models.items import ItemModel
+
+
+class EntityInventoryHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for EntityModel inventory helper APIs.
+
+    These tests use direct, deterministic item and item-transaction setup where
+    possible so the inventory helper contracts stay visible.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_entity_inventory_user",
+            email="api-entity-inventory-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Entity Inventory Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = entity_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = entity_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = entity_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = entity_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type=CREDIT,
+            active=True,
+            is_role_default=True,
+        )
+        cogs_account = entity_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        earnings_account = entity_model.create_account(
+            code="4010",
+            name=f"{name} Earnings Account",
+            role=INCOME_OPERATIONAL,
+            balance_type=CREDIT,
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = entity_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"inv-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": "API inventory vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "inventory_account": inventory_account,
+            "payable_account": payable_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+            "vendor_model": vendor_model,
+        }
+
+    def create_inventory_item(
+        self,
+        setup,
+        *,
+        name="API Inventory Item",
+        inventory_received=None,
+        inventory_received_value=None,
+    ):
+        item_model = setup["entity_model"].create_item_inventory(
+            name=name,
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=setup["uom_model"],
+            inventory_account=setup["inventory_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        if inventory_received is not None or inventory_received_value is not None:
+            item_model.inventory_received = inventory_received
+            item_model.inventory_received_value = inventory_received_value
+            item_model.save(update_fields=["inventory_received", "inventory_received_value", "updated"])
+            item_model.refresh_from_db()
+
+        return item_model
+
+    def create_product_item(self, setup, *, name="API Product Item"):
+        return setup["entity_model"].create_item_product(
+            name=name,
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=setup["uom_model"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+    def create_expense_item(self, setup, *, name="API Expense Item"):
+        return setup["entity_model"].create_item_expense(
+            name=name,
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=setup["uom_model"],
+            expense_account=setup["expense_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+    def create_received_inventory_line(
+        self,
+        setup,
+        item_model,
+        *,
+        quantity=Decimal("3.000"),
+        unit_cost=Decimal("20.00"),
+    ):
+        entity_model = setup["entity_model"]
+        po_model = entity_model.create_purchase_order(
+            po_title="API Inventory Purchase Order",
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        po_model.po_status = PurchaseOrderModel.PO_STATUS_APPROVED
+        po_model.date_approved = date(2025, 1, 16)
+        po_model.save(update_fields=["po_status", "date_approved", "updated"])
+
+        bill_model = entity_model.create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_ON_RECEIPT,
+            date_draft=date(2025, 1, 17),
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            payable_account=setup["payable_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        item_tx = ItemTransactionModel(
+            item_model=item_model,
+            po_model=po_model,
+            bill_model=bill_model,
+            po_quantity=float(quantity),
+            po_unit_cost=float(unit_cost),
+            po_item_status=ItemTransactionModel.STATUS_RECEIVED,
+            quantity=float(quantity),
+            unit_cost=float(unit_cost),
+        )
+        item_tx.clean()
+        item_tx.save()
+        item_tx.refresh_from_db()
+
+        return po_model, bill_model, item_tx
+
+    def test_inventory_adjustment_reports_counted_recorded_and_combined_differences(self):
+        counted_only_uuid = uuid4()
+        recorded_only_uuid = uuid4()
+        combined_uuid = uuid4()
+
+        counted_qs = [
+            {
+                "item_model_id": counted_only_uuid,
+                "item_model__name": "Counted Only",
+                "item_model__uom__name": "Each",
+                "quantity_onhand": Decimal("5.000"),
+                "value_onhand": Decimal("50.00"),
+                "cost_average": Decimal("10.00"),
+            },
+            {
+                "item_model_id": combined_uuid,
+                "item_model__name": "Combined",
+                "item_model__uom__name": "Each",
+                "quantity_onhand": Decimal("8.000"),
+                "value_onhand": Decimal("96.00"),
+                "cost_average": Decimal("12.00"),
+            },
+        ]
+        recorded_qs = [
+            {
+                "uuid": recorded_only_uuid,
+                "name": "Recorded Only",
+                "uom__name": "Each",
+                "inventory_received": Decimal("2.000"),
+                "inventory_received_value": Decimal("30.00"),
+            },
+            {
+                "uuid": combined_uuid,
+                "name": "Combined",
+                "uom__name": "Each",
+                "inventory_received": Decimal("3.000"),
+                "inventory_received_value": Decimal("30.00"),
+            },
+        ]
+
+        adjustment = EntityModel.inventory_adjustment(counted_qs, recorded_qs)
+
+        counted_only = adjustment[(counted_only_uuid, "Counted Only", "Each")]
+        recorded_only = adjustment[(recorded_only_uuid, "Recorded Only", "Each")]
+        combined = adjustment[(combined_uuid, "Combined", "Each")]
+
+        self.assertEqual(counted_only["count_diff"], Decimal("5.000"))
+        self.assertEqual(counted_only["value_diff"], Decimal("50.00"))
+        self.assertEqual(recorded_only["count_diff"], Decimal("-2.000"))
+        self.assertEqual(recorded_only["value_diff"], Decimal("-30.00"))
+        self.assertEqual(combined["count_diff"], Decimal("5.000"))
+        self.assertEqual(combined["value_diff"], Decimal("66.00"))
+
+    def test_inventory_query_helpers_expose_inventory_and_wip_items(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        inventory_item = self.create_inventory_item(setup, name="API WIP Inventory Item")
+        product_item = self.create_product_item(setup)
+        expense_item = self.create_expense_item(setup)
+
+        inventory_qs = entity_model.get_items_inventory()
+        wip_qs = entity_model.get_items_inventory_wip()
+
+        self.assertTrue(inventory_qs.filter(uuid=inventory_item.uuid).exists())
+        self.assertTrue(inventory_qs.filter(uuid=product_item.uuid).exists())
+        self.assertFalse(inventory_qs.filter(uuid=expense_item.uuid).exists())
+
+        self.assertTrue(wip_qs.filter(uuid=inventory_item.uuid).exists())
+        self.assertFalse(wip_qs.filter(uuid=product_item.uuid).exists())
+        self.assertFalse(wip_qs.filter(uuid=expense_item.uuid).exists())
+
+    def test_recorded_inventory_returns_values_or_item_queryset(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        item_model = self.create_inventory_item(
+            setup,
+            inventory_received=Decimal("4.000"),
+            inventory_received_value=Decimal("44.00"),
+        )
+
+        values_qs = entity_model.recorded_inventory(as_values=True)
+        model_qs = entity_model.recorded_inventory(as_values=False)
+
+        values = values_qs.get(uuid=item_model.uuid)
+        self.assertEqual(values["name"], item_model.name)
+        self.assertEqual(values["uom__name"], setup["uom_model"].name)
+        self.assertEqual(values["inventory_received"], Decimal("4.000"))
+        self.assertEqual(values["inventory_received_value"], Decimal("44.00"))
+
+        self.assertTrue(model_qs.filter(uuid=item_model.uuid).exists())
+        self.assertIsInstance(model_qs.get(uuid=item_model.uuid), ItemModel)
+
+    def test_update_inventory_commit_false_returns_adjustments_without_persisting(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        item_model = self.create_inventory_item(setup)
+        self.create_received_inventory_line(setup, item_model)
+
+        adjustment, counted_qs, recorded_qs = entity_model.update_inventory(commit=False)
+
+        item_key = (item_model.uuid, item_model.name, setup["uom_model"].name)
+        self.assertEqual(counted_qs.count(), 1)
+        self.assertTrue(recorded_qs.filter(uuid=item_model.uuid).exists())
+        self.assertEqual(adjustment[item_key]["counted"], Decimal("3"))
+        self.assertEqual(adjustment[item_key]["counted_value"], Decimal("60"))
+
+        item_model.refresh_from_db()
+        self.assertIsNone(item_model.inventory_received)
+        self.assertIsNone(item_model.inventory_received_value)
+
+    def test_update_inventory_commit_true_updates_recorded_inventory_fields(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+        item_model = self.create_inventory_item(setup)
+        self.create_received_inventory_line(
+            setup,
+            item_model,
+            quantity=Decimal("5.000"),
+            unit_cost=Decimal("12.00"),
+        )
+
+        adjustment, counted_qs, recorded_qs = entity_model.update_inventory(commit=True)
+
+        item_key = (item_model.uuid, item_model.name, setup["uom_model"].name)
+        self.assertEqual(counted_qs.count(), 1)
+        self.assertTrue(recorded_qs.filter(uuid=item_model.uuid).exists())
+        self.assertEqual(adjustment[item_key]["counted"], Decimal("5"))
+        self.assertEqual(adjustment[item_key]["counted_value"], Decimal("60"))
+
+        item_model.refresh_from_db()
+        self.assertEqual(item_model.inventory_received, Decimal("5.000"))
+        self.assertEqual(item_model.inventory_received_value, Decimal("60.00"))
+
+    def test_validate_item_qs_rejects_items_from_another_entity(self):
+        setup = self.create_entity_setup(name="API Inventory Entity A")
+        other_setup = self.create_entity_setup(name="API Inventory Entity B")
+
+        item_model = self.create_inventory_item(setup, name="API Entity A Inventory Item")
+        other_item_model = self.create_inventory_item(other_setup, name="API Entity B Inventory Item")
+
+        same_entity_qs = ItemModel.objects.filter(uuid=item_model.uuid)
+        mixed_entity_qs = ItemModel.objects.filter(uuid__in=[item_model.uuid, other_item_model.uuid])
+
+        self.assertTrue(setup["entity_model"].validate_item_qs(same_entity_qs))
+        self.assertFalse(
+            setup["entity_model"].validate_item_qs(
+                mixed_entity_qs,
+                raise_exception=False,
+            )
+        )
+
+        with self.assertRaises(EntityModelValidationError):
+            setup["entity_model"].validate_item_qs(mixed_entity_qs)

--- a/django_ledger/tests/api/test_entity_state_api.py
+++ b/django_ledger/tests/api/test_entity_state_api.py
@@ -1,14 +1,11 @@
 """
 High-level API behavior tests for EntityStateModel numbering state contracts.
 
-This file is part of a human-reviewed, AI-assisted contribution using
-OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
-coverage around Django Ledger's public/high-level API contracts without
-replacing or reorganizing the existing test suite.
+These tests document deterministic, user-visible numbering behavior and the
+state scoping that backs it.
 """
 
 from datetime import date, datetime
-from decimal import Decimal
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
@@ -27,6 +24,7 @@ from django_ledger.models.customer import CustomerModel
 from django_ledger.models.entity import EntityModel, EntityStateModel
 from django_ledger.models.items import ItemModel
 from django_ledger.models.vendor import VendorModel
+from django_ledger.settings import DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING
 
 
 class EntityStateHighLevelAPITest(TestCase):
@@ -53,12 +51,12 @@ class EntityStateHighLevelAPITest(TestCase):
             return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
         return datetime(2026, 1, 15, 12, 0)
 
-    def create_entity_setup(self, *, name="API Entity State Contract Entity"):
+    def create_entity_setup(self, *, name="API Entity State Contract Entity", fy_start_month=1):
         entity_model = EntityModel.create_entity(
             name=name,
             admin=self.user,
             use_accrual_method=True,
-            fy_start_month=1,
+            fy_start_month=fy_start_month,
         )
 
         coa_model = entity_model.create_chart_of_accounts(
@@ -242,7 +240,7 @@ class EntityStateHighLevelAPITest(TestCase):
             commit=True,
         )
 
-    def create_bill(self, setup):
+    def create_bill(self, setup, *, date_draft=date(2026, 1, 15)):
         bill_model = BillModel(
             vendor=setup["vendor_model"],
             cash_account=setup["cash_account"],
@@ -253,13 +251,13 @@ class EntityStateHighLevelAPITest(TestCase):
         _ledger_model, bill_model = bill_model.configure(
             entity_slug=setup["entity_model"],
             user_model=self.user,
-            date_draft=date(2026, 1, 15),
+            date_draft=date_draft,
             commit=True,
         )
 
         return bill_model
 
-    def create_invoice(self, setup):
+    def create_invoice(self, setup, *, date_draft=date(2026, 1, 15)):
         invoice_model = InvoiceModel(
             customer=setup["customer_model"],
             cash_account=setup["cash_account"],
@@ -270,13 +268,13 @@ class EntityStateHighLevelAPITest(TestCase):
         _ledger_model, invoice_model = invoice_model.configure(
             entity_slug=setup["entity_model"],
             user_model=self.user,
-            date_draft=date(2026, 1, 15),
+            date_draft=date_draft,
             commit=True,
         )
 
         return invoice_model
 
-    def create_estimate(self, setup):
+    def create_estimate(self, setup, *, date_draft=date(2026, 1, 15)):
         estimate_model = EstimateModel(
             terms=EstimateModel.CONTRACT_TERMS_FIXED,
         )
@@ -285,27 +283,27 @@ class EntityStateHighLevelAPITest(TestCase):
             entity_slug=setup["entity_model"],
             customer_model=setup["customer_model"],
             user_model=self.user,
-            date_draft=date(2026, 1, 15),
+            date_draft=date_draft,
             estimate_title="API Entity State Estimate",
             commit=True,
         )
 
         return estimate_model
 
-    def create_purchase_order(self, setup):
+    def create_purchase_order(self, setup, *, draft_date=date(2026, 1, 15)):
         po_model = PurchaseOrderModel()
 
         po_model.configure(
             entity_slug=setup["entity_model"],
             po_title="API Entity State Purchase Order",
             user_model=self.user,
-            draft_date=date(2026, 1, 15),
+            draft_date=draft_date,
             commit=True,
         )
 
         return po_model
 
-    def create_journal_entry(self, setup):
+    def create_journal_entry(self, setup, *, timestamp=None):
         ledger_model, _created = LedgerModel.objects.get_or_create(
             entity=setup["entity_model"],
             ledger_xid="api-entity-state-ledger",
@@ -316,7 +314,7 @@ class EntityStateHighLevelAPITest(TestCase):
 
         journal_entry = JournalEntryModel.objects.create(
             ledger=ledger_model,
-            timestamp=self.make_timestamp(),
+            timestamp=timestamp if timestamp is not None else self.make_timestamp(),
             description="API Entity State Journal Entry",
         )
 
@@ -333,26 +331,31 @@ class EntityStateHighLevelAPITest(TestCase):
             key=key,
         )
 
-    def test_entity_state_key_constants_are_public_contract(self):
-        self.assertEqual(EntityStateModel.KEY_JOURNAL_ENTRY, "je")
-        self.assertEqual(EntityStateModel.KEY_PURCHASE_ORDER, "po")
-        self.assertEqual(EntityStateModel.KEY_BILL, "bill")
-        self.assertEqual(EntityStateModel.KEY_INVOICE, "invoice")
-        self.assertEqual(EntityStateModel.KEY_ESTIMATE, "estimate")
-        self.assertEqual(EntityStateModel.KEY_VENDOR, "vendor")
-        self.assertEqual(EntityStateModel.KEY_CUSTOMER, "customer")
-        self.assertEqual(EntityStateModel.KEY_ITEM, "item")
-        self.assertEqual(EntityStateModel.KEY_RECEIPT, "receipt")
+    def assert_number_ends_with_sequence(self, number, sequence):
+        self.assertTrue(number)
+        self.assertTrue(number.endswith(str(sequence).zfill(DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING)))
 
     def test_customer_vendor_and_item_states_are_entity_scoped_without_fiscal_year(self):
         setup = self.create_entity_setup()
 
-        self.create_customer(setup, suffix="A")
-        self.create_customer(setup, suffix="B")
-        self.create_vendor(setup, suffix="A")
-        self.create_vendor(setup, suffix="B")
-        self.create_service_item(setup, suffix="A")
-        self.create_service_item(setup, suffix="B")
+        customer_a = self.create_customer(setup, suffix="A")
+        customer_b = self.create_customer(setup, suffix="B")
+        vendor_a = self.create_vendor(setup, suffix="A")
+        vendor_b = self.create_vendor(setup, suffix="B")
+        service_item_a = self.create_service_item(setup, suffix="A")
+        service_item_b = self.create_service_item(setup, suffix="B")
+
+        self.assertNotEqual(customer_a.customer_number, customer_b.customer_number)
+        self.assert_number_ends_with_sequence(customer_a.customer_number, 2)
+        self.assert_number_ends_with_sequence(customer_b.customer_number, 3)
+
+        self.assertNotEqual(vendor_a.vendor_number, vendor_b.vendor_number)
+        self.assert_number_ends_with_sequence(vendor_a.vendor_number, 2)
+        self.assert_number_ends_with_sequence(vendor_b.vendor_number, 3)
+
+        self.assertNotEqual(service_item_a.item_number, service_item_b.item_number)
+        self.assert_number_ends_with_sequence(service_item_a.item_number, 3)
+        self.assert_number_ends_with_sequence(service_item_b.item_number, 4)
 
         customer_state = self.get_state(
             setup,
@@ -384,21 +387,45 @@ class EntityStateHighLevelAPITest(TestCase):
         self.assertIsNone(item_state.entity_unit_id)
         self.assertIsNone(item_state.fiscal_year)
 
-    def test_document_states_are_entity_and_fiscal_year_scoped(self):
+    def test_document_numbers_advance_by_document_type_and_fiscal_year(self):
         setup = self.create_entity_setup()
         fy_key = setup["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
 
-        self.create_bill(setup)
-        self.create_bill(setup)
+        bill_a = self.create_bill(setup)
+        bill_b = self.create_bill(setup)
 
-        self.create_invoice(setup)
-        self.create_invoice(setup)
+        invoice_a = self.create_invoice(setup)
+        invoice_b = self.create_invoice(setup)
 
-        self.create_estimate(setup)
-        self.create_estimate(setup)
+        estimate_a = self.create_estimate(setup)
+        estimate_b = self.create_estimate(setup)
 
-        self.create_purchase_order(setup)
-        self.create_purchase_order(setup)
+        po_a = self.create_purchase_order(setup)
+        po_b = self.create_purchase_order(setup)
+
+        self.assertNotEqual(bill_a.bill_number, bill_b.bill_number)
+        self.assertIn(f"-{fy_key}-", bill_a.bill_number)
+        self.assertIn(f"-{fy_key}-", bill_b.bill_number)
+        self.assert_number_ends_with_sequence(bill_a.bill_number, 1)
+        self.assert_number_ends_with_sequence(bill_b.bill_number, 2)
+
+        self.assertNotEqual(invoice_a.invoice_number, invoice_b.invoice_number)
+        self.assertIn(f"-{fy_key}-", invoice_a.invoice_number)
+        self.assertIn(f"-{fy_key}-", invoice_b.invoice_number)
+        self.assert_number_ends_with_sequence(invoice_a.invoice_number, 1)
+        self.assert_number_ends_with_sequence(invoice_b.invoice_number, 2)
+
+        self.assertNotEqual(estimate_a.estimate_number, estimate_b.estimate_number)
+        self.assertIn(f"-{fy_key}-", estimate_a.estimate_number)
+        self.assertIn(f"-{fy_key}-", estimate_b.estimate_number)
+        self.assert_number_ends_with_sequence(estimate_a.estimate_number, 1)
+        self.assert_number_ends_with_sequence(estimate_b.estimate_number, 2)
+
+        self.assertNotEqual(po_a.po_number, po_b.po_number)
+        self.assertIn(f"-{fy_key}-", po_a.po_number)
+        self.assertIn(f"-{fy_key}-", po_b.po_number)
+        self.assert_number_ends_with_sequence(po_a.po_number, 1)
+        self.assert_number_ends_with_sequence(po_b.po_number, 2)
 
         bill_state = self.get_state(
             setup,
@@ -431,15 +458,20 @@ class EntityStateHighLevelAPITest(TestCase):
         self.assertIsNone(estimate_state.entity_unit_id)
         self.assertIsNone(po_state.entity_unit_id)
 
-    def test_document_state_sequences_are_isolated_by_entity(self):
+    def test_document_numbers_start_independently_per_entity(self):
         setup_a = self.create_entity_setup(name="API Entity State A")
         setup_b = self.create_entity_setup(name="API Entity State B")
 
         fy_a = setup_a["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
         fy_b = setup_b["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
 
-        self.create_bill(setup_a)
-        self.create_bill(setup_b)
+        bill_a = self.create_bill(setup_a)
+        bill_b = self.create_bill(setup_b)
+
+        self.assertIn(f"-{fy_a}-", bill_a.bill_number)
+        self.assertIn(f"-{fy_b}-", bill_b.bill_number)
+        self.assert_number_ends_with_sequence(bill_a.bill_number, 1)
+        self.assert_number_ends_with_sequence(bill_b.bill_number, 1)
 
         bill_state_a = self.get_state(
             setup_a,
@@ -456,12 +488,61 @@ class EntityStateHighLevelAPITest(TestCase):
         self.assertEqual(bill_state_b.sequence, 1)
         self.assertNotEqual(bill_state_a.entity_model_id, bill_state_b.entity_model_id)
 
-    def test_journal_entry_state_uses_journal_entry_key_and_fiscal_year(self):
+    def test_document_numbering_resets_across_non_calendar_fiscal_year(self):
+        setup = self.create_entity_setup(fy_start_month=4)
+
+        march_bill = self.create_bill(setup, date_draft=date(2026, 3, 31))
+        april_bill_a = self.create_bill(setup, date_draft=date(2026, 4, 1))
+        april_bill_b = self.create_bill(setup, date_draft=date(2026, 4, 2))
+
+        march_fy = setup["entity_model"].get_fy_for_date(dt=date(2026, 3, 31))
+        april_fy = setup["entity_model"].get_fy_for_date(dt=date(2026, 4, 1))
+
+        self.assertEqual(march_fy, 2025)
+        self.assertEqual(april_fy, 2026)
+
+        self.assertIn(f"-{march_fy}-", march_bill.bill_number)
+        self.assert_number_ends_with_sequence(march_bill.bill_number, 1)
+
+        self.assertIn(f"-{april_fy}-", april_bill_a.bill_number)
+        self.assertIn(f"-{april_fy}-", april_bill_b.bill_number)
+        self.assertNotEqual(april_bill_a.bill_number, april_bill_b.bill_number)
+        self.assert_number_ends_with_sequence(april_bill_a.bill_number, 1)
+        self.assert_number_ends_with_sequence(april_bill_b.bill_number, 2)
+
+        march_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_BILL,
+            fiscal_year=march_fy,
+        )
+        april_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_BILL,
+            fiscal_year=april_fy,
+        )
+
+        bill_state_count = EntityStateModel.objects.filter(
+            entity_model=setup["entity_model"],
+            entity_unit=None,
+            key=EntityStateModel.KEY_BILL,
+        ).count()
+
+        self.assertEqual(bill_state_count, 2)
+        self.assertEqual(march_state.sequence, 1)
+        self.assertEqual(april_state.sequence, 2)
+
+    def test_journal_entry_numbers_advance_by_fiscal_year_without_entity_unit(self):
         setup = self.create_entity_setup()
         fy_key = setup["entity_model"].get_fy_for_date(dt=self.make_timestamp())
 
-        self.create_journal_entry(setup)
-        self.create_journal_entry(setup)
+        journal_entry_a = self.create_journal_entry(setup)
+        journal_entry_b = self.create_journal_entry(setup)
+
+        self.assertNotEqual(journal_entry_a.je_number, journal_entry_b.je_number)
+        self.assertIn(f"-{fy_key}-", journal_entry_a.je_number)
+        self.assertIn(f"-{fy_key}-", journal_entry_b.je_number)
+        self.assert_number_ends_with_sequence(journal_entry_a.je_number, 1)
+        self.assert_number_ends_with_sequence(journal_entry_b.je_number, 2)
 
         je_state = self.get_state(
             setup,

--- a/django_ledger/tests/api/test_entity_state_api.py
+++ b/django_ledger/tests/api/test_entity_state_api.py
@@ -1,0 +1,473 @@
+"""
+High-level API behavior tests for EntityStateModel numbering state contracts.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import (
+    BillModel,
+    EstimateModel,
+    InvoiceModel,
+    JournalEntryModel,
+    LedgerModel,
+    PurchaseOrderModel,
+)
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel, EntityStateModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class EntityStateHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for EntityStateModel sequence contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic state/sequence invariants that should
+    remain true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_entity_state_contract_user",
+            email="api-entity-state-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Entity State Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        accounts_payable = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        unearned_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Unearned Revenue Account",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr="state",
+            active=True,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "prepaid_account": prepaid_account,
+            "inventory_account": inventory_account,
+            "accounts_payable": accounts_payable,
+            "unearned_account": unearned_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "service_item": service_item,
+            "expense_item": expense_item,
+        }
+
+    def create_customer(self, setup, *, suffix):
+        customer_model = CustomerModel(
+            customer_name=f"API Entity State Customer {suffix}",
+            entity_model=setup["entity_model"],
+            description=f"API Entity State Customer {suffix} description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_vendor(self, setup, *, suffix):
+        vendor_model = VendorModel(
+            vendor_name=f"API Entity State Vendor {suffix}",
+            entity_model=setup["entity_model"],
+            description=f"API Entity State Vendor {suffix} description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        return vendor_model
+
+    def create_service_item(self, setup, *, suffix):
+        return setup["entity_model"].create_item_service(
+            name=f"API Entity State Service Item {suffix}",
+            uom_model=setup["uom_model"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+    def create_bill(self, setup):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["accounts_payable"],
+        )
+
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return bill_model
+
+    def create_invoice(self, setup):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["unearned_account"],
+        )
+
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return invoice_model
+
+    def create_estimate(self, setup):
+        estimate_model = EstimateModel(
+            terms=EstimateModel.CONTRACT_TERMS_FIXED,
+        )
+
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            estimate_title="API Entity State Estimate",
+            commit=True,
+        )
+
+        return estimate_model
+
+    def create_purchase_order(self, setup):
+        po_model = PurchaseOrderModel()
+
+        po_model.configure(
+            entity_slug=setup["entity_model"],
+            po_title="API Entity State Purchase Order",
+            user_model=self.user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return po_model
+
+    def create_journal_entry(self, setup):
+        ledger_model, _created = LedgerModel.objects.get_or_create(
+            entity=setup["entity_model"],
+            ledger_xid="api-entity-state-ledger",
+            defaults={
+                "name": "API Entity State Ledger",
+            },
+        )
+
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API Entity State Journal Entry",
+        )
+
+        journal_entry.generate_je_number(commit=True)
+        journal_entry.refresh_from_db()
+
+        return journal_entry
+
+    def get_state(self, setup, *, key, fiscal_year=None, entity_unit=None):
+        return EntityStateModel.objects.get(
+            entity_model=setup["entity_model"],
+            entity_unit=entity_unit,
+            fiscal_year=fiscal_year,
+            key=key,
+        )
+
+    def test_entity_state_key_constants_are_public_contract(self):
+        self.assertEqual(EntityStateModel.KEY_JOURNAL_ENTRY, "je")
+        self.assertEqual(EntityStateModel.KEY_PURCHASE_ORDER, "po")
+        self.assertEqual(EntityStateModel.KEY_BILL, "bill")
+        self.assertEqual(EntityStateModel.KEY_INVOICE, "invoice")
+        self.assertEqual(EntityStateModel.KEY_ESTIMATE, "estimate")
+        self.assertEqual(EntityStateModel.KEY_VENDOR, "vendor")
+        self.assertEqual(EntityStateModel.KEY_CUSTOMER, "customer")
+        self.assertEqual(EntityStateModel.KEY_ITEM, "item")
+        self.assertEqual(EntityStateModel.KEY_RECEIPT, "receipt")
+
+    def test_customer_vendor_and_item_states_are_entity_scoped_without_fiscal_year(self):
+        setup = self.create_entity_setup()
+
+        self.create_customer(setup, suffix="A")
+        self.create_customer(setup, suffix="B")
+        self.create_vendor(setup, suffix="A")
+        self.create_vendor(setup, suffix="B")
+        self.create_service_item(setup, suffix="A")
+        self.create_service_item(setup, suffix="B")
+
+        customer_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_CUSTOMER,
+            fiscal_year=None,
+        )
+        vendor_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_VENDOR,
+            fiscal_year=None,
+        )
+        item_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_ITEM,
+            fiscal_year=None,
+        )
+
+        # setup already creates one customer, one vendor and one service item.
+        self.assertEqual(customer_state.sequence, 3)
+        self.assertEqual(vendor_state.sequence, 3)
+
+        # setup creates service + expense items, then this test creates 2 more.
+        self.assertEqual(item_state.sequence, 4)
+
+        self.assertIsNone(customer_state.entity_unit_id)
+        self.assertIsNone(customer_state.fiscal_year)
+        self.assertIsNone(vendor_state.entity_unit_id)
+        self.assertIsNone(vendor_state.fiscal_year)
+        self.assertIsNone(item_state.entity_unit_id)
+        self.assertIsNone(item_state.fiscal_year)
+
+    def test_document_states_are_entity_and_fiscal_year_scoped(self):
+        setup = self.create_entity_setup()
+        fy_key = setup["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
+
+        self.create_bill(setup)
+        self.create_bill(setup)
+
+        self.create_invoice(setup)
+        self.create_invoice(setup)
+
+        self.create_estimate(setup)
+        self.create_estimate(setup)
+
+        self.create_purchase_order(setup)
+        self.create_purchase_order(setup)
+
+        bill_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_BILL,
+            fiscal_year=fy_key,
+        )
+        invoice_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_INVOICE,
+            fiscal_year=fy_key,
+        )
+        estimate_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_ESTIMATE,
+            fiscal_year=fy_key,
+        )
+        po_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_PURCHASE_ORDER,
+            fiscal_year=fy_key,
+        )
+
+        self.assertEqual(bill_state.sequence, 2)
+        self.assertEqual(invoice_state.sequence, 2)
+        self.assertEqual(estimate_state.sequence, 2)
+        self.assertEqual(po_state.sequence, 2)
+
+        self.assertIsNone(bill_state.entity_unit_id)
+        self.assertIsNone(invoice_state.entity_unit_id)
+        self.assertIsNone(estimate_state.entity_unit_id)
+        self.assertIsNone(po_state.entity_unit_id)
+
+    def test_document_state_sequences_are_isolated_by_entity(self):
+        setup_a = self.create_entity_setup(name="API Entity State A")
+        setup_b = self.create_entity_setup(name="API Entity State B")
+
+        fy_a = setup_a["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
+        fy_b = setup_b["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
+
+        self.create_bill(setup_a)
+        self.create_bill(setup_b)
+
+        bill_state_a = self.get_state(
+            setup_a,
+            key=EntityStateModel.KEY_BILL,
+            fiscal_year=fy_a,
+        )
+        bill_state_b = self.get_state(
+            setup_b,
+            key=EntityStateModel.KEY_BILL,
+            fiscal_year=fy_b,
+        )
+
+        self.assertEqual(bill_state_a.sequence, 1)
+        self.assertEqual(bill_state_b.sequence, 1)
+        self.assertNotEqual(bill_state_a.entity_model_id, bill_state_b.entity_model_id)
+
+    def test_journal_entry_state_uses_journal_entry_key_and_fiscal_year(self):
+        setup = self.create_entity_setup()
+        fy_key = setup["entity_model"].get_fy_for_date(dt=self.make_timestamp())
+
+        self.create_journal_entry(setup)
+        self.create_journal_entry(setup)
+
+        je_state = self.get_state(
+            setup,
+            key=EntityStateModel.KEY_JOURNAL_ENTRY,
+            fiscal_year=fy_key,
+        )
+
+        self.assertEqual(je_state.sequence, 2)
+        self.assertIsNone(je_state.entity_unit_id)

--- a/django_ledger/tests/api/test_entity_unit_api.py
+++ b/django_ledger/tests/api/test_entity_unit_api.py
@@ -1,0 +1,286 @@
+"""
+High-level API behavior tests for EntityUnitModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityModel, EntityStateModel
+from django_ledger.models.unit import EntityUnitModel, EntityUnitModelValidationError
+
+
+class EntityUnitHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for EntityUnitModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic entity-unit invariants that should
+    remain true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_entity_unit_contract_user",
+            email="api-entity-unit-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Entity Unit Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        return {
+            "entity_model": entity_model,
+        }
+
+    def create_unit(
+        self,
+        setup,
+        *,
+        name="API Entity Unit",
+        slug="api-entity-unit",
+        document_prefix="AEU",
+        active=True,
+        hidden=False,
+    ):
+        unit_model = EntityUnitModel.add_root(
+            name=name,
+            slug=slug,
+            entity=setup["entity_model"],
+            document_prefix=document_prefix,
+            active=active,
+            hidden=hidden,
+        )
+
+        unit_model.refresh_from_db()
+        return unit_model
+
+    def create_ledger(self, setup):
+        ledger_model, _created = LedgerModel.objects.get_or_create(
+            entity=setup["entity_model"],
+            ledger_xid="api-entity-unit-ledger",
+            defaults={
+                "name": "API Entity Unit Ledger",
+            },
+        )
+
+        return ledger_model
+
+    def create_journal_entry(self, setup, *, unit_model=None):
+        ledger_model = self.create_ledger(setup)
+
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            entity_unit=unit_model,
+            timestamp=self.make_timestamp(),
+            description="API Entity Unit Journal Entry",
+        )
+
+        journal_entry.generate_je_number(commit=True)
+        journal_entry.refresh_from_db()
+
+        return journal_entry
+
+    def get_je_state(self, setup, *, unit_model=None):
+        fy_key = setup["entity_model"].get_fy_for_date(dt=self.make_timestamp())
+
+        return EntityStateModel.objects.get(
+            entity_model=setup["entity_model"],
+            entity_unit=unit_model,
+            fiscal_year=fy_key,
+            key=EntityStateModel.KEY_JOURNAL_ENTRY,
+        )
+
+    def test_entity_unit_creation_binds_entity_and_preserves_public_fields(self):
+        setup = self.create_entity_setup()
+
+        unit_model = self.create_unit(setup)
+
+        self.assertIsInstance(unit_model, EntityUnitModel)
+        self.assertIsNotNone(unit_model.uuid)
+        self.assertEqual(unit_model.entity_id, setup["entity_model"].uuid)
+        self.assertEqual(unit_model.name, "API Entity Unit")
+        self.assertEqual(unit_model.slug, "api-entity-unit")
+        self.assertEqual(unit_model.document_prefix, "AEU")
+        self.assertTrue(unit_model.active)
+        self.assertFalse(unit_model.hidden)
+
+    def test_entity_unit_for_entity_limits_queryset_to_entity_scope(self):
+        setup = self.create_entity_setup(name="API Entity Unit Entity A")
+        other_setup = self.create_entity_setup(name="API Entity Unit Entity B")
+
+        unit_model = self.create_unit(
+            setup,
+            name="API Unit A",
+            slug="api-unit-a",
+            document_prefix="AUA",
+        )
+
+        other_unit_model = self.create_unit(
+            other_setup,
+            name="API Unit B",
+            slug="api-unit-b",
+            document_prefix="AUB",
+        )
+
+        scoped_qs = EntityUnitModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=unit_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_unit_model.uuid).exists())
+
+    def test_entity_unit_for_entity_accepts_slug_and_uuid(self):
+        setup = self.create_entity_setup()
+
+        unit_model = self.create_unit(setup)
+
+        by_slug_qs = EntityUnitModel.objects.for_entity(setup["entity_model"].slug)
+        by_uuid_qs = EntityUnitModel.objects.for_entity(setup["entity_model"].uuid)
+
+        self.assertTrue(by_slug_qs.filter(uuid=unit_model.uuid).exists())
+        self.assertTrue(by_uuid_qs.filter(uuid=unit_model.uuid).exists())
+
+    def test_entity_unit_for_entity_rejects_invalid_input(self):
+        with self.assertRaises(EntityUnitModelValidationError):
+            EntityUnitModel.objects.for_entity(None)
+
+    def test_entity_unit_validate_for_entity_accepts_matching_entity_variants(self):
+        setup = self.create_entity_setup()
+
+        unit_model = self.create_unit(setup)
+
+        unit_model.validate_for_entity(setup["entity_model"])
+        unit_model.validate_for_entity(setup["entity_model"].uuid)
+        unit_model.validate_for_entity(setup["entity_model"].slug)
+
+    def test_entity_unit_validate_for_entity_rejects_mismatched_entity(self):
+        setup = self.create_entity_setup(name="API Entity Unit Entity A")
+        other_setup = self.create_entity_setup(name="API Entity Unit Entity B")
+
+        unit_model = self.create_unit(setup)
+
+        with self.assertRaises(EntityUnitModelValidationError):
+            unit_model.validate_for_entity(other_setup["entity_model"])
+
+    def test_entity_unit_document_prefix_is_unique_within_entity(self):
+        setup = self.create_entity_setup()
+
+        self.create_unit(
+            setup,
+            name="API Unit A",
+            slug="api-unit-a",
+            document_prefix="DUP",
+        )
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                self.create_unit(
+                    setup,
+                    name="API Unit B",
+                    slug="api-unit-b",
+                    document_prefix="DUP",
+                )
+
+    def test_entity_unit_slug_is_unique_within_entity(self):
+        setup = self.create_entity_setup()
+
+        self.create_unit(
+            setup,
+            name="API Unit A",
+            slug="api-unit",
+            document_prefix="AUA",
+        )
+
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                self.create_unit(
+                    setup,
+                    name="API Unit B",
+                    slug="api-unit",
+                    document_prefix="AUB",
+                )
+
+    def test_entity_unit_clean_generates_slug_and_document_prefix_when_missing(self):
+        setup = self.create_entity_setup()
+
+        unit_model = EntityUnitModel.add_root(
+            name="API Generated Unit",
+            entity=setup["entity_model"],
+        )
+
+        unit_model.clean()
+        unit_model.save()
+        unit_model.refresh_from_db()
+
+        self.assertTrue(unit_model.slug)
+        self.assertTrue(unit_model.slug.startswith("api-generated-unit"))
+        self.assertTrue(unit_model.document_prefix)
+        self.assertEqual(len(unit_model.document_prefix), 3)
+
+    def test_journal_entry_numbering_state_is_scoped_by_entity_unit(self):
+        setup = self.create_entity_setup()
+
+        unit_a = self.create_unit(
+            setup,
+            name="API Unit A",
+            slug="api-unit-a",
+            document_prefix="AUA",
+        )
+
+        unit_b = self.create_unit(
+            setup,
+            name="API Unit B",
+            slug="api-unit-b",
+            document_prefix="AUB",
+        )
+
+        self.create_journal_entry(setup, unit_model=unit_a)
+        self.create_journal_entry(setup, unit_model=unit_a)
+        self.create_journal_entry(setup, unit_model=unit_b)
+
+        state_a = self.get_je_state(setup, unit_model=unit_a)
+        state_b = self.get_je_state(setup, unit_model=unit_b)
+
+        self.assertEqual(state_a.sequence, 2)
+        self.assertEqual(state_b.sequence, 1)
+        self.assertEqual(state_a.entity_unit_id, unit_a.uuid)
+        self.assertEqual(state_b.entity_unit_id, unit_b.uuid)
+
+    def test_journal_entry_numbering_state_separates_unit_and_no_unit_sequences(self):
+        setup = self.create_entity_setup()
+
+        unit_model = self.create_unit(setup)
+
+        self.create_journal_entry(setup, unit_model=unit_model)
+        self.create_journal_entry(setup, unit_model=None)
+
+        unit_state = self.get_je_state(setup, unit_model=unit_model)
+        no_unit_state = self.get_je_state(setup, unit_model=None)
+
+        self.assertEqual(unit_state.sequence, 1)
+        self.assertEqual(no_unit_state.sequence, 1)
+        self.assertEqual(unit_state.entity_unit_id, unit_model.uuid)
+        self.assertIsNone(no_unit_state.entity_unit_id)

--- a/django_ledger/tests/api/test_entity_url_helpers_api.py
+++ b/django_ledger/tests/api/test_entity_url_helpers_api.py
@@ -1,0 +1,64 @@
+"""
+Smoke tests for EntityModel URL helper methods.
+
+These tests verify that model URL helpers resolve to entity-scoped URL strings
+without exercising view permissions or HTTP responses.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.entity import EntityModel
+
+
+class EntityURLHelpersAPITest(TestCase):
+    URL_HELPERS = (
+        "get_absolute_url",
+        "get_dashboard_url",
+        "get_manage_url",
+        "get_ledgers_url",
+        "get_bills_url",
+        "get_invoices_url",
+        "get_banks_url",
+        "get_balance_sheet_url",
+        "get_income_statement_url",
+        "get_cashflow_statement_url",
+        "get_data_import_url",
+        "get_coa_list_url",
+        "get_coa_list_inactive_url",
+        "get_coa_create_url",
+        "get_accounts_url",
+        "get_customers_url",
+        "get_vendors_url",
+        "get_delete_url",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_entity_url_helpers_admin",
+            email="api-entity-url-helpers-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.entity_model = EntityModel.create_entity(
+            name="API Entity URL Helpers Entity",
+            admin=cls.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        cls.entity_model.create_chart_of_accounts(
+            coa_name="API Entity URL Helpers CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+    def test_url_helpers_return_entity_scoped_urls(self):
+        for helper_name in self.URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(self.entity_model, helper_name)()
+
+                self.assertIsInstance(url, str)
+                self.assertTrue(url)
+                self.assertIn(self.entity_model.slug, url)

--- a/django_ledger/tests/api/test_estimate_amounts_url_signal_api.py
+++ b/django_ledger/tests/api/test_estimate_amounts_url_signal_api.py
@@ -1,0 +1,314 @@
+"""
+Smoke tests for EstimateModel amount, URL, display, and signal behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_INVENTORY,
+    COGS,
+    INCOME_OPERATIONAL,
+)
+from django_ledger.models import EstimateModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.signals import (
+    estimate_status_approved,
+    estimate_status_canceled,
+    estimate_status_completed,
+    estimate_status_draft,
+    estimate_status_in_review,
+    estimate_status_void,
+)
+
+
+class EstimateAmountsURLSignalAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_estimate_amount_url_signal_user",
+            email="api-estimate-amount-url-signal-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Estimate Amount URL Signal Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"Unit {str(entity_model.uuid)[:8]}",
+            unit_abbr=f"e-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} customer.",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+        }
+
+    def create_estimate(self, setup, *, title="API Estimate Amount URL Signal Contract"):
+        estimate_model = setup["entity_model"].create_estimate(
+            estimate_title=title,
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=setup["customer_model"],
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_service_item(self, estimate_model, setup, *, quantity="1.00", unit_cost="100.00", unit_revenue="150.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        unit_revenue = Decimal(unit_revenue)
+        estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "unit_revenue": unit_revenue,
+                    "total_amount": quantity * unit_revenue,
+                }
+            },
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_review_estimate(self, setup):
+        estimate_model = self.migrate_service_item(self.create_estimate(setup), setup)
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_approved_estimate(self, setup):
+        estimate_model = self.make_review_estimate(setup)
+        estimate_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def collect_signal_calls(self, signal):
+        calls = []
+        dispatch_uid = f"{self.id()}-{id(signal)}"
+
+        def receiver(sender, **kwargs):
+            calls.append(kwargs)
+
+        signal.connect(
+            receiver,
+            sender=EstimateModel,
+            weak=False,
+            dispatch_uid=dispatch_uid,
+        )
+        self.addCleanup(
+            signal.disconnect,
+            sender=EstimateModel,
+            dispatch_uid=dispatch_uid,
+        )
+        return calls
+
+    def assert_signal_received_once(self, calls, estimate_model, *, commit):
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0]["instance"], estimate_model)
+        self.assertEqual(calls[0]["commited"], commit)
+
+    def assert_entity_estimate_url(self, url, setup, estimate_model):
+        self.assertIsInstance(url, str)
+        self.assertIn(setup["entity_model"].slug, url)
+        self.assertIn(str(estimate_model.uuid), url)
+
+    def test_amount_helpers_calculate_cost_revenue_profit_and_markup_style_margin(self):
+        setup = self.create_entity_setup(name="API Estimate Amount Helper Entity")
+        estimate_model = self.migrate_service_item(self.create_estimate(setup), setup)
+
+        self.assertEqual(estimate_model.get_cost_estimate(), Decimal("100.00"))
+        self.assertEqual(estimate_model.get_revenue_estimate(), Decimal("150.00"))
+        self.assertEqual(estimate_model.get_profit_estimate(), Decimal("50.00"))
+        self.assertEqual(estimate_model.get_cost_estimate(as_float=True), 100.0)
+        self.assertEqual(estimate_model.get_revenue_estimate(as_float=True), 150.0)
+        self.assertEqual(estimate_model.get_profit_estimate(as_float=True), 50.0)
+        self.assertAlmostEqual(estimate_model.get_gross_margin_estimate(), 0.5)
+        self.assertAlmostEqual(estimate_model.get_gross_margin_estimate(as_percent=True), 50.0)
+
+    def test_update_cost_and_revenue_estimate_use_item_transaction_totals(self):
+        setup = self.create_entity_setup(name="API Estimate Amount Update Entity")
+        estimate_model = self.migrate_service_item(self.create_estimate(setup), setup)
+        itemtxs_qs, _itemtxs_data = estimate_model.get_itemtxs_data()
+
+        estimate_model.revenue_estimate = Decimal("0.00")
+        estimate_model.labor_estimate = Decimal("0.00")
+        estimate_model.update_revenue_estimate(itemtxs_qs=itemtxs_qs)
+        estimate_model.update_cost_estimate(itemtxs_qs=itemtxs_qs)
+
+        self.assertEqual(estimate_model.revenue_estimate, Decimal("150.00"))
+        self.assertEqual(estimate_model.labor_estimate, Decimal("100.00"))
+
+    def test_contract_summary_returns_estimate_amounts_and_zero_downstream_aggregates(self):
+        setup = self.create_entity_setup(name="API Estimate Contract Summary Entity")
+        estimate_model = self.make_approved_estimate(setup)
+
+        summary = estimate_model.get_contract_summary()
+
+        self.assertEqual(summary["cost_estimate"], 100.0)
+        self.assertEqual(summary["revenue_estimate"], 150.0)
+        self.assertEqual(float(summary["po_amount__sum"]), 0.0)
+        self.assertEqual(float(summary["bill_amount_due__sum"]), 0.0)
+        self.assertEqual(float(summary["invoice_amount_due__sum"]), 0.0)
+
+    def test_url_helpers_return_entity_scoped_strings(self):
+        setup = self.create_entity_setup(name="API Estimate URL Helper Entity")
+        estimate_model = self.create_estimate(setup)
+
+        url_helpers = [
+            estimate_model.get_mark_as_draft_url,
+            estimate_model.get_mark_as_review_url,
+            estimate_model.get_mark_as_approved_url,
+            estimate_model.get_mark_as_completed_url,
+            estimate_model.get_mark_as_canceled_url,
+            estimate_model.get_mark_as_void_url,
+        ]
+
+        for helper in url_helpers:
+            self.assert_entity_estimate_url(helper(), setup, estimate_model)
+
+    def test_display_message_and_html_helpers_include_stable_context(self):
+        setup = self.create_entity_setup(name="API Estimate Display Helper Entity")
+        estimate_model = self.create_estimate(setup)
+
+        self.assertIn(estimate_model.estimate_number, str(estimate_model))
+        self.assertIn(estimate_model.title, str(estimate_model))
+        self.assertTrue(str(estimate_model).startswith("Estimate "))
+
+        approved_estimate = self.make_approved_estimate(setup)
+        self.assertTrue(str(approved_estimate).startswith("Contract "))
+
+        html_helpers = [
+            estimate_model.get_html_id,
+            estimate_model.get_mark_as_draft_html_id,
+            estimate_model.get_mark_as_review_html_id,
+            estimate_model.get_mark_as_approved_html_id,
+            estimate_model.get_mark_as_completed_html_id,
+            estimate_model.get_mark_as_canceled_html_id,
+            estimate_model.get_mark_as_void_html_id,
+        ]
+        for helper in html_helpers:
+            self.assertIn(str(estimate_model.uuid), helper())
+
+        message_helpers = [
+            estimate_model.get_mark_as_draft_message,
+            estimate_model.get_mark_as_review_message,
+            estimate_model.get_mark_as_approved_message,
+            estimate_model.get_mark_as_completed_message,
+            estimate_model.get_mark_as_canceled_message,
+            estimate_model.get_mark_as_void_message,
+        ]
+        for helper in message_helpers:
+            self.assertIn(estimate_model.estimate_number, helper())
+
+    def test_mark_as_review_emits_estimate_status_in_review_signal(self):
+        setup = self.create_entity_setup(name="API Estimate Review Signal Entity")
+        estimate_model = self.migrate_service_item(self.create_estimate(setup), setup)
+        calls = self.collect_signal_calls(estimate_status_in_review)
+
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        self.assert_signal_received_once(calls, estimate_model, commit=True)
+
+    def test_mark_as_draft_emits_estimate_status_draft_signal(self):
+        setup = self.create_entity_setup(name="API Estimate Draft Signal Entity")
+        estimate_model = self.make_review_estimate(setup)
+        calls = self.collect_signal_calls(estimate_status_draft)
+
+        estimate_model.mark_as_draft(commit=True)
+
+        self.assert_signal_received_once(calls, estimate_model, commit=True)
+
+    def test_mark_as_approved_emits_estimate_status_approved_signal(self):
+        setup = self.create_entity_setup(name="API Estimate Approved Signal Entity")
+        estimate_model = self.make_review_estimate(setup)
+        calls = self.collect_signal_calls(estimate_status_approved)
+
+        estimate_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+
+        self.assert_signal_received_once(calls, estimate_model, commit=True)
+
+    def test_mark_as_completed_emits_estimate_status_completed_signal(self):
+        setup = self.create_entity_setup(name="API Estimate Completed Signal Entity")
+        estimate_model = self.make_approved_estimate(setup)
+        calls = self.collect_signal_calls(estimate_status_completed)
+
+        estimate_model.mark_as_completed(commit=True, date_completed=date(2025, 1, 18))
+
+        self.assert_signal_received_once(calls, estimate_model, commit=True)
+
+    def test_mark_as_canceled_emits_estimate_status_canceled_signal(self):
+        setup = self.create_entity_setup(name="API Estimate Canceled Signal Entity")
+        estimate_model = self.create_estimate(setup)
+        calls = self.collect_signal_calls(estimate_status_canceled)
+
+        estimate_model.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+
+        self.assert_signal_received_once(calls, estimate_model, commit=True)
+
+    def test_mark_as_void_emits_estimate_status_void_signal(self):
+        setup = self.create_entity_setup(name="API Estimate Void Signal Entity")
+        estimate_model = self.make_approved_estimate(setup)
+        calls = self.collect_signal_calls(estimate_status_void)
+
+        estimate_model.mark_as_void(commit=True, date_void=date(2025, 1, 19))
+
+        self.assert_signal_received_once(calls, estimate_model, commit=True)

--- a/django_ledger/tests/api/test_estimate_api.py
+++ b/django_ledger/tests/api/test_estimate_api.py
@@ -1,0 +1,304 @@
+"""
+High-level API behavior tests for EstimateModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import EstimateModel, ItemTransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+
+
+class EstimateHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for EstimateModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic estimate/customer/item lifecycle
+    invariants that should remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_estimate_contract_user",
+            email="api-estimate-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_estimate_setup(self, *, name="API Estimate Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Estimate Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name="API Estimate Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name="API Estimate COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name="API Estimate Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name="API Estimate Unit",
+            unit_abbr="api-est",
+            active=True,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name="API Estimate Customer",
+            entity_model=entity_model,
+            description="API Estimate Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        service_item = entity_model.create_item_service(
+            name="API Estimate Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        material_item = entity_model.create_item_product(
+            name="API Estimate Material Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "inventory_account": inventory_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "uom_model": uom_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+            "material_item": material_item,
+        }
+
+    def create_configured_estimate(self, setup):
+        estimate_model = EstimateModel(
+            terms=EstimateModel.CONTRACT_TERMS_FIXED,
+        )
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            estimate_title="API Estimate Contract",
+            commit=True,
+        )
+        return estimate_model
+
+    def migrate_service_item(
+        self,
+        estimate_model,
+        setup,
+        *,
+        quantity="2.00",
+        unit_cost="30.00",
+        unit_revenue="75.00",
+    ):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        unit_revenue = Decimal(unit_revenue)
+
+        itemtxs = {
+            setup["service_item"].item_number: {
+                "quantity": quantity,
+                "unit_cost": unit_cost,
+                "unit_revenue": unit_revenue,
+                "total_amount": quantity * unit_revenue,
+            }
+        }
+
+        estimate_model.migrate_itemtxs(
+            itemtxs=itemtxs,
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_material_item(
+        self,
+        estimate_model,
+        setup,
+        *,
+        quantity="3.00",
+        unit_cost="20.00",
+        unit_revenue="50.00",
+    ):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        unit_revenue = Decimal(unit_revenue)
+
+        itemtxs = {
+            setup["material_item"].item_number: {
+                "quantity": quantity,
+                "unit_cost": unit_cost,
+                "unit_revenue": unit_revenue,
+                "total_amount": quantity * unit_revenue,
+            }
+        }
+
+        estimate_model.migrate_itemtxs(
+            itemtxs=itemtxs,
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def test_estimate_configure_creates_draft_estimate_under_entity_and_customer(self):
+        setup = self.create_entity_with_estimate_setup()
+
+        estimate_model = self.create_configured_estimate(setup)
+
+        self.assertIsInstance(estimate_model, EstimateModel)
+        self.assertIsNotNone(estimate_model.uuid)
+        self.assertEqual(estimate_model.entity_id, setup["entity_model"].uuid)
+        self.assertEqual(estimate_model.customer_id, setup["customer_model"].uuid)
+        self.assertEqual(estimate_model.title, "API Estimate Contract")
+        self.assertTrue(estimate_model.is_draft())
+        self.assertFalse(estimate_model.is_approved())
+        self.assertTrue(estimate_model.estimate_number)
+
+    def test_estimate_item_migration_creates_item_transaction(self):
+        setup = self.create_entity_with_estimate_setup()
+        estimate_model = self.create_configured_estimate(setup)
+
+        self.migrate_service_item(estimate_model, setup)
+
+        item_txs = ItemTransactionModel.objects.filter(ce_model=estimate_model)
+
+        self.assertEqual(item_txs.count(), 1)
+
+        item_tx = item_txs.get()
+
+        self.assertEqual(item_tx.item_model_id, setup["service_item"].uuid)
+        self.assertEqual(item_tx.ce_quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.ce_unit_cost_estimate, Decimal("30.00"))
+        self.assertEqual(item_tx.ce_unit_revenue_estimate, Decimal("75.00"))
+        self.assertEqual(item_tx.ce_cost_estimate, Decimal("60.00"))
+        self.assertEqual(item_tx.ce_revenue_estimate, Decimal("150.00"))
+
+    def test_estimate_item_migration_updates_revenue_and_labor_estimates(self):
+        setup = self.create_entity_with_estimate_setup()
+        estimate_model = self.create_configured_estimate(setup)
+
+        estimate_model = self.migrate_service_item(estimate_model, setup)
+
+        self.assertEqual(estimate_model.revenue_estimate, Decimal("150.00"))
+        self.assertEqual(estimate_model.labor_estimate, Decimal("60.00"))
+
+    def test_estimate_item_migration_updates_material_estimate(self):
+        setup = self.create_entity_with_estimate_setup()
+        estimate_model = self.create_configured_estimate(setup)
+
+        estimate_model = self.migrate_material_item(estimate_model, setup)
+
+        self.assertEqual(estimate_model.revenue_estimate, Decimal("150.00"))
+        self.assertEqual(estimate_model.material_estimate, Decimal("60.00"))
+
+    def test_estimate_for_entity_queryset_limits_scope(self):
+        setup = self.create_entity_with_estimate_setup(name="API Estimate Entity A")
+        other_setup = self.create_entity_with_estimate_setup(name="API Estimate Entity B")
+
+        estimate_model = self.create_configured_estimate(setup)
+        other_estimate_model = self.create_configured_estimate(other_setup)
+
+        scoped_qs = EstimateModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=estimate_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_estimate_model.uuid).exists())
+
+    def test_estimate_can_move_from_draft_to_review(self):
+        setup = self.create_entity_with_estimate_setup()
+        estimate_model = self.create_configured_estimate(setup)
+        estimate_model = self.migrate_service_item(estimate_model, setup)
+
+        estimate_model.mark_as_review(commit=True)
+        estimate_model.refresh_from_db()
+
+        self.assertTrue(estimate_model.is_review())
+        self.assertFalse(estimate_model.is_draft())
+
+    def test_estimate_can_move_from_review_to_approved(self):
+        setup = self.create_entity_with_estimate_setup()
+        estimate_model = self.create_configured_estimate(setup)
+        estimate_model = self.migrate_service_item(estimate_model, setup)
+
+        estimate_model.mark_as_review(commit=True)
+        estimate_model.refresh_from_db()
+
+        estimate_model.mark_as_approved(commit=True)
+        estimate_model.refresh_from_db()
+
+        self.assertTrue(estimate_model.is_approved())
+        self.assertFalse(estimate_model.is_draft())
+
+    def test_approved_estimate_can_be_marked_completed(self):
+        setup = self.create_entity_with_estimate_setup()
+        estimate_model = self.create_configured_estimate(setup)
+        estimate_model = self.migrate_service_item(estimate_model, setup)
+
+        estimate_model.mark_as_review(commit=True)
+        estimate_model.refresh_from_db()
+
+        estimate_model.mark_as_approved(commit=True)
+        estimate_model.refresh_from_db()
+
+        estimate_model.mark_as_completed(commit=True)
+        estimate_model.refresh_from_db()
+
+        self.assertTrue(estimate_model.is_completed())

--- a/django_ledger/tests/api/test_estimate_configure_itemization_api.py
+++ b/django_ledger/tests/api/test_estimate_configure_itemization_api.py
@@ -1,0 +1,397 @@
+"""
+High-level API tests for EstimateModel configuration and itemization behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.http import Http404
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_INVENTORY,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+)
+from django_ledger.models import EstimateModel, ItemTransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel, EntityStateModel
+from django_ledger.models.estimate import EstimateModelValidationError
+from django_ledger.models.items import ItemModel
+from django_ledger.settings import DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING
+
+
+class EstimateConfigureItemizationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_estimate_configure_user",
+            email="api-estimate-configure-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_estimate_configure_unrelated",
+            email="api-estimate-configure-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Estimate Configure Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"e-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        product_item = entity_model.create_item_product(
+            name=f"{name} Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+            "product_item": product_item,
+            "expense_item": expense_item,
+        }
+
+    def configure_estimate(
+        self,
+        setup,
+        *,
+        entity_input=None,
+        customer_model=None,
+        user_model=None,
+        date_draft=date(2026, 1, 15),
+        commit=True,
+        title="API Estimate Configure Contract",
+    ):
+        estimate_model = EstimateModel(terms=EstimateModel.CONTRACT_TERMS_FIXED)
+        estimate_model.configure(
+            entity_slug=setup["entity_model"] if entity_input is None else entity_input,
+            customer_model=setup["customer_model"] if customer_model is None else customer_model,
+            user_model=self.user if user_model is None else user_model,
+            date_draft=date_draft,
+            estimate_title=title,
+            commit=commit,
+        )
+        if commit:
+            estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_service_item(
+        self,
+        estimate_model,
+        setup,
+        *,
+        quantity="2.00",
+        unit_cost="50.00",
+        unit_revenue="75.00",
+        operation=None,
+    ):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        unit_revenue = Decimal(unit_revenue)
+        itemtxs_batch = estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "unit_revenue": unit_revenue,
+                    "total_amount": quantity * unit_revenue,
+                }
+            },
+            operation=operation or EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model, itemtxs_batch
+
+    def migrate_product_item(self, estimate_model, setup, *, quantity="1.00", unit_cost="20.00", unit_revenue="35.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        unit_revenue = Decimal(unit_revenue)
+        itemtxs_batch = estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["product_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "unit_revenue": unit_revenue,
+                    "total_amount": quantity * unit_revenue,
+                }
+            },
+            operation=EstimateModel.ITEMIZE_APPEND,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model, itemtxs_batch
+
+    def assert_number_ends_with_sequence(self, number, sequence):
+        self.assertTrue(
+            number.endswith(str(sequence).zfill(DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING)),
+            msg=f"{number!r} does not end with sequence {sequence}",
+        )
+
+    def test_configure_accepts_entity_model_authorized_slug_and_authorized_uuid(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        by_model = self.configure_estimate(setup, entity_input=entity_model)
+        by_slug = self.configure_estimate(setup, entity_input=entity_model.slug)
+        by_uuid = self.configure_estimate(setup, entity_input=entity_model.uuid)
+
+        self.assertEqual(by_model.entity_id, entity_model.uuid)
+        self.assertEqual(by_slug.entity_id, entity_model.uuid)
+        self.assertEqual(by_uuid.entity_id, entity_model.uuid)
+        self.assertEqual(by_model.customer_id, setup["customer_model"].uuid)
+        self.assertEqual(by_slug.customer_id, setup["customer_model"].uuid)
+        self.assertEqual(by_uuid.customer_id, setup["customer_model"].uuid)
+        self.assertTrue(by_model.estimate_number)
+        self.assertTrue(by_slug.estimate_number)
+        self.assertTrue(by_uuid.estimate_number)
+
+    def test_configure_rejects_slug_without_user_and_unauthorized_slug_or_uuid(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Rejection Entity")
+
+        with self.assertRaises(EstimateModelValidationError):
+            EstimateModel(terms=EstimateModel.CONTRACT_TERMS_FIXED).configure(
+                entity_slug=setup["entity_model"].slug,
+                customer_model=setup["customer_model"],
+            )
+
+        with self.assertRaises(Http404):
+            self.configure_estimate(
+                setup,
+                entity_input=setup["entity_model"].slug,
+                user_model=self.unrelated_user,
+            )
+
+        with self.assertRaises(Http404):
+            self.configure_estimate(
+                setup,
+                entity_input=setup["entity_model"].uuid,
+                user_model=self.unrelated_user,
+            )
+
+    def test_configure_rejects_customer_from_another_entity(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Customer Entity")
+        other_setup = self.create_entity_setup(name="API Estimate Configure Other Customer Entity")
+
+        with self.assertRaises(EstimateModelValidationError):
+            self.configure_estimate(setup, customer_model=other_setup["customer_model"])
+
+        self.assertFalse(
+            EstimateModel.objects.filter(
+                entity=setup["entity_model"],
+                customer=other_setup["customer_model"],
+            ).exists()
+        )
+
+    def test_configure_respects_explicit_draft_date(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Draft Date Entity")
+
+        estimate_model = self.configure_estimate(setup, date_draft=date(2025, 12, 31))
+
+        self.assertEqual(estimate_model.date_draft, date(2025, 12, 31))
+        self.assertIn("-2025-", estimate_model.estimate_number)
+
+    def test_configure_commit_false_generates_number_and_state_without_persisting_estimate(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Commit False Entity")
+
+        estimate_model = self.configure_estimate(setup, commit=False)
+
+        self.assertTrue(estimate_model.is_configured())
+        self.assertTrue(estimate_model.estimate_number)
+        self.assertEqual(estimate_model.date_draft, date(2026, 1, 15))
+        self.assertFalse(EstimateModel.objects.filter(uuid=estimate_model.uuid).exists())
+
+        state_model = EntityStateModel.objects.get(
+            entity_model=setup["entity_model"],
+            entity_unit__isnull=True,
+            fiscal_year=2026,
+            key=EntityStateModel.KEY_ESTIMATE,
+        )
+        self.assertEqual(state_model.sequence, 1)
+        self.assert_number_ends_with_sequence(estimate_model.estimate_number, 1)
+
+    def test_generate_estimate_number_commit_false_and_true_behaviors(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Number Entity")
+        manual_estimate = EstimateModel.objects.create(
+            entity=setup["entity_model"],
+            customer=setup["customer_model"],
+            terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            title="API Manual Number Estimate",
+            date_draft=date(2026, 1, 15),
+            estimate_number="manual-est-1",
+        )
+        manual_estimate.estimate_number = ""
+
+        self.assertTrue(manual_estimate.can_generate_estimate_number())
+        generated_number = manual_estimate.generate_estimate_number(commit=False)
+
+        self.assertTrue(generated_number)
+        self.assertEqual(
+            EstimateModel.objects.get(uuid=manual_estimate.uuid).estimate_number,
+            "manual-est-1",
+        )
+
+        persisted_estimate = EstimateModel.objects.create(
+            entity=setup["entity_model"],
+            customer=setup["customer_model"],
+            terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            title="API Persisted Number Estimate",
+            date_draft=date(2026, 1, 15),
+            estimate_number="manual-est-2",
+        )
+        persisted_estimate.estimate_number = ""
+
+        persisted_number = persisted_estimate.generate_estimate_number(commit=True)
+
+        self.assertTrue(persisted_number)
+        self.assertEqual(
+            EstimateModel.objects.get(uuid=persisted_estimate.uuid).estimate_number,
+            persisted_number,
+        )
+
+    def test_get_item_model_qs_returns_estimate_eligible_items(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Item Query Entity")
+        estimate_model = self.configure_estimate(setup)
+
+        item_qs = estimate_model.get_item_model_qs()
+
+        self.assertTrue(item_qs.filter(uuid=setup["service_item"].uuid).exists())
+        self.assertTrue(item_qs.filter(uuid=setup["product_item"].uuid).exists())
+        self.assertFalse(item_qs.filter(uuid=setup["expense_item"].uuid).exists())
+
+    def test_migrate_itemtxs_replace_and_append_create_estimate_items_and_update_amounts(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Item Migration Entity")
+        estimate_model = self.configure_estimate(setup)
+
+        estimate_model, itemtxs_batch = self.migrate_service_item(estimate_model, setup)
+
+        self.assertEqual(len(itemtxs_batch), 1)
+        item_tx = ItemTransactionModel.objects.get(ce_model=estimate_model)
+        self.assertEqual(item_tx.item_model_id, setup["service_item"].uuid)
+        self.assertEqual(item_tx.ce_quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.ce_unit_cost_estimate, Decimal("50.00"))
+        self.assertEqual(item_tx.ce_unit_revenue_estimate, Decimal("75.00"))
+        self.assertEqual(item_tx.ce_cost_estimate, Decimal("100.00"))
+        self.assertEqual(item_tx.ce_revenue_estimate, Decimal("150.00"))
+        self.assertEqual(estimate_model.revenue_estimate, Decimal("150.00"))
+        self.assertEqual(estimate_model.labor_estimate, Decimal("100.00"))
+
+        estimate_model, appended_batch = self.migrate_product_item(estimate_model, setup)
+
+        self.assertEqual(len(appended_batch), 2)
+        self.assertEqual(ItemTransactionModel.objects.filter(ce_model=estimate_model).count(), 2)
+        self.assertEqual(estimate_model.revenue_estimate, Decimal("185.00"))
+        self.assertEqual(estimate_model.material_estimate, Decimal("20.00"))
+
+        estimate_model, replacement_batch = self.migrate_service_item(
+            estimate_model,
+            setup,
+            quantity="1.00",
+            unit_cost="25.00",
+            unit_revenue="40.00",
+        )
+
+        self.assertEqual(len(replacement_batch), 1)
+        self.assertEqual(ItemTransactionModel.objects.filter(ce_model=estimate_model).count(), 1)
+        self.assertEqual(estimate_model.revenue_estimate, Decimal("40.00"))
+        self.assertEqual(estimate_model.labor_estimate, Decimal("25.00"))
+        self.assertEqual(estimate_model.material_estimate, Decimal("0.00"))
+
+    def test_validate_itemtxs_qs_rejects_transactions_from_another_estimate(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Validate ItemTx Entity")
+        estimate_model = self.configure_estimate(setup)
+        other_estimate_model = self.configure_estimate(setup, title="API Other Estimate")
+        other_estimate_model, _itemtxs_batch = self.migrate_service_item(other_estimate_model, setup)
+        other_itemtxs = ItemTransactionModel.objects.filter(ce_model=other_estimate_model)
+
+        with self.assertRaises(EstimateModelValidationError):
+            estimate_model.validate_itemtxs_qs(other_itemtxs)
+
+        with self.assertRaises(EstimateModelValidationError):
+            estimate_model.validate_item_transaction_qs(other_itemtxs)
+
+    def test_get_itemtxs_data_returns_estimate_items_without_aggregate_payload(self):
+        setup = self.create_entity_setup(name="API Estimate Configure Item Data Entity")
+        estimate_model = self.configure_estimate(setup)
+        estimate_model, _itemtxs_batch = self.migrate_service_item(estimate_model, setup)
+
+        itemtxs_qs, itemtxs_data = estimate_model.get_itemtxs_data()
+
+        self.assertEqual(itemtxs_qs.count(), 1)
+        self.assertIsNone(itemtxs_data)
+        self.assertEqual(itemtxs_qs.get().ce_revenue_estimate, Decimal("150.00"))

--- a/django_ledger/tests/api/test_estimate_invoice_binding_api.py
+++ b/django_ledger/tests/api/test_estimate_invoice_binding_api.py
@@ -1,0 +1,252 @@
+"""
+High-level API tests for EstimateModel to InvoiceModel binding behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import EstimateModel, InvoiceModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.invoice import InvoiceModelValidationError
+
+
+class EstimateInvoiceBindingAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_estimate_invoice_binding_user",
+            email="api-estimate-invoice-binding-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Estimate Invoice Binding Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"Unit {str(entity_model.uuid)[:8]}",
+            unit_abbr=f"e-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = self.create_customer(entity_model, name=f"{name} Customer")
+        other_customer_model = self.create_customer(entity_model, name=f"{name} Other Customer")
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "other_customer_model": other_customer_model,
+            "service_item": service_item,
+        }
+
+    def create_customer(self, entity_model, *, name):
+        customer_model = CustomerModel(
+            customer_name=name,
+            entity_model=entity_model,
+            description=f"{name} description.",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        return customer_model
+
+    def create_estimate(self, setup, *, title="API Estimate Invoice Binding Contract"):
+        estimate_model = setup["entity_model"].create_estimate(
+            estimate_title=title,
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=setup["customer_model"],
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_service_item(self, estimate_model, setup):
+        estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": Decimal("100.00"),
+                    "unit_revenue": Decimal("150.00"),
+                    "total_amount": Decimal("150.00"),
+                }
+            },
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_review_estimate(self, setup, *, title="API Review Estimate"):
+        estimate_model = self.migrate_service_item(self.create_estimate(setup, title=title), setup)
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_approved_estimate(self, setup, *, title="API Approved Estimate"):
+        estimate_model = self.make_review_estimate(setup, title=title)
+        estimate_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def create_invoice(self, setup, *, customer_model=None):
+        invoice_model = setup["entity_model"].create_invoice(
+            customer_model=customer_model or setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            date_draft=date(2025, 1, 20),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def test_approved_estimate_can_bind_to_invoice(self):
+        setup = self.create_entity_setup()
+        estimate_model = self.make_approved_estimate(setup)
+        invoice_model = self.create_invoice(setup)
+
+        self.assertTrue(invoice_model.can_bind_estimate(estimate_model))
+
+        invoice_model.bind_estimate(estimate_model, commit=True)
+        invoice_model.refresh_from_db()
+
+        self.assertEqual(invoice_model.ce_model_id, estimate_model.uuid)
+        self.assertEqual(invoice_model.customer_id, estimate_model.customer_id)
+        self.assertTrue(estimate_model.invoicemodel_set.filter(uuid=invoice_model.uuid).exists())
+
+    def test_unapproved_estimate_cannot_bind_to_invoice(self):
+        setup = self.create_entity_setup(name="API Estimate Invoice Binding Unapproved Entity")
+        draft_estimate = self.create_estimate(setup, title="API Draft Estimate")
+        review_estimate = self.make_review_estimate(setup, title="API Review Estimate")
+        invoice_model = self.create_invoice(setup)
+
+        self.assertFalse(invoice_model.can_bind_estimate(draft_estimate))
+        self.assertFalse(invoice_model.can_bind_estimate(review_estimate))
+
+        with self.assertRaises(InvoiceModelValidationError):
+            invoice_model.bind_estimate(draft_estimate, commit=True)
+
+        with self.assertRaises(InvoiceModelValidationError):
+            invoice_model.bind_estimate(review_estimate, commit=True)
+
+        invoice_model.refresh_from_db()
+        self.assertIsNone(invoice_model.ce_model_id)
+
+    def test_binding_updates_invoice_customer_from_estimate(self):
+        setup = self.create_entity_setup(name="API Estimate Invoice Binding Customer Entity")
+        estimate_model = self.make_approved_estimate(setup)
+        invoice_model = self.create_invoice(setup, customer_model=setup["other_customer_model"])
+
+        self.assertNotEqual(invoice_model.customer_id, estimate_model.customer_id)
+
+        invoice_model.bind_estimate(estimate_model, commit=True)
+        invoice_model.refresh_from_db()
+
+        self.assertEqual(invoice_model.ce_model_id, estimate_model.uuid)
+        self.assertEqual(invoice_model.customer_id, estimate_model.customer_id)
+
+    def test_already_bound_invoice_rejects_second_estimate(self):
+        setup = self.create_entity_setup(name="API Estimate Invoice Binding Bound Entity")
+        first_estimate = self.make_approved_estimate(setup, title="API First Estimate")
+        second_estimate = self.make_approved_estimate(setup, title="API Second Estimate")
+        invoice_model = self.create_invoice(setup)
+        invoice_model.bind_estimate(first_estimate, commit=True)
+        invoice_model.refresh_from_db()
+
+        self.assertFalse(invoice_model.can_bind_estimate(second_estimate))
+
+        with self.assertRaises(InvoiceModelValidationError):
+            invoice_model.bind_estimate(second_estimate, commit=True)
+
+        invoice_model.refresh_from_db()
+        self.assertEqual(invoice_model.ce_model_id, first_estimate.uuid)
+
+    def test_cross_entity_estimate_cannot_bind_to_invoice(self):
+        setup = self.create_entity_setup(name="API Estimate Invoice Binding Entity A")
+        other_setup = self.create_entity_setup(name="API Estimate Invoice Binding Entity B")
+        other_estimate = self.make_approved_estimate(other_setup)
+        invoice_model = self.create_invoice(setup)
+
+        self.assertFalse(invoice_model.can_bind_estimate(other_estimate))
+
+        with self.assertRaises(InvoiceModelValidationError):
+            invoice_model.bind_estimate(other_estimate, commit=True)
+
+        invoice_model.refresh_from_db()
+        self.assertIsNone(invoice_model.ce_model_id)
+        self.assertEqual(invoice_model.entity_model_id, setup["entity_model"].uuid)
+        self.assertEqual(invoice_model.customer_id, setup["customer_model"].uuid)

--- a/django_ledger/tests/api/test_estimate_lifecycle_api.py
+++ b/django_ledger/tests/api/test_estimate_lifecycle_api.py
@@ -1,0 +1,304 @@
+"""
+High-level API tests for EstimateModel lifecycle transitions.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_INVENTORY,
+    COGS,
+    INCOME_OPERATIONAL,
+)
+from django_ledger.models import EstimateModel, ItemTransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.estimate import EstimateModelValidationError
+
+
+class EstimateLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_estimate_lifecycle_user",
+            email="api-estimate-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Estimate Lifecycle Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"Unit {str(entity_model.uuid)[:8]}",
+            unit_abbr=f"e-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} customer.",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+        }
+
+    def create_estimate(self, setup, *, date_draft=date(2025, 1, 15), title="API Estimate Lifecycle Contract"):
+        estimate_model = setup["entity_model"].create_estimate(
+            estimate_title=title,
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=setup["customer_model"],
+            date_draft=date_draft,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_service_item(self, estimate_model, setup, *, quantity="1.00", unit_cost="100.00", unit_revenue="150.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        unit_revenue = Decimal(unit_revenue)
+        estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "unit_revenue": unit_revenue,
+                    "total_amount": quantity * unit_revenue,
+                }
+            },
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_review_estimate(self, setup):
+        estimate_model = self.migrate_service_item(self.create_estimate(setup), setup)
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_approved_estimate(self, setup):
+        estimate_model = self.make_review_estimate(setup)
+        estimate_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_completed_estimate(self, setup):
+        estimate_model = self.make_approved_estimate(setup)
+        estimate_model.mark_as_completed(commit=True, date_completed=date(2025, 1, 18))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def test_valid_status_transitions_set_dates_and_contract_flags(self):
+        setup = self.create_entity_setup(name="API Estimate Lifecycle Valid Entity")
+        estimate_model = self.migrate_service_item(self.create_estimate(setup), setup)
+
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        estimate_model.refresh_from_db()
+        self.assertTrue(estimate_model.is_review())
+        self.assertFalse(estimate_model.is_contract())
+        self.assertEqual(estimate_model.date_in_review, date(2025, 1, 16))
+
+        estimate_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        estimate_model.refresh_from_db()
+        self.assertTrue(estimate_model.is_approved())
+        self.assertTrue(estimate_model.is_contract())
+        self.assertEqual(estimate_model.date_approved, date(2025, 1, 17))
+
+        estimate_model.mark_as_completed(commit=True, date_completed=date(2025, 1, 18))
+        estimate_model.refresh_from_db()
+        self.assertTrue(estimate_model.is_completed())
+        self.assertTrue(estimate_model.is_contract())
+        self.assertEqual(estimate_model.date_completed, date(2025, 1, 18))
+
+    def test_cancel_and_void_transitions_set_terminal_status_dates(self):
+        setup = self.create_entity_setup(name="API Estimate Lifecycle Terminal Entity")
+
+        draft_estimate = self.create_estimate(setup)
+        draft_estimate.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        draft_estimate.refresh_from_db()
+        self.assertTrue(draft_estimate.is_canceled())
+        self.assertEqual(draft_estimate.date_canceled, date(2025, 1, 20))
+
+        review_estimate = self.make_review_estimate(setup)
+        review_estimate.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 21))
+        review_estimate.refresh_from_db()
+        self.assertTrue(review_estimate.is_canceled())
+        self.assertEqual(review_estimate.date_canceled, date(2025, 1, 21))
+
+        approved_estimate = self.make_approved_estimate(setup)
+        approved_estimate.mark_as_void(commit=True, date_void=date(2025, 1, 22))
+        approved_estimate.refresh_from_db()
+        self.assertTrue(approved_estimate.is_void())
+        self.assertEqual(approved_estimate.date_void, date(2025, 1, 22))
+
+    def test_can_predicates_reflect_status_transitions(self):
+        setup = self.create_entity_setup(name="API Estimate Lifecycle Predicate Entity")
+
+        draft_estimate = self.create_estimate(setup)
+        self.assertFalse(draft_estimate.can_draft())
+        self.assertTrue(draft_estimate.can_review())
+        self.assertFalse(draft_estimate.can_approve())
+        self.assertFalse(draft_estimate.can_complete())
+        self.assertTrue(draft_estimate.can_cancel())
+        self.assertFalse(draft_estimate.can_void())
+        self.assertTrue(draft_estimate.can_update_items())
+        self.assertFalse(draft_estimate.can_bind())
+
+        review_estimate = self.make_review_estimate(setup)
+        self.assertTrue(review_estimate.can_draft())
+        self.assertFalse(review_estimate.can_review())
+        self.assertTrue(review_estimate.can_approve())
+        self.assertFalse(review_estimate.can_complete())
+        self.assertTrue(review_estimate.can_cancel())
+        self.assertFalse(review_estimate.can_void())
+        self.assertFalse(review_estimate.can_update_items())
+        self.assertFalse(review_estimate.can_bind())
+
+        approved_estimate = self.make_approved_estimate(setup)
+        self.assertFalse(approved_estimate.can_draft())
+        self.assertFalse(approved_estimate.can_approve())
+        self.assertTrue(approved_estimate.can_complete())
+        self.assertFalse(approved_estimate.can_cancel())
+        self.assertTrue(approved_estimate.can_void())
+        self.assertFalse(approved_estimate.can_update_items())
+        self.assertTrue(approved_estimate.can_bind())
+
+        completed_estimate = self.make_completed_estimate(setup)
+        self.assertFalse(completed_estimate.can_complete())
+        self.assertFalse(completed_estimate.can_cancel())
+        self.assertFalse(completed_estimate.can_void())
+        self.assertFalse(completed_estimate.can_update_items())
+        self.assertFalse(completed_estimate.can_bind())
+
+    def test_commit_false_transitions_mutate_in_memory_without_persisting(self):
+        setup = self.create_entity_setup(name="API Estimate Lifecycle Commit False Entity")
+        estimate_model = self.migrate_service_item(self.create_estimate(setup), setup)
+
+        estimate_model.mark_as_review(commit=False, date_in_review=date(2025, 1, 16))
+        self.assertTrue(estimate_model.is_review())
+        self.assertEqual(estimate_model.date_in_review, date(2025, 1, 16))
+        db_estimate = EstimateModel.objects.get(uuid=estimate_model.uuid)
+        self.assertTrue(db_estimate.is_draft())
+        self.assertIsNone(db_estimate.date_in_review)
+
+        estimate_model.refresh_from_db()
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        estimate_model.refresh_from_db()
+        estimate_model.mark_as_approved(commit=False, date_approved=date(2025, 1, 17))
+        self.assertTrue(estimate_model.is_approved())
+        self.assertEqual(estimate_model.date_approved, date(2025, 1, 17))
+        db_estimate = EstimateModel.objects.get(uuid=estimate_model.uuid)
+        self.assertTrue(db_estimate.is_review())
+        self.assertIsNone(db_estimate.date_approved)
+
+    def test_review_requires_items_cost_and_revenue(self):
+        setup = self.create_entity_setup(name="API Estimate Lifecycle Review Requirement Entity")
+        estimate_model = self.create_estimate(setup)
+
+        with self.assertRaises(EstimateModelValidationError):
+            estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        self.assertFalse(ItemTransactionModel.objects.filter(ce_model=estimate_model).exists())
+
+        zero_cost_estimate = self.migrate_service_item(
+            self.create_estimate(setup, title="API Zero Cost Estimate"),
+            setup,
+            unit_cost="0.00",
+            unit_revenue="150.00",
+        )
+        with self.assertRaises(EstimateModelValidationError):
+            zero_cost_estimate.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        zero_revenue_estimate = self.migrate_service_item(
+            self.create_estimate(setup, title="API Zero Revenue Estimate"),
+            setup,
+            unit_cost="100.00",
+            unit_revenue="0.00",
+        )
+        with self.assertRaises(EstimateModelValidationError):
+            zero_revenue_estimate.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+    def test_invalid_transitions_raise_validation_errors_or_noop_when_suppressed(self):
+        setup = self.create_entity_setup(name="API Estimate Lifecycle Invalid Entity")
+        draft_estimate = self.create_estimate(setup)
+
+        with self.assertRaises(EstimateModelValidationError):
+            draft_estimate.mark_as_completed(commit=True, date_completed=date(2025, 1, 18))
+
+        result = draft_estimate.mark_as_completed(
+            commit=True,
+            date_completed=date(2025, 1, 18),
+            raise_exception=False,
+        )
+        self.assertIsNone(result)
+        draft_estimate.refresh_from_db()
+        self.assertTrue(draft_estimate.is_draft())
+
+        completed_estimate = self.make_completed_estimate(setup)
+        with self.assertRaises(EstimateModelValidationError):
+            completed_estimate.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 19))
+        with self.assertRaises(EstimateModelValidationError):
+            completed_estimate.mark_as_void(commit=True, date_void=date(2025, 1, 19))
+
+        canceled_estimate = self.create_estimate(setup)
+        canceled_estimate.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        with self.assertRaises(ValidationError):
+            canceled_estimate.mark_as_review(commit=True, date_in_review=date(2025, 1, 21))
+
+        void_estimate = self.make_approved_estimate(setup)
+        void_estimate.mark_as_void(commit=True, date_void=date(2025, 1, 22))
+        with self.assertRaises(EstimateModelValidationError):
+            void_estimate.mark_as_completed(commit=True, date_completed=date(2025, 1, 23))

--- a/django_ledger/tests/api/test_estimate_queryset_api.py
+++ b/django_ledger/tests/api/test_estimate_queryset_api.py
@@ -1,0 +1,242 @@
+"""
+High-level API tests for EstimateModel queryset and manager behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_INVENTORY,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+)
+from django_ledger.models import EstimateModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.estimate import EstimateModelValidationError
+from django_ledger.models.items import ItemModel
+
+
+class EstimateQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_estimate_queryset_admin",
+            email="api-estimate-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_estimate_queryset_manager",
+            email="api-estimate-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_estimate_queryset_other_admin",
+            email="api-estimate-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_estimate_queryset_unrelated",
+            email="api-estimate-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_estimate_queryset_superuser",
+            email="api-estimate-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Estimate Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"e-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+        }
+
+    def create_estimate(self, setup, *, date_draft=date(2026, 1, 15), title="API Estimate Queryset Estimate"):
+        estimate_model = EstimateModel(terms=EstimateModel.CONTRACT_TERMS_FIXED)
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.admin_user,
+            date_draft=date_draft,
+            estimate_title=title,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_service_item(self, estimate_model, setup, *, quantity="2.00", unit_cost="50.00", unit_revenue="75.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        unit_revenue = Decimal(unit_revenue)
+        estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "unit_revenue": unit_revenue,
+                    "total_amount": quantity * unit_revenue,
+                }
+            },
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def move_to_approved(self, estimate_model, setup):
+        estimate_model = self.migrate_service_item(estimate_model, setup)
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2026, 1, 16))
+        estimate_model.refresh_from_db()
+        estimate_model.mark_as_approved(commit=True, date_approved=date(2026, 1, 17))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def move_to_completed(self, estimate_model, setup):
+        estimate_model = self.move_to_approved(estimate_model, setup)
+        estimate_model.mark_as_completed(commit=True, date_completed=date(2026, 1, 18))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def assert_estimate_uuids(self, queryset, expected_estimates):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {estimate_model.uuid for estimate_model in expected_estimates},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Estimate Queryset Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Estimate Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        estimate_model = self.create_estimate(setup)
+        self.create_estimate(other_setup)
+        entity_model = setup["entity_model"]
+
+        self.assert_estimate_uuids(EstimateModel.objects.for_entity(entity_model), [estimate_model])
+        self.assert_estimate_uuids(EstimateModel.objects.for_entity(entity_model.slug), [estimate_model])
+        self.assert_estimate_uuids(EstimateModel.objects.for_entity(entity_model.uuid), [estimate_model])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_estimate(self.create_entity_setup())
+
+        with self.assertRaises(EstimateModelValidationError):
+            EstimateModel.objects.for_entity(object())
+
+        self.assertFalse(EstimateModel.objects.for_entity("missing-estimate-entity-slug").exists())
+
+    def test_for_user_scopes_to_authorized_users_and_superuser(self):
+        setup = self.create_entity_setup(
+            name="API Estimate Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API Estimate Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        estimate_model = self.create_estimate(setup)
+        other_estimate_model = self.create_estimate(other_setup)
+
+        self.assert_estimate_uuids(EstimateModel.objects.all().for_user(self.admin_user), [estimate_model])
+        self.assert_estimate_uuids(EstimateModel.objects.all().for_user(self.manager_user), [estimate_model])
+        self.assertFalse(EstimateModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_estimate_uuids(
+            EstimateModel.objects.all().for_user(self.superuser),
+            [estimate_model, other_estimate_model],
+        )
+
+    def test_status_filters_return_estimates_and_contracts(self):
+        setup = self.create_entity_setup(name="API Estimate Queryset Status Entity")
+        draft_estimate = self.create_estimate(setup, title="API Draft Estimate")
+        approved_estimate = self.move_to_approved(self.create_estimate(setup, title="API Approved Estimate"), setup)
+        completed_estimate = self.move_to_completed(self.create_estimate(setup, title="API Completed Estimate"), setup)
+
+        estimates_qs = EstimateModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_estimate_uuids(estimates_qs.draft(), [draft_estimate])
+        self.assert_estimate_uuids(estimates_qs.approved(), [approved_estimate, completed_estimate])
+        self.assert_estimate_uuids(estimates_qs.contracts(), [approved_estimate, completed_estimate])
+        self.assert_estimate_uuids(estimates_qs.not_approved(), [draft_estimate])
+        self.assert_estimate_uuids(estimates_qs.estimates(), [draft_estimate])

--- a/django_ledger/tests/api/test_import_job_helpers_api.py
+++ b/django_ledger/tests/api/test_import_job_helpers_api.py
@@ -1,0 +1,237 @@
+"""
+High-level API behavior tests for ImportJobModel helpers.
+
+These tests cover import job configuration, display, URL, and validation
+behavior without exercising staged transaction migration or matching flows.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models import BankAccountModel, LedgerModel
+from django_ledger.models.data_import import (
+    ImportJobModel,
+    ImportJobModelValidationError,
+)
+from django_ledger.models.entity import EntityModel
+
+
+class ImportJobHelpersAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_import_job_helpers_admin",
+            email="api-import-job-helpers-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_import_job_helpers_other_admin",
+            email="api-import-job-helpers-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Import Job Helpers Entity",
+        admin=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+            hidden=False,
+        )
+        bank_account.configure(
+            entity_slug=entity_model,
+            user_model=admin or self.admin_user,
+            commit=True,
+        )
+        bank_account.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "bank_account": bank_account,
+        }
+
+    def create_unconfigured_import_job(
+        self,
+        setup,
+        *,
+        description="API Import Job Helpers Job",
+    ):
+        return ImportJobModel.objects.create(
+            description=description,
+            bank_account_model=setup["bank_account"],
+        )
+
+    def create_configured_import_job(
+        self,
+        setup,
+        *,
+        description="API Import Job Helpers Job",
+    ):
+        import_job = self.create_unconfigured_import_job(
+            setup,
+            description=description,
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return import_job
+
+    def test_configure_commit_false_creates_in_memory_ledger_without_persisting_binding(self):
+        setup = self.create_entity_setup(name="API Import Job Commit False Entity")
+        import_job = self.create_unconfigured_import_job(
+            setup,
+            description="API Import Job Commit False",
+        )
+
+        import_job.configure(commit=False)
+
+        self.assertTrue(import_job.is_configured())
+        self.assertIsNotNone(import_job.ledger_model_id)
+        self.assertEqual(import_job.ledger_model.entity_id, setup["entity_model"].uuid)
+        self.assertTrue(
+            LedgerModel.objects.filter(uuid=import_job.ledger_model_id).exists()
+        )
+
+        persisted_import_job = ImportJobModel._base_manager.get(uuid=import_job.uuid)
+        self.assertIsNone(persisted_import_job.ledger_model_id)
+
+    def test_configure_commit_true_persists_ledger_binding(self):
+        setup = self.create_entity_setup(name="API Import Job Commit True Entity")
+        import_job = self.create_unconfigured_import_job(
+            setup,
+            description="API Import Job Commit True",
+        )
+
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+
+        self.assertTrue(import_job.is_configured())
+        self.assertIsNotNone(import_job.ledger_model_id)
+        self.assertEqual(import_job.ledger_model.entity_id, setup["entity_model"].uuid)
+        self.assertEqual(
+            import_job.bank_account_model.entity_model_id,
+            import_job.ledger_model.entity_id,
+        )
+
+    def test_presave_rejects_bank_account_and_ledger_from_different_entities(self):
+        setup = self.create_entity_setup(name="API Import Job Valid Entity")
+        other_setup = self.create_entity_setup(
+            name="API Import Job Other Ledger Entity",
+            admin=self.other_admin_user,
+        )
+        other_ledger = other_setup["entity_model"].create_ledger(
+            name="API Import Job Mismatched Ledger",
+        )
+
+        with self.assertRaises(ImportJobModelValidationError):
+            ImportJobModel.objects.create(
+                description="API Import Job Mismatched Entity",
+                bank_account_model=setup["bank_account"],
+                ledger_model=other_ledger,
+            )
+
+    def test_entity_slug_and_uuid_use_annotation_and_fallback(self):
+        setup = self.create_entity_setup(name="API Import Job Annotation Fallback Entity")
+        import_job = self.create_configured_import_job(
+            setup,
+            description="API Import Job Annotation Fallback",
+        )
+
+        annotated_import_job = ImportJobModel.objects.get(uuid=import_job.uuid)
+        self.assertEqual(annotated_import_job.entity_slug, setup["entity_model"].slug)
+        self.assertEqual(annotated_import_job.entity_uuid, setup["entity_model"].uuid)
+
+        direct_import_job = ImportJobModel(
+            description="API Direct Import Job",
+            bank_account_model=setup["bank_account"],
+            ledger_model=import_job.ledger_model,
+        )
+
+        self.assertEqual(direct_import_job.entity_slug, setup["entity_model"].slug)
+        self.assertEqual(direct_import_job.entity_uuid, setup["entity_model"].uuid)
+
+    def test_url_helpers_include_entity_slug_and_job_uuid(self):
+        setup = self.create_entity_setup(name="API Import Job URL Entity")
+        import_job = self.create_configured_import_job(
+            setup,
+            description="API Import Job URL",
+        )
+        entity_slug = setup["entity_model"].slug
+        job_uuid = str(import_job.uuid)
+
+        job_url_helpers = [
+            "get_data_import_url",
+            "get_data_import_reset_url",
+            "get_absolute_url",
+            "get_detail_url",
+            "get_update_url",
+            "get_delete_url",
+            "get_edit_txs_url",
+        ]
+
+        for helper_name in job_url_helpers:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(import_job, helper_name)()
+
+                self.assertIsInstance(url, str)
+                self.assertTrue(url)
+                self.assertIn(entity_slug, url)
+                self.assertIn(job_uuid, url)
+
+        list_url = import_job.get_list_url()
+        self.assertIsInstance(list_url, str)
+        self.assertTrue(list_url)
+        self.assertIn(entity_slug, list_url)
+        self.assertNotIn(job_uuid, list_url)
+
+        ledger_url = import_job.get_ledger_detail_url()
+        self.assertIsInstance(ledger_url, str)
+        self.assertTrue(ledger_url)
+        self.assertIn(entity_slug, ledger_url)
+        self.assertIn(str(import_job.ledger_model_id), ledger_url)
+
+    def test_str_and_delete_message_include_description(self):
+        setup = self.create_entity_setup(name="API Import Job Display Entity")
+        import_job = self.create_configured_import_job(
+            setup,
+            description="API Import Job Display",
+        )
+
+        display_value = str(import_job)
+        delete_message = str(import_job.get_delete_message())
+
+        self.assertIsInstance(display_value, str)
+        self.assertTrue(display_value)
+        self.assertIn("API Import Job Display", display_value)
+
+        self.assertIsInstance(delete_message, str)
+        self.assertTrue(delete_message)
+        self.assertIn("API Import Job Display", delete_message)

--- a/django_ledger/tests/api/test_import_job_queryset_api.py
+++ b/django_ledger/tests/api/test_import_job_queryset_api.py
@@ -1,0 +1,267 @@
+"""
+High-level API behavior tests for ImportJobModel queryset helpers.
+
+These tests cover entity/user scoping and manager annotations without
+exercising staged transaction migration, matching, receipts, or undo flows.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, DEBIT
+from django_ledger.models import BankAccountModel, JournalEntryModel, TransactionModel
+from django_ledger.models.data_import import (
+    ImportJobModel,
+    ImportJobModelValidationError,
+    StagedTransactionModel,
+)
+from django_ledger.models.entity import EntityManagementModel, EntityModel
+
+
+class ImportJobQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_import_job_queryset_admin",
+            email="api-import-job-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_import_job_queryset_other_admin",
+            email="api-import-job-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_import_job_queryset_manager",
+            email="api-import-job-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_import_job_queryset_unrelated",
+            email="api-import-job-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_import_job_queryset_superuser",
+            email="api-import-job-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Import Job QuerySet Entity",
+        admin=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+            hidden=False,
+        )
+        bank_account.configure(
+            entity_slug=entity_model,
+            user_model=admin or self.admin_user,
+            commit=True,
+        )
+        bank_account.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "bank_account": bank_account,
+        }
+
+    def create_import_job(self, setup, *, description="API Import Job QuerySet Job"):
+        import_job = ImportJobModel.objects.create(
+            description=description,
+            bank_account_model=setup["bank_account"],
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return import_job
+
+    def create_staged_transaction(
+        self,
+        import_job,
+        *,
+        fit_id,
+        amount="125.00",
+        transaction_model=None,
+    ):
+        return StagedTransactionModel.objects.create(
+            import_job=import_job,
+            fit_id=fit_id,
+            date_posted=date(2026, 1, 15),
+            amount=Decimal(amount),
+            name=f"API Staged Transaction {fit_id}",
+            memo=f"API staged transaction memo {fit_id}",
+            transaction_model=transaction_model,
+        )
+
+    def create_imported_transaction(self, import_job, account_model):
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=import_job.ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API Import Job Annotation Journal Entry",
+        )
+        return TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=account_model,
+            amount=Decimal("125.00"),
+            description="API imported transaction.",
+        )
+
+    def test_for_entity_accepts_entity_model_and_uuid(self):
+        setup = self.create_entity_setup(name="API Import Job Entity Scope A")
+        other_setup = self.create_entity_setup(
+            name="API Import Job Entity Scope B",
+            admin=self.other_admin_user,
+        )
+        import_job = self.create_import_job(setup, description="API Import Job A")
+        other_import_job = self.create_import_job(
+            other_setup,
+            description="API Import Job B",
+        )
+        entity_model = setup["entity_model"]
+
+        for entity_lookup in (entity_model, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                import_job_qs = ImportJobModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(import_job_qs.filter(uuid=import_job.uuid).exists())
+                self.assertFalse(
+                    import_job_qs.filter(uuid=other_import_job.uuid).exists()
+                )
+
+    def test_for_entity_slug_behavior(self):
+        setup = self.create_entity_setup(name="API Import Job Slug Scope A")
+        other_setup = self.create_entity_setup(
+            name="API Import Job Slug Scope B",
+            admin=self.other_admin_user,
+        )
+        import_job = self.create_import_job(setup, description="API Import Job Slug A")
+        other_import_job = self.create_import_job(
+            other_setup,
+            description="API Import Job Slug B",
+        )
+
+        import_job_qs = ImportJobModel.objects.for_entity(setup["entity_model"].slug)
+
+        self.assertTrue(import_job_qs.filter(uuid=import_job.uuid).exists())
+        self.assertFalse(import_job_qs.filter(uuid=other_import_job.uuid).exists())
+
+    def test_for_entity_rejects_invalid_input(self):
+        with self.assertRaises(ImportJobModelValidationError):
+            ImportJobModel.objects.for_entity(object())
+
+    def test_for_user_scopes_import_jobs_by_entity_access(self):
+        setup = self.create_entity_setup(name="API Import Job User Scope Entity")
+        other_setup = self.create_entity_setup(
+            name="API Import Job Other User Scope Entity",
+            admin=self.other_admin_user,
+        )
+        import_job = self.create_import_job(setup, description="API User Scope Job")
+        other_import_job = self.create_import_job(
+            other_setup,
+            description="API Other User Scope Job",
+        )
+
+        EntityManagementModel.objects.create(
+            entity=setup["entity_model"],
+            user=self.manager_user,
+            permission_level="read",
+        )
+
+        import_job_qs = ImportJobModel.objects.all()
+        admin_qs = import_job_qs.for_user(self.admin_user)
+        manager_qs = import_job_qs.for_user(self.manager_user)
+        unrelated_qs = import_job_qs.for_user(self.unrelated_user)
+        superuser_qs = import_job_qs.for_user(self.superuser)
+
+        self.assertTrue(admin_qs.filter(uuid=import_job.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_import_job.uuid).exists())
+
+        self.assertTrue(manager_qs.filter(uuid=import_job.uuid).exists())
+        self.assertFalse(manager_qs.filter(uuid=other_import_job.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=import_job.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_import_job.uuid).exists())
+
+        self.assertTrue(superuser_qs.filter(uuid=import_job.uuid).exists())
+        self.assertTrue(superuser_qs.filter(uuid=other_import_job.uuid).exists())
+
+    def test_manager_annotations_track_pending_and_complete_jobs(self):
+        setup = self.create_entity_setup(name="API Import Job Annotation Entity")
+        pending_job = self.create_import_job(setup, description="API Pending Import Job")
+        complete_job = self.create_import_job(setup, description="API Complete Import Job")
+        empty_job = self.create_import_job(setup, description="API Empty Import Job")
+
+        self.create_staged_transaction(
+            pending_job,
+            fit_id="FIT-PENDING-001",
+            amount="125.00",
+        )
+        imported_transaction = self.create_imported_transaction(
+            complete_job,
+            setup["cash_account"],
+        )
+        self.create_staged_transaction(
+            complete_job,
+            fit_id="FIT-IMPORTED-001",
+            amount="125.00",
+            transaction_model=imported_transaction,
+        )
+
+        annotated_pending_job = ImportJobModel.objects.get(uuid=pending_job.uuid)
+        annotated_complete_job = ImportJobModel.objects.get(uuid=complete_job.uuid)
+        annotated_empty_job = ImportJobModel.objects.get(uuid=empty_job.uuid)
+
+        self.assertEqual(annotated_pending_job.txs_count, 1)
+        self.assertEqual(annotated_pending_job.txs_imported_count, 0)
+        self.assertEqual(annotated_pending_job.txs_pending, 1)
+        self.assertFalse(annotated_pending_job.is_complete)
+
+        self.assertEqual(annotated_complete_job.txs_count, 1)
+        self.assertEqual(annotated_complete_job.txs_imported_count, 1)
+        self.assertEqual(annotated_complete_job.txs_pending, 0)
+        self.assertTrue(annotated_complete_job.is_complete)
+
+        self.assertEqual(annotated_empty_job.txs_count, 0)
+        self.assertEqual(annotated_empty_job.txs_imported_count, 0)
+        self.assertEqual(annotated_empty_job.txs_pending, 0)
+        self.assertFalse(annotated_empty_job.is_complete)

--- a/django_ledger/tests/api/test_invoice_api.py
+++ b/django_ledger/tests/api/test_invoice_api.py
@@ -1,0 +1,299 @@
+"""
+High-level API behavior tests for InvoiceModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import InvoiceModel, ItemTransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+
+
+class InvoiceHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for InvoiceModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic invoice/customer/item lifecycle
+    invariants that should remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_invoice_contract_user",
+            email="api-invoice-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_invoice_setup(self, *, name="API Invoice Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Invoice Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name="API Invoice Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name="API Invoice Receivable Account",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        unearned_account = coa_model.create_account(
+            code="2310",
+            name="API Invoice Unearned Revenue Account",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name="API Invoice Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name="API Invoice COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name="API Invoice Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name="API Invoice Unit",
+            unit_abbr="api-inv",
+            active=True,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name="API Invoice Customer",
+            entity_model=entity_model,
+            description="API Invoice Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        service_item = entity_model.create_item_service(
+            name="API Invoice Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        product_item = entity_model.create_item_product(
+            name="API Invoice Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "unearned_account": unearned_account,
+            "inventory_account": inventory_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "uom_model": uom_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+            "product_item": product_item,
+        }
+
+    def create_configured_invoice(self, setup):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["unearned_account"],
+        )
+
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return invoice_model
+
+    def migrate_service_item(self, invoice_model, setup, *, quantity="2.00", unit_cost="50.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+
+        itemtxs = {
+            setup["service_item"].item_number: {
+                "quantity": quantity,
+                "unit_cost": unit_cost,
+                "total_amount": quantity * unit_cost,
+            }
+        }
+
+        invoice_model.migrate_itemtxs(
+            itemtxs=itemtxs,
+            operation=InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def test_invoice_configure_creates_draft_invoice_under_entity_and_customer(self):
+        setup = self.create_entity_with_invoice_setup()
+
+        invoice_model = self.create_configured_invoice(setup)
+
+        self.assertIsInstance(invoice_model, InvoiceModel)
+        self.assertIsNotNone(invoice_model.uuid)
+        self.assertEqual(invoice_model.ledger.entity_id, setup["entity_model"].uuid)
+        self.assertEqual(invoice_model.customer_id, setup["customer_model"].uuid)
+        self.assertTrue(invoice_model.is_draft())
+        self.assertFalse(invoice_model.is_approved())
+        self.assertFalse(invoice_model.is_paid())
+        self.assertTrue(invoice_model.invoice_number)
+
+    def test_invoice_item_migration_creates_item_transaction(self):
+        setup = self.create_entity_with_invoice_setup()
+        invoice_model = self.create_configured_invoice(setup)
+
+        self.migrate_service_item(invoice_model, setup)
+
+        item_txs = ItemTransactionModel.objects.filter(invoice_model=invoice_model)
+
+        self.assertEqual(item_txs.count(), 1)
+
+        item_tx = item_txs.get()
+
+        self.assertEqual(item_tx.item_model_id, setup["service_item"].uuid)
+        self.assertEqual(item_tx.quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.unit_cost, Decimal("50.00"))
+        self.assertEqual(item_tx.total_amount, Decimal("100.00"))
+
+    def test_invoice_item_migration_updates_amount_due(self):
+        setup = self.create_entity_with_invoice_setup()
+        invoice_model = self.create_configured_invoice(setup)
+
+        invoice_model = self.migrate_service_item(invoice_model, setup)
+
+        self.assertEqual(invoice_model.amount_due, Decimal("100.00"))
+        self.assertEqual(invoice_model.amount_paid, Decimal("0.00"))
+
+    def test_invoice_for_entity_queryset_limits_scope(self):
+        setup = self.create_entity_with_invoice_setup(name="API Invoice Entity A")
+        other_setup = self.create_entity_with_invoice_setup(name="API Invoice Entity B")
+
+        invoice_model = self.create_configured_invoice(setup)
+        other_invoice_model = self.create_configured_invoice(other_setup)
+
+        scoped_qs = InvoiceModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=invoice_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_invoice_model.uuid).exists())
+
+    def test_invoice_can_move_from_draft_to_review(self):
+        setup = self.create_entity_with_invoice_setup()
+        invoice_model = self.create_configured_invoice(setup)
+        invoice_model = self.migrate_service_item(invoice_model, setup)
+
+        invoice_model.mark_as_review(commit=True)
+        invoice_model.refresh_from_db()
+
+        self.assertTrue(invoice_model.is_review())
+        self.assertFalse(invoice_model.is_draft())
+
+    def test_invoice_can_move_from_review_to_approved(self):
+        setup = self.create_entity_with_invoice_setup()
+        invoice_model = self.create_configured_invoice(setup)
+        invoice_model = self.migrate_service_item(invoice_model, setup)
+
+        invoice_model.mark_as_review(commit=True)
+        invoice_model.refresh_from_db()
+
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+
+        self.assertTrue(invoice_model.is_approved())
+        self.assertFalse(invoice_model.is_paid())
+        self.assertEqual(invoice_model.amount_due, Decimal("100.00"))
+
+    def test_approved_invoice_can_be_marked_paid(self):
+        setup = self.create_entity_with_invoice_setup()
+        invoice_model = self.create_configured_invoice(setup)
+        invoice_model = self.migrate_service_item(invoice_model, setup)
+
+        invoice_model.mark_as_review(commit=True)
+        invoice_model.refresh_from_db()
+
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+
+        invoice_model.mark_as_paid(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+
+        self.assertTrue(invoice_model.is_paid())
+        self.assertEqual(invoice_model.amount_paid, invoice_model.amount_due)

--- a/django_ledger/tests/api/test_invoice_configure_itemization_api.py
+++ b/django_ledger/tests/api/test_invoice_configure_itemization_api.py
@@ -1,0 +1,348 @@
+"""
+High-level API tests for InvoiceModel configuration and itemization behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.http import Http404
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import InvoiceModel, ItemTransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.invoice import InvoiceModelValidationError
+from django_ledger.models.items import ItemModel
+
+
+class InvoiceConfigureItemizationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_invoice_configure_user",
+            email="api-invoice-configure-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_invoice_configure_unrelated",
+            email="api-invoice-configure-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Invoice Configure Entity",
+        use_accrual_method=True,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=use_accrual_method,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        deferred_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"i-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        product_item = entity_model.create_item_product(
+            name=f"{name} Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "deferred_account": deferred_account,
+            "expense_account": expense_account,
+            "cogs_account": cogs_account,
+            "inventory_account": inventory_account,
+            "income_account": income_account,
+            "customer_model": customer_model,
+            "service_item": service_item,
+            "product_item": product_item,
+            "expense_item": expense_item,
+        }
+
+    def build_invoice(self, setup, **overrides):
+        invoice_kwargs = {
+            "customer": setup["customer_model"],
+            "terms": InvoiceModel.TERMS_NET_30,
+            "cash_account": setup["cash_account"],
+            "prepaid_account": setup["receivable_account"],
+            "unearned_account": setup["deferred_account"],
+        }
+        invoice_kwargs.update(overrides)
+        return InvoiceModel(**invoice_kwargs)
+
+    def configure_invoice(
+        self,
+        setup,
+        *,
+        entity_input=None,
+        user_model=None,
+        commit=True,
+        commit_ledger=False,
+        **invoice_overrides,
+    ):
+        invoice_model = self.build_invoice(setup, **invoice_overrides)
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"] if entity_input is None else entity_input,
+            user_model=self.user if user_model is None else user_model,
+            date_draft=date(2026, 1, 15),
+            ledger_name="API Invoice Configure Ledger",
+            commit=commit,
+            commit_ledger=commit_ledger,
+        )
+        if commit:
+            invoice_model.refresh_from_db()
+        return invoice_model
+
+    def migrate_service_item(self, invoice_model, setup, *, quantity="2.00", unit_cost="50.00", operation=None):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        itemtxs = {
+            setup["service_item"].item_number: {
+                "quantity": quantity,
+                "unit_cost": unit_cost,
+                "total_amount": quantity * unit_cost,
+            }
+        }
+        itemtxs_batch = invoice_model.migrate_itemtxs(
+            itemtxs=itemtxs,
+            operation=operation or InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model, itemtxs_batch
+
+    def test_configure_accepts_entity_model_and_authorized_slug(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        by_model = self.configure_invoice(setup, entity_input=entity_model)
+        by_slug = self.configure_invoice(setup, entity_input=entity_model.slug)
+
+        self.assertEqual(by_model.entity_model_id, entity_model.uuid)
+        self.assertEqual(by_slug.entity_model_id, entity_model.uuid)
+        self.assertEqual(by_model.customer_id, setup["customer_model"].uuid)
+        self.assertEqual(by_slug.customer_id, setup["customer_model"].uuid)
+        self.assertTrue(by_model.invoice_number)
+        self.assertTrue(by_slug.invoice_number)
+
+    def test_configure_rejects_uuid_entity_input_and_unauthorized_slug(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Rejection Entity")
+
+        with self.assertRaises(InvoiceModelValidationError):
+            self.configure_invoice(setup, entity_input=setup["entity_model"].uuid)
+
+        with self.assertRaises(InvoiceModelValidationError):
+            self.build_invoice(setup).configure(entity_slug=setup["entity_model"].slug)
+
+        with self.assertRaises(Http404):
+            self.configure_invoice(setup, entity_input=setup["entity_model"].slug, user_model=self.unrelated_user)
+
+    def test_configure_commit_false_persists_wrapper_ledger_but_not_invoice(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Commit False Entity")
+
+        invoice_model = self.configure_invoice(setup, commit=False, commit_ledger=False)
+
+        self.assertTrue(invoice_model.is_configured())
+        self.assertTrue(invoice_model.invoice_number)
+        self.assertIsNotNone(invoice_model.ledger_id)
+        self.assertFalse(InvoiceModel.objects.filter(uuid=invoice_model.uuid).exists())
+        self.assertTrue(invoice_model.ledger.__class__.objects.filter(uuid=invoice_model.ledger_id).exists())
+        self.assertTrue(invoice_model.ledger.ledger_xid)
+
+    def test_configure_commit_ledger_true_persists_ledger_without_persisting_invoice(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Ledger Commit Entity")
+
+        invoice_model = self.configure_invoice(setup, commit=False, commit_ledger=True)
+
+        self.assertFalse(InvoiceModel.objects.filter(uuid=invoice_model.uuid).exists())
+        self.assertTrue(invoice_model.ledger.__class__.objects.filter(uuid=invoice_model.ledger_id).exists())
+
+    def test_configure_sets_accrual_behavior_from_entity_accounting_method(self):
+        accrual_setup = self.create_entity_setup(name="API Invoice Configure Accrual Entity", use_accrual_method=True)
+        cash_setup = self.create_entity_setup(name="API Invoice Configure Cash Entity", use_accrual_method=False)
+
+        accrual_invoice = self.configure_invoice(accrual_setup)
+        cash_invoice = self.configure_invoice(cash_setup)
+
+        self.assertTrue(accrual_invoice.accrue)
+        self.assertEqual(accrual_invoice.progress, Decimal("1.00"))
+        self.assertFalse(cash_invoice.accrue)
+
+    def test_clean_rejects_invalid_account_roles(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Invalid Role Entity")
+
+        with self.assertRaises(ValidationError):
+            self.configure_invoice(setup, cash_account=setup["expense_account"])
+
+        with self.assertRaises(ValidationError):
+            self.configure_invoice(setup, prepaid_account=setup["cash_account"])
+
+        with self.assertRaises(ValidationError):
+            self.configure_invoice(setup, unearned_account=setup["cash_account"])
+
+    def test_get_item_model_qs_returns_invoice_eligible_items(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Item Query Entity")
+        invoice_model = self.configure_invoice(setup)
+
+        item_qs = invoice_model.get_item_model_qs()
+
+        self.assertTrue(item_qs.filter(uuid=setup["service_item"].uuid).exists())
+        self.assertTrue(item_qs.filter(uuid=setup["product_item"].uuid).exists())
+        self.assertFalse(item_qs.filter(uuid=setup["expense_item"].uuid).exists())
+
+    def test_migrate_itemtxs_replace_creates_invoice_items_and_updates_amount_due(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Item Migration Entity")
+        invoice_model = self.configure_invoice(setup)
+
+        invoice_model, itemtxs_batch = self.migrate_service_item(invoice_model, setup)
+
+        self.assertEqual(len(itemtxs_batch), 1)
+        item_tx = ItemTransactionModel.objects.get(invoice_model=invoice_model)
+        self.assertEqual(item_tx.item_model_id, setup["service_item"].uuid)
+        self.assertEqual(item_tx.quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.unit_cost, Decimal("50.00"))
+        self.assertEqual(item_tx.total_amount, Decimal("100.00"))
+        self.assertEqual(invoice_model.amount_due, Decimal("100.00"))
+
+        invoice_model, replacement_batch = self.migrate_service_item(
+            invoice_model,
+            setup,
+            quantity="1.00",
+            unit_cost="25.00",
+        )
+        self.assertEqual(len(replacement_batch), 1)
+        self.assertEqual(ItemTransactionModel.objects.filter(invoice_model=invoice_model).count(), 1)
+        self.assertEqual(invoice_model.amount_due, Decimal("25.00"))
+
+    def test_validate_itemtxs_qs_rejects_transactions_from_another_invoice(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Validate ItemTx Entity")
+        invoice_model = self.configure_invoice(setup)
+        other_invoice_model = self.configure_invoice(setup)
+        other_invoice_model, _itemtxs_batch = self.migrate_service_item(other_invoice_model, setup)
+        other_itemtxs = list(ItemTransactionModel.objects.filter(invoice_model=other_invoice_model))
+
+        with self.assertRaises(InvoiceModelValidationError):
+            invoice_model.validate_itemtxs_qs(other_itemtxs)
+
+    def test_get_itemtxs_data_and_update_amount_due_use_item_transaction_totals(self):
+        setup = self.create_entity_setup(name="API Invoice Configure Item Data Entity")
+        invoice_model = self.configure_invoice(setup)
+        invoice_model, _itemtxs_batch = self.migrate_service_item(invoice_model, setup)
+
+        itemtxs_qs, itemtxs_data = invoice_model.get_itemtxs_data()
+
+        self.assertEqual(itemtxs_qs.count(), 1)
+        self.assertEqual(itemtxs_data["total_amount__sum"], Decimal("100.00"))
+        self.assertEqual(itemtxs_data["total_items"], 1)
+
+        invoice_model.amount_due = Decimal("0.00")
+        invoice_model.update_amount_due(itemtxs_qs=itemtxs_qs)
+
+        self.assertEqual(invoice_model.amount_due, Decimal("100.00"))

--- a/django_ledger/tests/api/test_invoice_lifecycle_api.py
+++ b/django_ledger/tests/api/test_invoice_lifecycle_api.py
@@ -1,0 +1,332 @@
+"""
+High-level API tests for InvoiceModel lifecycle transitions.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import InvoiceModel, ItemTransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.invoice import InvoiceModelValidationError
+from django_ledger.models.items import ItemModel
+
+
+class InvoiceLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_invoice_lifecycle_user",
+            email="api-invoice-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Invoice Lifecycle Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"i-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} customer.",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+        }
+
+    def create_invoice(self, setup, *, date_draft=date(2025, 1, 15)):
+        invoice_model = setup["entity_model"].create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            date_draft=date_draft,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def migrate_service_item(self, invoice_model, setup, *, total_amount=Decimal("100.00")):
+        invoice_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": total_amount,
+                    "total_amount": total_amount,
+                }
+            },
+            operation=InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_review_invoice(self, setup):
+        invoice_model = self.migrate_service_item(self.create_invoice(setup), setup)
+        invoice_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_approved_invoice(self, setup):
+        invoice_model = self.make_review_invoice(setup)
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_paid_invoice(self, setup):
+        invoice_model = self.make_approved_invoice(setup)
+        invoice_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def test_valid_status_transitions_set_dates_and_ledger_state(self):
+        setup = self.create_entity_setup(name="API Invoice Lifecycle Valid Entity")
+        invoice_model = self.migrate_service_item(self.create_invoice(setup), setup)
+
+        invoice_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        invoice_model.refresh_from_db()
+        self.assertTrue(invoice_model.is_review())
+        self.assertEqual(invoice_model.date_in_review, date(2025, 1, 16))
+        self.assertFalse(invoice_model.ledger.posted)
+
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        self.assertTrue(invoice_model.is_approved())
+        self.assertEqual(invoice_model.date_approved, date(2025, 1, 17))
+        self.assertEqual(invoice_model.date_due, date(2025, 2, 16))
+        self.assertTrue(invoice_model.ledger.posted)
+        self.assertFalse(invoice_model.ledger.locked)
+
+        invoice_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        self.assertTrue(invoice_model.is_paid())
+        self.assertEqual(invoice_model.date_paid, date(2025, 1, 18))
+        self.assertEqual(invoice_model.amount_paid, invoice_model.amount_due)
+        self.assertTrue(invoice_model.ledger.locked)
+
+    def test_mark_as_draft_returns_review_invoice_to_draft_and_sets_draft_date(self):
+        setup = self.create_entity_setup(name="API Invoice Lifecycle Draft Entity")
+        invoice_model = self.make_review_invoice(setup)
+
+        invoice_model.mark_as_draft(draft_date=date(2025, 1, 19), commit=True)
+        invoice_model.refresh_from_db()
+
+        self.assertTrue(invoice_model.is_draft())
+        self.assertEqual(invoice_model.date_draft, date(2025, 1, 19))
+
+    def test_cancel_and_void_transitions_set_terminal_status_dates(self):
+        setup = self.create_entity_setup(name="API Invoice Lifecycle Terminal Entity")
+
+        draft_invoice = self.create_invoice(setup)
+        draft_invoice.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        draft_invoice.refresh_from_db()
+        self.assertTrue(draft_invoice.is_canceled())
+        self.assertEqual(draft_invoice.date_canceled, date(2025, 1, 20))
+
+        review_invoice = self.make_review_invoice(setup)
+        review_invoice.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 21))
+        review_invoice.refresh_from_db()
+        self.assertTrue(review_invoice.is_canceled())
+        self.assertEqual(review_invoice.date_canceled, date(2025, 1, 21))
+
+        approved_invoice = self.make_approved_invoice(setup)
+        approved_invoice.mark_as_void(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_void=date(2025, 1, 22),
+            commit=True,
+        )
+        approved_invoice.refresh_from_db()
+        self.assertTrue(approved_invoice.is_void())
+        self.assertEqual(approved_invoice.date_void, date(2025, 1, 22))
+        self.assertEqual(approved_invoice.amount_paid, Decimal("0.00"))
+        self.assertTrue(approved_invoice.ledger.locked)
+
+    def test_invalid_transitions_raise_validation_errors(self):
+        setup = self.create_entity_setup(name="API Invoice Lifecycle Invalid Entity")
+        draft_invoice = self.create_invoice(setup)
+
+        with self.assertRaises(InvoiceModelValidationError):
+            draft_invoice.mark_as_paid(
+                entity_slug=setup["entity_model"].slug,
+                user_model=self.user,
+                date_paid=date(2025, 1, 18),
+                commit=True,
+            )
+
+        paid_invoice = self.make_paid_invoice(setup)
+        with self.assertRaises(InvoiceModelValidationError):
+            paid_invoice.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 19))
+        with self.assertRaises(InvoiceModelValidationError):
+            paid_invoice.mark_as_void(
+                entity_slug=setup["entity_model"].slug,
+                user_model=self.user,
+                date_void=date(2025, 1, 19),
+                commit=True,
+            )
+
+        canceled_invoice = self.create_invoice(setup)
+        canceled_invoice.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        with self.assertRaises(InvoiceModelValidationError):
+            canceled_invoice.mark_as_review(commit=True, date_in_review=date(2025, 1, 21))
+
+    def test_can_predicates_reflect_status_transitions(self):
+        setup = self.create_entity_setup(name="API Invoice Lifecycle Predicate Entity")
+        draft_invoice = self.create_invoice(setup)
+
+        self.assertFalse(draft_invoice.can_draft())
+        self.assertTrue(draft_invoice.can_review())
+        self.assertFalse(draft_invoice.can_approve())
+        self.assertFalse(draft_invoice.can_pay())
+        self.assertFalse(draft_invoice.can_void())
+        self.assertTrue(draft_invoice.can_cancel())
+
+        review_invoice = self.make_review_invoice(setup)
+        self.assertTrue(review_invoice.can_draft())
+        self.assertTrue(review_invoice.can_approve())
+        self.assertFalse(review_invoice.can_pay())
+        self.assertFalse(review_invoice.can_void())
+        self.assertTrue(review_invoice.can_cancel())
+
+        approved_invoice = self.make_approved_invoice(setup)
+        self.assertFalse(approved_invoice.can_draft())
+        self.assertFalse(approved_invoice.can_approve())
+        self.assertTrue(approved_invoice.can_pay())
+        self.assertTrue(approved_invoice.can_void())
+        self.assertFalse(approved_invoice.can_cancel())
+
+        paid_invoice = self.make_paid_invoice(setup)
+        self.assertFalse(paid_invoice.can_pay())
+        self.assertFalse(paid_invoice.can_void())
+        self.assertFalse(paid_invoice.can_cancel())
+
+    def test_commit_false_transitions_mutate_in_memory_without_persisting(self):
+        setup = self.create_entity_setup(name="API Invoice Lifecycle Commit False Entity")
+        invoice_model = self.migrate_service_item(self.create_invoice(setup), setup)
+
+        invoice_model.mark_as_review(commit=False, date_in_review=date(2025, 1, 16))
+        self.assertTrue(invoice_model.is_review())
+        self.assertEqual(invoice_model.date_in_review, date(2025, 1, 16))
+        db_invoice = InvoiceModel.objects.get(uuid=invoice_model.uuid)
+        self.assertTrue(db_invoice.is_draft())
+        self.assertIsNone(db_invoice.date_in_review)
+
+        invoice_model.refresh_from_db()
+        invoice_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        invoice_model.refresh_from_db()
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=False,
+        )
+        self.assertTrue(invoice_model.is_approved())
+        self.assertEqual(invoice_model.date_approved, date(2025, 1, 17))
+        db_invoice = InvoiceModel.objects.get(uuid=invoice_model.uuid)
+        self.assertTrue(db_invoice.is_review())
+        self.assertIsNone(db_invoice.date_approved)
+        self.assertFalse(db_invoice.ledger.posted)
+
+    def test_review_rejects_invoice_without_items(self):
+        setup = self.create_entity_setup(name="API Invoice Lifecycle No Items Entity")
+        invoice_model = self.create_invoice(setup)
+
+        with self.assertRaises(InvoiceModelValidationError):
+            invoice_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        self.assertFalse(ItemTransactionModel.objects.filter(invoice_model=invoice_model).exists())

--- a/django_ledger/tests/api/test_invoice_payment_void_delete_api.py
+++ b/django_ledger/tests/api/test_invoice_payment_void_delete_api.py
@@ -1,0 +1,293 @@
+"""
+High-level API tests for InvoiceModel payment, void, cancel, and delete behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import InvoiceModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.invoice import InvoiceModelValidationError
+from django_ledger.models.items import ItemModel
+
+
+class InvoicePaymentVoidDeleteAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_invoice_payment_user",
+            email="api-invoice-payment-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Invoice Payment Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"i-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} customer.",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+        }
+
+    def create_invoice(self, setup):
+        invoice_model = setup["entity_model"].create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def migrate_service_item(self, invoice_model, setup, *, total_amount=Decimal("100.00")):
+        invoice_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": total_amount,
+                    "total_amount": total_amount,
+                }
+            },
+            operation=InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_review_invoice(self, setup):
+        invoice_model = self.migrate_service_item(self.create_invoice(setup), setup)
+        invoice_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_approved_invoice(self, setup):
+        invoice_model = self.make_review_invoice(setup)
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_paid_invoice(self, setup):
+        invoice_model = self.make_approved_invoice(setup)
+        invoice_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def test_make_payment_partial_commit_true_updates_amounts_without_paid_status(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Partial Entity")
+        invoice_model = self.make_approved_invoice(setup)
+
+        invoice_model.make_payment(
+            payment_amount=Decimal("25.00"),
+            payment_date=date(2025, 1, 18),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+
+        self.assertTrue(invoice_model.is_approved())
+        self.assertEqual(invoice_model.amount_paid, Decimal("25.00"))
+        self.assertEqual(invoice_model.amount_due, Decimal("100.00"))
+        self.assertTrue(invoice_model.can_make_payment())
+
+    def test_make_payment_accepts_payment_date_before_approval_as_current_behavior(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Early Entity")
+        invoice_model = self.make_approved_invoice(setup)
+
+        invoice_model.make_payment(
+            payment_amount=Decimal("25.00"),
+            payment_date=date(2025, 1, 16),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+
+        self.assertEqual(invoice_model.date_approved, date(2025, 1, 17))
+        self.assertEqual(invoice_model.amount_paid, Decimal("25.00"))
+
+    def test_make_payment_rejects_overpayment_and_characterizes_no_raise_path(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Overpay Entity")
+        invoice_model = self.make_approved_invoice(setup)
+
+        with self.assertRaises(InvoiceModelValidationError):
+            invoice_model.make_payment(payment_amount=Decimal("150.00"), commit=True)
+        self.assertGreater(invoice_model.amount_paid, invoice_model.amount_due)
+        invoice_model.refresh_from_db()
+        self.assertEqual(invoice_model.amount_paid, Decimal("0.00"))
+
+        invoice_model.make_payment(
+            payment_amount=Decimal("150.00"),
+            commit=True,
+            raise_exception=False,
+        )
+        self.assertGreater(invoice_model.amount_paid, invoice_model.amount_due)
+        invoice_model.refresh_from_db()
+        self.assertEqual(invoice_model.amount_paid, Decimal("0.00"))
+
+    def test_mark_as_paid_pays_invoice_and_locks_ledger(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Paid Entity")
+        invoice_model = self.make_approved_invoice(setup)
+
+        invoice_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+
+        self.assertTrue(invoice_model.is_paid())
+        self.assertEqual(invoice_model.amount_paid, invoice_model.amount_due)
+        self.assertEqual(invoice_model.date_paid, date(2025, 1, 18))
+        self.assertTrue(invoice_model.ledger.locked)
+
+    def test_mark_as_void_voids_unpaid_approved_invoice_and_locks_ledger(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Void Entity")
+        invoice_model = self.make_approved_invoice(setup)
+
+        invoice_model.mark_as_void(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_void=date(2025, 1, 19),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+
+        self.assertTrue(invoice_model.is_void())
+        self.assertEqual(invoice_model.date_void, date(2025, 1, 19))
+        self.assertEqual(invoice_model.amount_paid, Decimal("0.00"))
+        self.assertEqual(invoice_model.amount_due, Decimal("100.00"))
+        self.assertTrue(invoice_model.ledger.locked)
+
+    def test_cancel_rejects_active_invoices_and_allows_draft_or_review_invoices(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Cancel Entity")
+
+        draft_invoice = self.create_invoice(setup)
+        draft_invoice.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        draft_invoice.refresh_from_db()
+        self.assertTrue(draft_invoice.is_canceled())
+
+        review_invoice = self.make_review_invoice(setup)
+        review_invoice.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 21))
+        review_invoice.refresh_from_db()
+        self.assertTrue(review_invoice.is_canceled())
+
+        approved_invoice = self.make_approved_invoice(setup)
+        with self.assertRaises(InvoiceModelValidationError):
+            approved_invoice.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 22))
+        approved_invoice.refresh_from_db()
+        self.assertTrue(approved_invoice.is_approved())
+
+    def test_delete_defaults_to_cancel_and_force_delete_removes_deletable_invoice(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Delete Entity")
+
+        cancel_invoice = self.create_invoice(setup)
+        cancel_invoice.delete()
+        cancel_invoice.refresh_from_db()
+        self.assertTrue(cancel_invoice.is_canceled())
+
+        delete_invoice = self.create_invoice(setup)
+        delete_uuid = delete_invoice.uuid
+        delete_invoice.delete(force_db_delete=True)
+        self.assertFalse(InvoiceModel.objects.filter(uuid=delete_uuid).exists())
+
+    def test_force_delete_rejects_locked_paid_invoice_and_leaves_it_intact(self):
+        setup = self.create_entity_setup(name="API Invoice Payment Delete Guard Entity")
+        paid_invoice = self.make_paid_invoice(setup)
+        paid_uuid = paid_invoice.uuid
+
+        with self.assertRaises(InvoiceModelValidationError):
+            paid_invoice.delete(force_db_delete=True)
+
+        persisted_invoice = InvoiceModel.objects.get(uuid=paid_uuid)
+        self.assertTrue(persisted_invoice.is_paid())
+        self.assertTrue(persisted_invoice.ledger.locked)

--- a/django_ledger/tests/api/test_invoice_queryset_api.py
+++ b/django_ledger/tests/api/test_invoice_queryset_api.py
@@ -1,0 +1,303 @@
+"""
+High-level API tests for InvoiceModel queryset and manager behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import InvoiceModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.invoice import InvoiceModelValidationError
+from django_ledger.models.items import ItemModel
+
+
+class InvoiceQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_invoice_queryset_admin",
+            email="api-invoice-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_invoice_queryset_manager",
+            email="api-invoice-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_invoice_queryset_other_admin",
+            email="api-invoice-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_invoice_queryset_unrelated",
+            email="api-invoice-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_invoice_queryset_superuser",
+            email="api-invoice-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Invoice Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        deferred_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"i-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "deferred_account": deferred_account,
+            "customer_model": customer_model,
+            "service_item": service_item,
+        }
+
+    def create_invoice(self, setup, *, date_draft=date(2026, 1, 15)):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["deferred_account"],
+        )
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_draft=date_draft,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def migrate_service_item(self, invoice_model, setup, *, quantity="2.00", unit_cost="50.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        invoice_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def move_to_review(self, invoice_model, setup):
+        invoice_model = self.migrate_service_item(invoice_model, setup)
+        invoice_model.mark_as_review(commit=True, date_in_review=date(2026, 1, 16))
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def move_to_approved(self, invoice_model, setup):
+        invoice_model = self.move_to_review(invoice_model, setup)
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def move_to_paid(self, invoice_model, setup):
+        invoice_model = self.move_to_approved(invoice_model, setup)
+        invoice_model.mark_as_paid(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def move_to_void(self, invoice_model, setup):
+        invoice_model = self.move_to_approved(invoice_model, setup)
+        invoice_model.mark_as_void(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def move_to_canceled(self, invoice_model):
+        invoice_model.mark_as_canceled(date_canceled=date(2026, 1, 20), commit=True)
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def assert_invoice_uuids(self, queryset, expected_invoices):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {invoice_model.uuid for invoice_model in expected_invoices},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Invoice Queryset Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Invoice Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        invoice_model = self.create_invoice(setup)
+        self.create_invoice(other_setup)
+        entity_model = setup["entity_model"]
+
+        self.assert_invoice_uuids(InvoiceModel.objects.for_entity(entity_model), [invoice_model])
+        self.assert_invoice_uuids(InvoiceModel.objects.for_entity(entity_model.slug), [invoice_model])
+        self.assert_invoice_uuids(InvoiceModel.objects.for_entity(entity_model.uuid), [invoice_model])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_invoice(self.create_entity_setup())
+
+        with self.assertRaises(InvoiceModelValidationError):
+            InvoiceModel.objects.for_entity(object())
+
+        self.assertFalse(InvoiceModel.objects.for_entity("missing-invoice-entity-slug").exists())
+
+    def test_for_user_scopes_to_authorized_users_and_superuser(self):
+        setup = self.create_entity_setup(
+            name="API Invoice Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API Invoice Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        invoice_model = self.create_invoice(setup)
+        other_invoice_model = self.create_invoice(other_setup)
+
+        self.assert_invoice_uuids(InvoiceModel.objects.all().for_user(self.admin_user), [invoice_model])
+        self.assert_invoice_uuids(InvoiceModel.objects.all().for_user(self.manager_user), [invoice_model])
+        self.assertFalse(InvoiceModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_invoice_uuids(
+            InvoiceModel.objects.all().for_user(self.superuser),
+            [invoice_model, other_invoice_model],
+        )
+
+    def test_status_filters_return_matching_invoices(self):
+        setup = self.create_entity_setup(name="API Invoice Queryset Status Entity")
+        draft_invoice = self.create_invoice(setup)
+        review_invoice = self.move_to_review(self.create_invoice(setup), setup)
+        approved_invoice = self.move_to_approved(self.create_invoice(setup), setup)
+        paid_invoice = self.move_to_paid(self.create_invoice(setup), setup)
+        void_invoice = self.move_to_void(self.create_invoice(setup), setup)
+        canceled_invoice = self.move_to_canceled(self.create_invoice(setup))
+
+        invoices_qs = InvoiceModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_invoice_uuids(invoices_qs.draft(), [draft_invoice])
+        self.assert_invoice_uuids(invoices_qs.in_review(), [review_invoice])
+        self.assert_invoice_uuids(invoices_qs.approved(), [approved_invoice])
+        self.assert_invoice_uuids(invoices_qs.paid(), [paid_invoice])
+        self.assert_invoice_uuids(invoices_qs.void(), [void_invoice])
+        self.assert_invoice_uuids(invoices_qs.canceled(), [canceled_invoice])
+
+    def test_semantic_filters_return_active_unpaid_and_overdue_invoices(self):
+        setup = self.create_entity_setup(name="API Invoice Queryset Semantic Entity")
+        draft_invoice = self.create_invoice(setup)
+        approved_invoice = self.move_to_approved(self.create_invoice(setup), setup)
+        paid_invoice = self.move_to_paid(self.create_invoice(setup), setup)
+        void_invoice = self.move_to_void(self.create_invoice(setup), setup)
+
+        overdue_invoice = self.create_invoice(setup)
+        overdue_invoice.date_due = date(2000, 1, 1)
+        overdue_invoice.save(update_fields=["date_due", "updated"])
+
+        future_due_invoice = self.create_invoice(setup)
+        future_due_invoice.date_due = date(2099, 1, 1)
+        future_due_invoice.save(update_fields=["date_due", "updated"])
+
+        invoices_qs = InvoiceModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_invoice_uuids(invoices_qs.active(), [approved_invoice, paid_invoice])
+        self.assert_invoice_uuids(invoices_qs.unpaid(), [approved_invoice])
+        self.assertTrue(invoices_qs.overdue().filter(uuid=overdue_invoice.uuid).exists())
+        self.assertFalse(invoices_qs.overdue().filter(uuid=future_due_invoice.uuid).exists())
+        self.assertFalse(invoices_qs.active().filter(uuid=draft_invoice.uuid).exists())
+        self.assertFalse(invoices_qs.active().filter(uuid=void_invoice.uuid).exists())

--- a/django_ledger/tests/api/test_invoice_url_signal_api.py
+++ b/django_ledger/tests/api/test_invoice_url_signal_api.py
@@ -1,0 +1,317 @@
+"""
+Smoke tests for InvoiceModel URL, display, and lifecycle signal behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import InvoiceModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.signals import (
+    invoice_status_approved,
+    invoice_status_canceled,
+    invoice_status_draft,
+    invoice_status_in_review,
+    invoice_status_paid,
+    invoice_status_void,
+)
+
+
+class InvoiceURLSignalAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_invoice_url_signal_user",
+            email="api-invoice-url-signal-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Invoice URL Signal Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue Account",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"i-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} customer.",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "service_item": service_item,
+        }
+
+    def create_invoice(self, setup):
+        invoice_model = setup["entity_model"].create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def migrate_service_item(self, invoice_model, setup):
+        invoice_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": Decimal("100.00"),
+                    "total_amount": Decimal("100.00"),
+                }
+            },
+            operation=InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_review_invoice(self, setup):
+        invoice_model = self.migrate_service_item(self.create_invoice(setup), setup)
+        invoice_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def make_approved_invoice(self, setup):
+        invoice_model = self.make_review_invoice(setup)
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def collect_signal_calls(self, signal):
+        calls = []
+        dispatch_uid = f"{self.id()}-{id(signal)}"
+
+        def receiver(sender, **kwargs):
+            calls.append(kwargs)
+
+        signal.connect(
+            receiver,
+            sender=InvoiceModel,
+            weak=False,
+            dispatch_uid=dispatch_uid,
+        )
+        self.addCleanup(
+            signal.disconnect,
+            sender=InvoiceModel,
+            dispatch_uid=dispatch_uid,
+        )
+        return calls
+
+    def assert_signal_received_once(self, calls, invoice_model, *, commit):
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0]["instance"], invoice_model)
+        self.assertEqual(calls[0]["commited"], commit)
+
+    def assert_entity_invoice_url(self, url, setup, invoice_model):
+        self.assertIsInstance(url, str)
+        self.assertIn(setup["entity_model"].slug, url)
+        self.assertIn(str(invoice_model.uuid), url)
+
+    def test_url_helpers_return_entity_scoped_strings(self):
+        setup = self.create_entity_setup(name="API Invoice URL Helper Entity")
+        invoice_model = self.create_invoice(setup)
+
+        url_helpers = [
+            invoice_model.get_absolute_url,
+            invoice_model.get_mark_as_draft_url,
+            invoice_model.get_mark_as_review_url,
+            invoice_model.get_mark_as_approved_url,
+            invoice_model.get_mark_as_paid_url,
+            invoice_model.get_mark_as_void_url,
+            invoice_model.get_mark_as_canceled_url,
+        ]
+
+        for helper in url_helpers:
+            self.assert_entity_invoice_url(helper(), setup, invoice_model)
+
+    def test_display_message_and_html_helpers_include_stable_context(self):
+        setup = self.create_entity_setup(name="API Invoice Display Helper Entity")
+        invoice_model = self.create_invoice(setup)
+
+        self.assertIn(invoice_model.invoice_number, str(invoice_model))
+        self.assertIn(invoice_model.get_invoice_status_display(), str(invoice_model))
+
+        title = invoice_model.generate_descriptive_title()
+        self.assertTrue(title.startswith("Invoice "))
+        self.assertIn("Invoice", title)
+        self.assertIn(invoice_model.invoice_number, title)
+        self.assertIn(setup["customer_model"].customer_name, title)
+        self.assertIn(invoice_model.get_invoice_status_display(), title)
+
+        html_helpers = [
+            invoice_model.get_html_id,
+            invoice_model.get_html_amount_due_id,
+            invoice_model.get_html_amount_paid_id,
+            invoice_model.get_html_form_id,
+            invoice_model.get_mark_as_draft_html_id,
+            invoice_model.get_mark_as_review_html_id,
+            invoice_model.get_mark_as_approved_html_id,
+            invoice_model.get_mark_as_paid_html_id,
+            invoice_model.get_mark_as_void_html_id,
+            invoice_model.get_mark_as_canceled_html_id,
+        ]
+        for helper in html_helpers:
+            self.assertIn(str(invoice_model.uuid), helper())
+
+        message_helpers = [
+            invoice_model.get_mark_as_draft_message,
+            invoice_model.get_mark_as_review_message,
+            invoice_model.get_mark_as_approved_message,
+            invoice_model.get_mark_as_paid_message,
+            invoice_model.get_mark_as_void_message,
+            invoice_model.get_mark_as_canceled_message,
+        ]
+        for helper in message_helpers:
+            self.assertIn(invoice_model.invoice_number, helper())
+
+    def test_mark_as_review_emits_invoice_status_in_review_signal(self):
+        setup = self.create_entity_setup(name="API Invoice Review Signal Entity")
+        invoice_model = self.migrate_service_item(self.create_invoice(setup), setup)
+        calls = self.collect_signal_calls(invoice_status_in_review)
+
+        invoice_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        self.assert_signal_received_once(calls, invoice_model, commit=True)
+
+    def test_mark_as_draft_emits_invoice_status_draft_signal(self):
+        setup = self.create_entity_setup(name="API Invoice Draft Signal Entity")
+        invoice_model = self.make_review_invoice(setup)
+        calls = self.collect_signal_calls(invoice_status_draft)
+
+        invoice_model.mark_as_draft(draft_date=date(2025, 1, 17), commit=True)
+
+        self.assert_signal_received_once(calls, invoice_model, commit=True)
+
+    def test_mark_as_approved_emits_invoice_status_approved_signal(self):
+        setup = self.create_entity_setup(name="API Invoice Approved Signal Entity")
+        invoice_model = self.make_review_invoice(setup)
+        calls = self.collect_signal_calls(invoice_status_approved)
+
+        invoice_model.mark_as_approved(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_approved=date(2025, 1, 17),
+            commit=True,
+        )
+
+        self.assert_signal_received_once(calls, invoice_model, commit=True)
+
+    def test_mark_as_paid_emits_invoice_status_paid_signal(self):
+        setup = self.create_entity_setup(name="API Invoice Paid Signal Entity")
+        invoice_model = self.make_approved_invoice(setup)
+        calls = self.collect_signal_calls(invoice_status_paid)
+
+        invoice_model.mark_as_paid(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_paid=date(2025, 1, 18),
+            commit=True,
+        )
+
+        self.assert_signal_received_once(calls, invoice_model, commit=True)
+
+    def test_mark_as_canceled_emits_invoice_status_canceled_signal(self):
+        setup = self.create_entity_setup(name="API Invoice Canceled Signal Entity")
+        invoice_model = self.create_invoice(setup)
+        calls = self.collect_signal_calls(invoice_status_canceled)
+
+        invoice_model.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+
+        self.assert_signal_received_once(calls, invoice_model, commit=True)
+
+    def test_mark_as_void_emits_invoice_status_void_signal(self):
+        setup = self.create_entity_setup(name="API Invoice Void Signal Entity")
+        invoice_model = self.make_approved_invoice(setup)
+        calls = self.collect_signal_calls(invoice_status_void)
+
+        invoice_model.mark_as_void(
+            entity_slug=setup["entity_model"].slug,
+            user_model=self.user,
+            date_void=date(2025, 1, 19),
+            commit=True,
+        )
+
+        self.assert_signal_received_once(calls, invoice_model, commit=True)

--- a/django_ledger/tests/api/test_io_api.py
+++ b/django_ledger/tests/api/test_io_api.py
@@ -1,0 +1,246 @@
+"""
+High-level API behavior tests for Django Ledger IO engine.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io.io_library import IOLibrary, IOBluePrint, IOCursorValidationError
+from django_ledger.models import AccountModel, JournalEntryModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+
+
+class IOHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for Django Ledger IO engine contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic posting-engine behavior that should
+    remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_io_contract_user",
+            email="api-io-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_with_accounting_setup(self, *, name="API IO Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API IO Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name="API IO Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name="API IO Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+
+        return entity_model, coa_model, cash_account, expense_account
+
+    def create_balanced_blueprint(self, *, cash_account, expense_account):
+        blueprint = IOBluePrint(name="api-io-expense-blueprint")
+
+        blueprint.debit(
+            account_code=expense_account.code,
+            amount=Decimal("100.00"),
+            description="API IO expense debit.",
+        )
+
+        blueprint.credit(
+            account_code=cash_account.code,
+            amount=Decimal("100.00"),
+            description="API IO cash credit.",
+        )
+
+        return blueprint
+
+    def first_commit_payload(self, commit_result):
+        self.assertEqual(
+            len(commit_result),
+            1,
+            "A single-blueprint commit without an explicit ledger should produce one ledger payload.",
+        )
+
+        return next(iter(commit_result.values()))
+
+    def test_io_blueprint_accepts_balanced_debit_credit_instructions(self):
+        _entity_model, _coa_model, cash_account, expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        blueprint = self.create_balanced_blueprint(
+            cash_account=cash_account,
+            expense_account=expense_account,
+        )
+
+        self.assertEqual(blueprint.name, "api-io-expense-blueprint")
+        self.assertEqual(len(blueprint.registry), 2)
+
+    def test_io_library_registers_blueprint_factory_by_function_name(self):
+        def expense_blueprint():
+            return IOBluePrint(name="api-io-expense-blueprint")
+
+        io_library = IOLibrary(name="api-io-library")
+        io_library.register(expense_blueprint)
+
+        self.assertIs(io_library.get_blueprint("expense_blueprint"), expense_blueprint)
+
+    def test_io_blueprint_commit_creates_balanced_journal_entry(self):
+        entity_model, _coa_model, cash_account, expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        blueprint = self.create_balanced_blueprint(
+            cash_account=cash_account,
+            expense_account=expense_account,
+        )
+
+        result = blueprint.commit(
+            entity_model=entity_model,
+            user_model=self.user,
+            je_timestamp=self.make_timestamp(),
+            post_new_ledgers=False,
+            post_journal_entries=False,
+        )
+
+        payload = self.first_commit_payload(result)
+
+        self.assertIn("ledger_model", payload)
+        self.assertIn("journal_entry", payload)
+        self.assertIn("txs_models", payload)
+
+        journal_entry = payload["journal_entry"]
+        transactions = payload["txs_models"]
+
+        self.assertIsInstance(journal_entry, JournalEntryModel)
+        self.assertEqual(journal_entry.ledger.entity_id, entity_model.uuid)
+        self.assertFalse(journal_entry.posted)
+        self.assertEqual(len(transactions), 2)
+
+        debit_total = sum(
+            tx.amount for tx in transactions if tx.tx_type == TransactionModel.DEBIT
+        )
+        credit_total = sum(
+            tx.amount for tx in transactions if tx.tx_type == TransactionModel.CREDIT
+        )
+
+        self.assertEqual(debit_total, Decimal("100.00"))
+        self.assertEqual(credit_total, Decimal("100.00"))
+        self.assertEqual(debit_total, credit_total)
+
+        self.assertTrue(
+            TransactionModel.objects.filter(
+                journal_entry=journal_entry,
+                tx_type=TransactionModel.DEBIT,
+                account=expense_account,
+                amount=Decimal("100.00"),
+            ).exists()
+        )
+
+        self.assertTrue(
+            TransactionModel.objects.filter(
+                journal_entry=journal_entry,
+                tx_type=TransactionModel.CREDIT,
+                account=cash_account,
+                amount=Decimal("100.00"),
+            ).exists()
+        )
+
+    def test_io_blueprint_commit_keeps_transactions_within_entity_default_coa(self):
+        entity_model, coa_model, cash_account, expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        blueprint = self.create_balanced_blueprint(
+            cash_account=cash_account,
+            expense_account=expense_account,
+        )
+
+        result = blueprint.commit(
+            entity_model=entity_model,
+            user_model=self.user,
+            je_timestamp=self.make_timestamp(),
+            post_new_ledgers=False,
+            post_journal_entries=False,
+        )
+
+        payload = self.first_commit_payload(result)
+        journal_entry = payload["journal_entry"]
+
+        tx_accounts = AccountModel.objects.filter(
+            transactionmodel__journal_entry=journal_entry,
+        )
+
+        self.assertEqual(tx_accounts.count(), 2)
+        self.assertTrue(tx_accounts.filter(uuid=cash_account.uuid).exists())
+        self.assertTrue(tx_accounts.filter(uuid=expense_account.uuid).exists())
+
+        for account in tx_accounts:
+            self.assertEqual(account.coa_model_id, coa_model.uuid)
+            self.assertFalse(account.is_root_account())
+            self.assertTrue(account.active)
+
+    def test_imbalanced_io_blueprint_commit_fails(self):
+        entity_model, _coa_model, cash_account, expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        blueprint = IOBluePrint(name="api-io-imbalanced-blueprint")
+        blueprint.debit(
+            account_code=expense_account.code,
+            amount=Decimal("100.00"),
+            description="API IO expense debit.",
+        )
+        blueprint.credit(
+            account_code=cash_account.code,
+            amount=Decimal("90.00"),
+            description="API IO cash credit.",
+        )
+
+        with self.assertRaises(IOCursorValidationError):
+            blueprint.commit(
+                entity_model=entity_model,
+                user_model=self.user,
+                je_timestamp=self.make_timestamp(),
+                post_new_ledgers=False,
+                post_journal_entries=False,
+            )

--- a/django_ledger/tests/api/test_item_api.py
+++ b/django_ledger/tests/api/test_item_api.py
@@ -1,0 +1,314 @@
+"""
+High-level API behavior tests for UnitOfMeasureModel and ItemModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import AccountModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel, UnitOfMeasureModel
+
+
+class ItemHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for UnitOfMeasureModel and ItemModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic item/catalog API invariants that
+    should remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_item_contract_user",
+            email="api-item-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_accounting_setup(self, *, name="API Item Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Item Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name="API Item Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name="API Item Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name="API Item COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name="API Item Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name="API Item Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "inventory_account": inventory_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+        }
+
+    def create_uom(self, entity_model, *, name="API Unit", unit_abbr="api-unit"):
+        return entity_model.create_uom(
+            name=name,
+            unit_abbr=unit_abbr,
+            active=True,
+            commit=True,
+        )
+
+    def test_create_uom_creates_unit_under_entity_context(self):
+        setup = self.create_entity_with_accounting_setup()
+        entity_model = setup["entity_model"]
+
+        uom_model = self.create_uom(
+            entity_model,
+            name="API Hour",
+            unit_abbr="api-hour",
+        )
+
+        self.assertIsInstance(uom_model, UnitOfMeasureModel)
+        self.assertIsNotNone(uom_model.uuid)
+        self.assertEqual(uom_model.entity_id, entity_model.uuid)
+        self.assertEqual(uom_model.name, "API Hour")
+        self.assertEqual(uom_model.unit_abbr, "api-hour")
+        self.assertTrue(uom_model.is_active)
+
+    def test_create_expense_item_assigns_expense_role_and_account(self):
+        setup = self.create_entity_with_accounting_setup()
+        entity_model = setup["entity_model"]
+        expense_account = setup["expense_account"]
+        uom_model = self.create_uom(entity_model)
+
+        item_model = entity_model.create_item_expense(
+            name="API Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            commit=True,
+        )
+
+        self.assertIsInstance(item_model, ItemModel)
+        self.assertEqual(item_model.entity_id, entity_model.uuid)
+        self.assertEqual(item_model.name, "API Expense Item")
+        self.assertTrue(item_model.is_expense())
+        self.assertEqual(item_model.expense_account_id, expense_account.uuid)
+        self.assertEqual(item_model.uom_id, uom_model.uuid)
+        self.assertTrue(item_model.item_number)
+
+    def test_create_service_item_assigns_service_role_and_accounts(self):
+        setup = self.create_entity_with_accounting_setup()
+        entity_model = setup["entity_model"]
+        uom_model = self.create_uom(entity_model)
+
+        item_model = entity_model.create_item_service(
+            name="API Service Item",
+            uom_model=uom_model,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        self.assertIsInstance(item_model, ItemModel)
+        self.assertEqual(item_model.entity_id, entity_model.uuid)
+        self.assertEqual(item_model.name, "API Service Item")
+        self.assertTrue(item_model.is_service())
+        self.assertEqual(item_model.uom_id, uom_model.uuid)
+        self.assertIsNotNone(item_model.cogs_account_id)
+        self.assertIsNotNone(item_model.earnings_account_id)
+        self.assertTrue(item_model.item_number)
+
+    def test_create_product_item_assigns_product_role_and_accounts(self):
+        setup = self.create_entity_with_accounting_setup()
+        entity_model = setup["entity_model"]
+        uom_model = self.create_uom(entity_model)
+
+        item_model = entity_model.create_item_product(
+            name="API Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        self.assertIsInstance(item_model, ItemModel)
+        self.assertEqual(item_model.entity_id, entity_model.uuid)
+        self.assertEqual(item_model.name, "API Product Item")
+        self.assertTrue(item_model.is_product())
+        self.assertEqual(item_model.uom_id, uom_model.uuid)
+        self.assertIsNotNone(item_model.inventory_account_id)
+        self.assertIsNotNone(item_model.cogs_account_id)
+        self.assertIsNotNone(item_model.earnings_account_id)
+        self.assertTrue(item_model.item_number)
+
+    def test_create_inventory_item_assigns_inventory_role_and_account(self):
+        setup = self.create_entity_with_accounting_setup()
+        entity_model = setup["entity_model"]
+        inventory_account = setup["inventory_account"]
+        uom_model = self.create_uom(entity_model)
+
+        item_model = entity_model.create_item_inventory(
+            name="API Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        self.assertIsInstance(item_model, ItemModel)
+        self.assertEqual(item_model.entity_id, entity_model.uuid)
+        self.assertEqual(item_model.name, "API Inventory Item")
+        self.assertTrue(item_model.is_inventory())
+        self.assertEqual(item_model.inventory_account_id, inventory_account.uuid)
+        self.assertEqual(item_model.uom_id, uom_model.uuid)
+        self.assertTrue(item_model.item_number)
+
+    def test_item_for_entity_limits_queryset_to_entity_scope(self):
+        setup = self.create_entity_with_accounting_setup(name="API Item Entity A")
+        other_setup = self.create_entity_with_accounting_setup(name="API Item Entity B")
+
+        uom_model = self.create_uom(setup["entity_model"], unit_abbr="api-unit-a")
+        other_uom_model = self.create_uom(other_setup["entity_model"], unit_abbr="api-unit-b")
+
+        item_model = setup["entity_model"].create_item_expense(
+            name="API Entity A Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=setup["expense_account"],
+            commit=True,
+        )
+
+        other_item_model = other_setup["entity_model"].create_item_expense(
+            name="API Entity B Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=other_uom_model,
+            expense_account=other_setup["expense_account"],
+            commit=True,
+        )
+
+        scoped_qs = ItemModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=item_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_item_model.uuid).exists())
+
+    def test_item_invoice_queryset_exposes_product_and_service_items(self):
+        setup = self.create_entity_with_accounting_setup()
+        entity_model = setup["entity_model"]
+        uom_model = self.create_uom(entity_model)
+
+        product_item = entity_model.create_item_product(
+            name="API Invoice Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        service_item = entity_model.create_item_service(
+            name="API Invoice Service Item",
+            uom_model=uom_model,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        expense_item = entity_model.create_item_expense(
+            name="API Invoice Excluded Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=setup["expense_account"],
+            commit=True,
+        )
+
+        invoice_items_qs = ItemModel.objects.for_invoice(entity_model)
+
+        self.assertTrue(invoice_items_qs.filter(uuid=product_item.uuid).exists())
+        self.assertTrue(invoice_items_qs.filter(uuid=service_item.uuid).exists())
+        self.assertFalse(invoice_items_qs.filter(uuid=expense_item.uuid).exists())
+
+    def test_item_bill_queryset_exposes_expense_and_inventory_items(self):
+        setup = self.create_entity_with_accounting_setup()
+        entity_model = setup["entity_model"]
+        uom_model = self.create_uom(entity_model)
+
+        expense_item = entity_model.create_item_expense(
+            name="API Bill Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=setup["expense_account"],
+            commit=True,
+        )
+
+        inventory_item = entity_model.create_item_inventory(
+            name="API Bill Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=setup["inventory_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        service_item = entity_model.create_item_service(
+            name="API Bill Excluded Service Item",
+            uom_model=uom_model,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        bill_items_qs = ItemModel.objects.for_bill(entity_model)
+
+        self.assertTrue(bill_items_qs.filter(uuid=expense_item.uuid).exists())
+        self.assertTrue(bill_items_qs.filter(uuid=inventory_item.uuid).exists())
+        self.assertFalse(bill_items_qs.filter(uuid=service_item.uuid).exists())

--- a/django_ledger/tests/api/test_item_queryset_api.py
+++ b/django_ledger/tests/api/test_item_queryset_api.py
@@ -1,0 +1,239 @@
+"""
+High-level API tests for ItemModel manager and queryset eligibility behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_INVENTORY,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+)
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel, ItemModelValidationError
+
+
+class ItemQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_item_queryset_admin",
+            email="api-item-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_item_queryset_manager",
+            email="api-item-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_item_queryset_other_admin",
+            email="api-item-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_item_queryset_unrelated",
+            email="api-item-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_item_queryset_superuser",
+            email="api-item-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Item Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"iq-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "inventory_account": inventory_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+        }
+
+    def create_items(self, setup, *, name_prefix="API Item Queryset"):
+        entity_model = setup["entity_model"]
+        uom_model = setup["uom_model"]
+        product_item = entity_model.create_item_product(
+            name=f"{name_prefix} Product",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+        service_item = entity_model.create_item_service(
+            name=f"{name_prefix} Service",
+            uom_model=uom_model,
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name_prefix} Expense",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=setup["expense_account"],
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name_prefix} Inventory",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=setup["inventory_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+        return {
+            "product": product_item,
+            "service": service_item,
+            "expense": expense_item,
+            "inventory": inventory_item,
+        }
+
+    def assert_item_uuids(self, queryset, expected_items):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {item_model.uuid for item_model in expected_items},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Item Queryset Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Item Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        items = self.create_items(setup)
+        self.create_items(other_setup, name_prefix="API Other Item Queryset")
+
+        self.assert_item_uuids(ItemModel.objects.for_entity(setup["entity_model"]), items.values())
+        self.assert_item_uuids(ItemModel.objects.for_entity(setup["entity_model"].slug), items.values())
+        self.assert_item_uuids(ItemModel.objects.for_entity(setup["entity_model"].uuid), items.values())
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_items(self.create_entity_setup())
+
+        with self.assertRaises(ItemModelValidationError):
+            ItemModel.objects.for_entity(object())
+
+        self.assertFalse(ItemModel.objects.for_entity("missing-item-entity-slug").exists())
+
+    def test_for_entity_active_returns_only_active_items(self):
+        setup = self.create_entity_setup()
+        items = self.create_items(setup)
+        items["expense"].is_active = False
+        items["expense"].save(update_fields=["is_active", "updated"])
+
+        active_qs = ItemModel.objects.for_entity_active(setup["entity_model"])
+
+        self.assertTrue(active_qs.filter(uuid=items["product"].uuid).exists())
+        self.assertFalse(active_qs.filter(uuid=items["expense"].uuid).exists())
+
+    def test_for_user_scopes_to_authorized_users_and_superuser(self):
+        setup = self.create_entity_setup(
+            name="API Item Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API Item Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        items = self.create_items(setup)
+        other_items = self.create_items(other_setup, name_prefix="API Other Access Item")
+
+        self.assert_item_uuids(ItemModel.objects.all().for_user(self.admin_user), items.values())
+        self.assert_item_uuids(ItemModel.objects.all().for_user(self.manager_user), items.values())
+        self.assertFalse(ItemModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_item_uuids(
+            ItemModel.objects.all().for_user(self.superuser),
+            [*items.values(), *other_items.values()],
+        )
+
+    def test_role_filters_select_expected_item_categories(self):
+        setup = self.create_entity_setup()
+        items = self.create_items(setup)
+        item_qs = ItemModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_item_uuids(item_qs.products(), [items["product"]])
+        self.assert_item_uuids(item_qs.services(), [items["service"]])
+        self.assert_item_uuids(item_qs.expenses(), [items["expense"]])
+        self.assert_item_uuids(item_qs.inventory_wip(), [items["inventory"]])
+        self.assert_item_uuids(item_qs.inventory_all(), [items["product"], items["inventory"]])
+
+    def test_queryset_document_eligibility_helpers_select_expected_roles(self):
+        setup = self.create_entity_setup()
+        items = self.create_items(setup)
+        item_qs = ItemModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_item_uuids(item_qs.invoices(), [items["product"], items["service"]])
+        self.assert_item_uuids(item_qs.estimates(), [items["product"], items["service"]])
+        self.assert_item_uuids(item_qs.bills(), [items["product"], items["expense"], items["inventory"]])
+        self.assert_item_uuids(item_qs.purchase_orders(), [items["product"], items["inventory"]])
+
+    def test_manager_document_eligibility_helpers_scope_to_active_supported_items(self):
+        setup = self.create_entity_setup()
+        items = self.create_items(setup)
+        items["product"].is_active = False
+        items["product"].save(update_fields=["is_active", "updated"])
+
+        entity_model = setup["entity_model"]
+
+        self.assert_item_uuids(ItemModel.objects.for_invoice(entity_model), [items["service"]])
+        self.assert_item_uuids(ItemModel.objects.for_bill(entity_model), [items["expense"], items["inventory"]])
+        self.assert_item_uuids(ItemModel.objects.for_estimate(entity_model), [items["service"]])

--- a/django_ledger/tests/api/test_item_role_account_api.py
+++ b/django_ledger/tests/api/test_item_role_account_api.py
@@ -1,0 +1,402 @@
+"""
+High-level API tests for ItemModel role, account, and numbering behavior.
+"""
+
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_INVENTORY,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+)
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel, ItemModelValidationError
+from django_ledger.settings import (
+    DJANGO_LEDGER_EXPENSE_NUMBER_PREFIX,
+    DJANGO_LEDGER_INVENTORY_NUMBER_PREFIX,
+    DJANGO_LEDGER_PRODUCT_NUMBER_PREFIX,
+)
+
+
+class ItemRoleAccountAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_item_role_account_admin",
+            email="api-item-role-account-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Item Role Account Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"ir-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "inventory_account": inventory_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+        }
+
+    def create_items(self, setup, *, name_prefix="API Item Role Account"):
+        entity_model = setup["entity_model"]
+        uom_model = setup["uom_model"]
+        return {
+            "product": entity_model.create_item_product(
+                name=f"{name_prefix} Product",
+                item_type=ItemModel.ITEM_TYPE_MATERIAL,
+                uom_model=uom_model,
+                coa_model=setup["coa_model"],
+                commit=True,
+            ),
+            "service": entity_model.create_item_service(
+                name=f"{name_prefix} Service",
+                uom_model=uom_model,
+                coa_model=setup["coa_model"],
+                commit=True,
+            ),
+            "expense": entity_model.create_item_expense(
+                name=f"{name_prefix} Expense",
+                expense_type=ItemModel.ITEM_TYPE_OTHER,
+                uom_model=uom_model,
+                expense_account=setup["expense_account"],
+                commit=True,
+            ),
+            "inventory": entity_model.create_item_inventory(
+                name=f"{name_prefix} Inventory",
+                item_type=ItemModel.ITEM_TYPE_MATERIAL,
+                uom_model=uom_model,
+                inventory_account=setup["inventory_account"],
+                coa_model=setup["coa_model"],
+                commit=True,
+            ),
+        }
+
+    def make_item(self, setup, *, item_role, item_type=ItemModel.ITEM_TYPE_MATERIAL, **accounts):
+        return ItemModel(
+            entity=setup["entity_model"],
+            name=f"API Direct {item_role.title()} Item",
+            uom=setup["uom_model"],
+            item_role=item_role,
+            item_type=item_type,
+            **accounts,
+        )
+
+    def item_sequence(self, item_model):
+        return int(item_model.item_number.rsplit("-", 1)[-1])
+
+    def test_role_helpers_identify_representative_item_roles(self):
+        items = self.create_items(self.create_entity_setup())
+
+        self.assertTrue(items["product"].is_product())
+        self.assertFalse(items["product"].is_service())
+        self.assertTrue(items["service"].is_service())
+        self.assertFalse(items["service"].is_product())
+        self.assertTrue(items["expense"].is_expense())
+        self.assertFalse(items["expense"].is_inventory())
+        self.assertTrue(items["inventory"].is_inventory())
+        self.assertFalse(items["inventory"].is_expense())
+
+    def test_type_helpers_identify_representative_item_types(self):
+        setup = self.create_entity_setup()
+
+        labor_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_SERVICE,
+            item_type=ItemModel.ITEM_TYPE_LABOR,
+        )
+        material_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_PRODUCT,
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+        )
+        equipment_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_PRODUCT,
+            item_type=ItemModel.ITEM_TYPE_EQUIPMENT,
+        )
+        lump_sum_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_EXPENSE,
+            item_type=ItemModel.ITEM_TYPE_LUMP_SUM,
+        )
+        other_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_EXPENSE,
+            item_type=ItemModel.ITEM_TYPE_OTHER,
+        )
+
+        self.assertTrue(labor_item.is_labor())
+        self.assertTrue(material_item.is_material())
+        self.assertTrue(equipment_item.is_equipment())
+        self.assertTrue(lump_sum_item.is_lump_sum())
+        self.assertTrue(other_item.is_other())
+
+    def test_product_or_service_display_returns_user_facing_role_names(self):
+        items = self.create_items(self.create_entity_setup())
+
+        self.assertEqual(items["product"].product_or_service_display(), "product")
+        self.assertEqual(items["service"].product_or_service_display(), "service")
+        self.assertIsNone(items["expense"].product_or_service_display())
+
+    def test_clean_requires_role_specific_accounts(self):
+        setup = self.create_entity_setup()
+
+        invalid_product = self.make_item(setup, item_role=ItemModel.ITEM_ROLE_PRODUCT)
+        invalid_service = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_SERVICE,
+            item_type=ItemModel.ITEM_TYPE_LABOR,
+        )
+        invalid_expense = self.make_item(setup, item_role=ItemModel.ITEM_ROLE_EXPENSE)
+        invalid_inventory = self.make_item(setup, item_role=ItemModel.ITEM_ROLE_INVENTORY)
+
+        with self.assertRaises(ItemModelValidationError):
+            invalid_product.clean()
+        with self.assertRaises(ItemModelValidationError):
+            invalid_service.clean()
+        with self.assertRaises(ItemModelValidationError):
+            invalid_expense.clean()
+        with self.assertRaises(ItemModelValidationError):
+            invalid_inventory.clean()
+
+    def test_clean_accepts_representative_valid_role_account_combinations(self):
+        setup = self.create_entity_setup()
+
+        valid_product = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_PRODUCT,
+            inventory_account=setup["inventory_account"],
+            cogs_account=setup["cogs_account"],
+            earnings_account=setup["earnings_account"],
+        )
+        valid_service = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_SERVICE,
+            item_type=ItemModel.ITEM_TYPE_LABOR,
+            cogs_account=setup["cogs_account"],
+            earnings_account=setup["earnings_account"],
+        )
+        valid_expense = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_EXPENSE,
+            item_type=ItemModel.ITEM_TYPE_OTHER,
+            expense_account=setup["expense_account"],
+        )
+        valid_inventory = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_INVENTORY,
+            inventory_account=setup["inventory_account"],
+        )
+
+        valid_product.clean()
+        valid_service.clean()
+        valid_expense.clean()
+        valid_inventory.clean()
+
+    def test_clean_normalizes_incompatible_accounts_for_each_role(self):
+        setup = self.create_entity_setup()
+
+        expense_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_EXPENSE,
+            item_type=ItemModel.ITEM_TYPE_OTHER,
+            expense_account=setup["expense_account"],
+            inventory_account=setup["inventory_account"],
+            cogs_account=setup["cogs_account"],
+            earnings_account=setup["earnings_account"],
+        )
+        expense_item.clean()
+        self.assertIsNone(expense_item.inventory_account)
+        self.assertIsNone(expense_item.cogs_account)
+        self.assertIsNone(expense_item.earnings_account)
+        self.assertFalse(expense_item.for_inventory)
+        self.assertFalse(expense_item.is_product_or_service)
+
+        service_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_SERVICE,
+            item_type=ItemModel.ITEM_TYPE_OTHER,
+            expense_account=setup["expense_account"],
+            inventory_account=setup["inventory_account"],
+            cogs_account=setup["cogs_account"],
+            earnings_account=setup["earnings_account"],
+        )
+        service_item.clean()
+        self.assertIsNone(service_item.inventory_account)
+        self.assertIsNone(service_item.expense_account)
+        self.assertEqual(service_item.item_type, ItemModel.ITEM_TYPE_LABOR)
+        self.assertTrue(service_item.is_product_or_service)
+
+        inventory_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_INVENTORY,
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            expense_account=setup["expense_account"],
+            inventory_account=setup["inventory_account"],
+            cogs_account=setup["cogs_account"],
+            earnings_account=setup["earnings_account"],
+        )
+        inventory_item.clean()
+        self.assertIsNone(inventory_item.expense_account)
+        self.assertIsNone(inventory_item.earnings_account)
+        self.assertEqual(inventory_item.inventory_account_id, setup["inventory_account"].uuid)
+        self.assertFalse(inventory_item.is_product_or_service)
+
+        product_item = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_PRODUCT,
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            expense_account=setup["expense_account"],
+            inventory_account=setup["inventory_account"],
+            cogs_account=setup["cogs_account"],
+            earnings_account=setup["earnings_account"],
+        )
+        product_item.clean()
+        self.assertIsNone(product_item.expense_account)
+        self.assertEqual(product_item.inventory_account_id, setup["inventory_account"].uuid)
+        self.assertEqual(product_item.cogs_account_id, setup["cogs_account"].uuid)
+        self.assertEqual(product_item.earnings_account_id, setup["earnings_account"].uuid)
+        self.assertTrue(product_item.for_inventory)
+        self.assertTrue(product_item.is_product_or_service)
+
+    def test_can_generate_item_number_and_generate_commit_false_assigns_number_in_memory(self):
+        setup = self.create_entity_setup()
+        item_model = self.make_item(
+            setup,
+            item_role=ItemModel.ITEM_ROLE_PRODUCT,
+            inventory_account=setup["inventory_account"],
+            cogs_account=setup["cogs_account"],
+            earnings_account=setup["earnings_account"],
+        )
+
+        self.assertTrue(item_model.can_generate_item_number())
+
+        generated_number = item_model.generate_item_number(commit=False)
+
+        self.assertTrue(generated_number)
+        self.assertEqual(item_model.item_number, generated_number)
+        self.assertTrue(generated_number.startswith(f"{DJANGO_LEDGER_PRODUCT_NUMBER_PREFIX}-"))
+        self.assertFalse(ItemModel.objects.filter(uuid=item_model.uuid).exists())
+
+    def test_generate_item_number_commit_true_persists_number_for_saved_item(self):
+        setup = self.create_entity_setup()
+        item_model = setup["entity_model"].create_item_expense(
+            name="API Item Number Commit Expense",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=setup["uom_model"],
+            expense_account=setup["expense_account"],
+            commit=True,
+        )
+        ItemModel.objects.filter(uuid=item_model.uuid).update(item_number="")
+        item_model.item_number = ""
+
+        generated_number = item_model.generate_item_number(commit=True)
+
+        item_model.refresh_from_db()
+        self.assertEqual(item_model.item_number, generated_number)
+        self.assertTrue(generated_number.startswith(f"{DJANGO_LEDGER_EXPENSE_NUMBER_PREFIX}-"))
+
+    def test_item_numbers_advance_within_entity_and_restart_for_other_entity(self):
+        setup = self.create_entity_setup(name="API Item Number Entity A")
+        other_setup = self.create_entity_setup(name="API Item Number Entity B")
+
+        first_item = setup["entity_model"].create_item_expense(
+            name="API First Numbered Expense",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=setup["uom_model"],
+            expense_account=setup["expense_account"],
+            commit=True,
+        )
+        second_item = setup["entity_model"].create_item_inventory(
+            name="API Second Numbered Inventory",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=setup["uom_model"],
+            inventory_account=setup["inventory_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+        other_first_item = other_setup["entity_model"].create_item_expense(
+            name="API Other Entity First Numbered Expense",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=other_setup["uom_model"],
+            expense_account=other_setup["expense_account"],
+            commit=True,
+        )
+
+        self.assertTrue(first_item.item_number.startswith(f"{DJANGO_LEDGER_EXPENSE_NUMBER_PREFIX}-"))
+        self.assertTrue(second_item.item_number.startswith(f"{DJANGO_LEDGER_INVENTORY_NUMBER_PREFIX}-"))
+        self.assertEqual(self.item_sequence(second_item), self.item_sequence(first_item) + 1)
+        self.assertEqual(self.item_sequence(other_first_item), self.item_sequence(first_item))
+
+    def test_get_average_cost_returns_default_or_simple_average(self):
+        setup = self.create_entity_setup()
+        item_model = setup["entity_model"].create_item_inventory(
+            name="API Average Cost Inventory",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=setup["uom_model"],
+            inventory_account=setup["inventory_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+        self.assertEqual(item_model.get_average_cost(), Decimal("0.00"))
+
+        item_model.inventory_received = Decimal("4.000")
+        item_model.inventory_received_value = Decimal("50.00")
+
+        self.assertEqual(item_model.get_average_cost(), Decimal("12.5"))

--- a/django_ledger/tests/api/test_item_transaction_amount_status_api.py
+++ b/django_ledger/tests/api/test_item_transaction_amount_status_api.py
@@ -1,0 +1,423 @@
+"""
+High-level API tests for ItemTransactionModel amount and status helpers.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import (
+    BillModel,
+    EstimateModel,
+    InvoiceModel,
+    ItemTransactionModel,
+    PurchaseOrderModel,
+)
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class ItemTransactionAmountStatusAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_itemtx_amount_status_admin",
+            email="api-itemtx-amount-status-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API ItemTx Amount Status Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        accounts_payable = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        unearned_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"ia-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "prepaid_account": prepaid_account,
+            "accounts_payable": accounts_payable,
+            "unearned_account": unearned_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "service_item": service_item,
+            "inventory_item": inventory_item,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["accounts_payable"],
+        )
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+        return bill_model
+
+    def create_invoice(self, setup):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["unearned_account"],
+        )
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+        return invoice_model
+
+    def create_estimate(self, setup):
+        estimate_model = EstimateModel(terms=EstimateModel.CONTRACT_TERMS_FIXED)
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.admin_user,
+            date_draft=date(2026, 1, 15),
+            estimate_title="API ItemTx Amount Status Estimate",
+            commit=True,
+        )
+        return estimate_model
+
+    def create_purchase_order(self, setup):
+        po_model = PurchaseOrderModel()
+        po_model.configure(
+            entity_slug=setup["entity_model"],
+            po_title="API ItemTx Amount Status Purchase Order",
+            user_model=self.admin_user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+        return po_model
+
+    def make_item_transaction(self, **kwargs):
+        item_tx = ItemTransactionModel(**kwargs)
+        item_tx.clean()
+        return item_tx
+
+    def test_bill_and_invoice_total_amount_helpers_compute_quantity_times_unit_cost(self):
+        setup = self.create_entity_setup()
+        bill_item_tx = self.make_item_transaction(
+            item_model=setup["expense_item"],
+            bill_model=self.create_bill(setup),
+            quantity=2.0,
+            unit_cost=50.0,
+        )
+        invoice_item_tx = self.make_item_transaction(
+            item_model=setup["service_item"],
+            invoice_model=self.create_invoice(setup),
+            quantity=3.0,
+            unit_cost=75.0,
+        )
+
+        self.assertEqual(bill_item_tx.total_amount, Decimal("100.00"))
+        self.assertEqual(invoice_item_tx.total_amount, Decimal("225.00"))
+
+    def test_purchase_order_total_helper_computes_authorized_amount(self):
+        setup = self.create_entity_setup()
+        po_item_tx = self.make_item_transaction(
+            item_model=setup["inventory_item"],
+            po_model=self.create_purchase_order(setup),
+            po_quantity=4.0,
+            po_unit_cost=20.0,
+            po_item_status=ItemTransactionModel.STATUS_ORDERED,
+        )
+
+        self.assertEqual(po_item_tx.po_total_amount, Decimal("80.00"))
+
+    def test_estimate_cost_and_revenue_helpers_compute_current_totals(self):
+        setup = self.create_entity_setup()
+        estimate_item_tx = self.make_item_transaction(
+            item_model=setup["service_item"],
+            ce_model=self.create_estimate(setup),
+            ce_quantity=2.0,
+            ce_unit_cost_estimate=30.0,
+            ce_unit_revenue_estimate=75.0,
+        )
+
+        self.assertEqual(estimate_item_tx.ce_cost_estimate, Decimal("60.00"))
+        self.assertEqual(estimate_item_tx.ce_revenue_estimate, Decimal("150"))
+
+    def test_po_backed_bill_line_cannot_exceed_authorized_quantity_or_amount(self):
+        setup = self.create_entity_setup()
+        bill_model = self.create_bill(setup)
+        po_model = self.create_purchase_order(setup)
+
+        quantity_too_high = ItemTransactionModel(
+            item_model=setup["inventory_item"],
+            bill_model=bill_model,
+            po_model=po_model,
+            po_quantity=4.0,
+            po_unit_cost=20.0,
+            quantity=5.0,
+            unit_cost=20.0,
+            po_item_status=ItemTransactionModel.STATUS_ORDERED,
+        )
+        amount_too_high = ItemTransactionModel(
+            item_model=setup["inventory_item"],
+            bill_model=bill_model,
+            po_model=po_model,
+            po_quantity=4.0,
+            po_unit_cost=20.0,
+            quantity=4.0,
+            unit_cost=25.0,
+            po_item_status=ItemTransactionModel.STATUS_ORDERED,
+        )
+
+        with self.assertRaises(ValidationError):
+            quantity_too_high.clean()
+        with self.assertRaises(ValidationError):
+            amount_too_high.clean()
+
+    def test_can_create_bill_reflects_bill_link_and_purchase_status(self):
+        setup = self.create_entity_setup()
+        po_model = self.create_purchase_order(setup)
+        ordered_item_tx = self.make_item_transaction(
+            item_model=setup["inventory_item"],
+            po_model=po_model,
+            po_quantity=4.0,
+            po_unit_cost=20.0,
+            po_item_status=ItemTransactionModel.STATUS_ORDERED,
+        )
+        not_ordered_item_tx = self.make_item_transaction(
+            item_model=setup["inventory_item"],
+            po_model=po_model,
+            po_quantity=4.0,
+            po_unit_cost=20.0,
+            po_item_status=ItemTransactionModel.STATUS_NOT_ORDERED,
+        )
+        already_billed_item_tx = self.make_item_transaction(
+            item_model=setup["inventory_item"],
+            bill_model=self.create_bill(setup),
+            po_model=po_model,
+            po_quantity=4.0,
+            po_unit_cost=20.0,
+            quantity=1.0,
+            unit_cost=20.0,
+            po_item_status=ItemTransactionModel.STATUS_RECEIVED,
+        )
+
+        self.assertTrue(ordered_item_tx.can_create_bill())
+        self.assertFalse(not_ordered_item_tx.can_create_bill())
+        self.assertFalse(already_billed_item_tx.can_create_bill())
+
+    def test_instance_status_helpers_reflect_purchase_order_status(self):
+        ordered_item_tx = ItemTransactionModel(po_item_status=ItemTransactionModel.STATUS_ORDERED)
+        received_item_tx = ItemTransactionModel(po_item_status=ItemTransactionModel.STATUS_RECEIVED)
+        canceled_item_tx = ItemTransactionModel(po_item_status=ItemTransactionModel.STATUS_CANCELED)
+
+        self.assertTrue(ordered_item_tx.is_ordered())
+        self.assertFalse(received_item_tx.is_ordered())
+        self.assertTrue(received_item_tx.is_received())
+        self.assertTrue(canceled_item_tx.is_canceled())
+
+    def test_status_css_helper_reflects_current_purchase_order_status(self):
+        ordered_item_tx = ItemTransactionModel(po_item_status=ItemTransactionModel.STATUS_ORDERED)
+        in_transit_item_tx = ItemTransactionModel(po_item_status=ItemTransactionModel.STATUS_IN_TRANSIT)
+        received_item_tx = ItemTransactionModel(po_item_status=ItemTransactionModel.STATUS_RECEIVED)
+        canceled_item_tx = ItemTransactionModel(po_item_status=ItemTransactionModel.STATUS_CANCELED)
+
+        self.assertEqual(ordered_item_tx.get_status_css_class(), " is-info")
+        self.assertEqual(in_transit_item_tx.get_status_css_class(), " is-warning")
+        self.assertEqual(received_item_tx.get_status_css_class(), " is-success")
+        self.assertEqual(canceled_item_tx.get_status_css_class(), " is-danger")
+
+    def test_document_ownership_helpers_identify_associated_document(self):
+        setup = self.create_entity_setup()
+        bill_item_tx = self.make_item_transaction(
+            item_model=setup["expense_item"],
+            bill_model=self.create_bill(setup),
+            quantity=1.0,
+            unit_cost=10.0,
+        )
+        invoice_item_tx = self.make_item_transaction(
+            item_model=setup["service_item"],
+            invoice_model=self.create_invoice(setup),
+            quantity=1.0,
+            unit_cost=10.0,
+        )
+        estimate_item_tx = self.make_item_transaction(
+            item_model=setup["service_item"],
+            ce_model=self.create_estimate(setup),
+            ce_quantity=1.0,
+            ce_unit_cost_estimate=10.0,
+            ce_unit_revenue_estimate=20.0,
+        )
+        po_item_tx = self.make_item_transaction(
+            item_model=setup["inventory_item"],
+            po_model=self.create_purchase_order(setup),
+            po_quantity=1.0,
+            po_unit_cost=10.0,
+        )
+
+        self.assertTrue(bill_item_tx.has_bill())
+        self.assertTrue(invoice_item_tx.has_invoice())
+        self.assertTrue(estimate_item_tx.has_estimate())
+        self.assertTrue(po_item_tx.has_po())
+
+    def test_html_id_and_string_helpers_return_stable_user_facing_context(self):
+        setup = self.create_entity_setup()
+        bill_item_tx = self.make_item_transaction(
+            item_model=setup["expense_item"],
+            bill_model=self.create_bill(setup),
+            quantity=2.0,
+            unit_cost=50.0,
+        )
+
+        self.assertIn(str(bill_item_tx.uuid), bill_item_tx.html_id())
+        self.assertIn(str(bill_item_tx.uuid), bill_item_tx.html_id_unit_cost())
+        self.assertIn(str(bill_item_tx.uuid), bill_item_tx.html_id_quantity())
+
+        display = str(bill_item_tx)
+        self.assertTrue(display)
+        self.assertIn("Bill Model", display)
+        self.assertIn("100.00", display)

--- a/django_ledger/tests/api/test_item_transaction_api.py
+++ b/django_ledger/tests/api/test_item_transaction_api.py
@@ -1,0 +1,486 @@
+"""
+High-level API behavior tests for ItemTransactionModel document relationships.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import (
+    BillModel,
+    EstimateModel,
+    InvoiceModel,
+    ItemTransactionModel,
+    PurchaseOrderModel,
+)
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class ItemTransactionHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for ItemTransactionModel as the shared document
+    line-item model.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic relationship and amount invariants
+    that should remain true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_item_transaction_contract_user",
+            email="api-item-transaction-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_document_setup(
+        self,
+        *,
+        name="API Item Transaction Contract Entity",
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Item Transaction Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name="API Item Transaction Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name="API Item Transaction Receivable Account",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name="API Item Transaction Prepaid Account",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name="API Item Transaction Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        accounts_payable = coa_model.create_account(
+            code="2010",
+            name="API Item Transaction Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        unearned_account = coa_model.create_account(
+            code="2310",
+            name="API Item Transaction Unearned Revenue Account",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name="API Item Transaction COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name="API Item Transaction Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name="API Item Transaction Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name="API Item Transaction Unit",
+            unit_abbr="api-itx",
+            active=True,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name="API Item Transaction Customer",
+            entity_model=entity_model,
+            description="API Item Transaction Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        vendor_model = VendorModel(
+            vendor_name="API Item Transaction Vendor",
+            entity_model=entity_model,
+            description="API Item Transaction Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        service_item = entity_model.create_item_service(
+            name="API Item Transaction Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        product_item = entity_model.create_item_product(
+            name="API Item Transaction Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        inventory_item = entity_model.create_item_inventory(
+            name="API Item Transaction Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        expense_item = entity_model.create_item_expense(
+            name="API Item Transaction Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "prepaid_account": prepaid_account,
+            "inventory_account": inventory_account,
+            "accounts_payable": accounts_payable,
+            "unearned_account": unearned_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "service_item": service_item,
+            "product_item": product_item,
+            "inventory_item": inventory_item,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["accounts_payable"],
+        )
+
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return bill_model
+
+    def create_invoice(self, setup):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["unearned_account"],
+        )
+
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return invoice_model
+
+    def create_estimate(self, setup):
+        estimate_model = EstimateModel(
+            terms=EstimateModel.CONTRACT_TERMS_FIXED,
+        )
+
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            estimate_title="API Item Transaction Estimate",
+            commit=True,
+        )
+
+        return estimate_model
+
+    def create_purchase_order(self, setup):
+        po_model = PurchaseOrderModel()
+
+        po_model.configure(
+            entity_slug=setup["entity_model"],
+            po_title="API Item Transaction Purchase Order",
+            user_model=self.user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return po_model
+
+    def migrate_bill_item(self, bill_model, setup):
+        quantity = Decimal("2.00")
+        unit_cost = Decimal("50.00")
+
+        bill_model.migrate_itemtxs(
+            itemtxs={
+                setup["expense_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def migrate_invoice_item(self, invoice_model, setup):
+        quantity = Decimal("2.00")
+        unit_cost = Decimal("75.00")
+
+        invoice_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def migrate_estimate_item(self, estimate_model, setup):
+        quantity = Decimal("2.00")
+        unit_cost = Decimal("30.00")
+        unit_revenue = Decimal("75.00")
+
+        estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "unit_revenue": unit_revenue,
+                    "total_amount": quantity * unit_revenue,
+                }
+            },
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_purchase_order_item(self, po_model, setup):
+        quantity = Decimal("3.00")
+        unit_cost = Decimal("20.00")
+
+        po_model.migrate_itemtxs(
+            itemtxs={
+                setup["inventory_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        po_model.refresh_from_db()
+        return po_model
+
+    def test_bill_item_transaction_belongs_only_to_bill_document(self):
+        setup = self.create_entity_with_document_setup()
+        bill_model = self.create_bill(setup)
+
+        self.migrate_bill_item(bill_model, setup)
+
+        item_tx = ItemTransactionModel.objects.get(bill_model=bill_model)
+
+        self.assertEqual(item_tx.bill_model_id, bill_model.uuid)
+        self.assertIsNone(item_tx.invoice_model_id)
+        self.assertIsNone(item_tx.ce_model_id)
+        self.assertIsNone(item_tx.po_model_id)
+        self.assertEqual(item_tx.item_model_id, setup["expense_item"].uuid)
+        self.assertEqual(item_tx.quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.unit_cost, Decimal("50.00"))
+        self.assertEqual(item_tx.total_amount, Decimal("100.00"))
+
+    def test_invoice_item_transaction_belongs_only_to_invoice_document(self):
+        setup = self.create_entity_with_document_setup()
+        invoice_model = self.create_invoice(setup)
+
+        self.migrate_invoice_item(invoice_model, setup)
+
+        item_tx = ItemTransactionModel.objects.get(invoice_model=invoice_model)
+
+        self.assertEqual(item_tx.invoice_model_id, invoice_model.uuid)
+        self.assertIsNone(item_tx.bill_model_id)
+        self.assertIsNone(item_tx.ce_model_id)
+        self.assertIsNone(item_tx.po_model_id)
+        self.assertEqual(item_tx.item_model_id, setup["service_item"].uuid)
+        self.assertEqual(item_tx.quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.unit_cost, Decimal("75.00"))
+        self.assertEqual(item_tx.total_amount, Decimal("150.00"))
+
+    def test_estimate_item_transaction_belongs_only_to_estimate_document(self):
+        setup = self.create_entity_with_document_setup()
+        estimate_model = self.create_estimate(setup)
+
+        self.migrate_estimate_item(estimate_model, setup)
+
+        item_tx = ItemTransactionModel.objects.get(ce_model=estimate_model)
+
+        self.assertEqual(item_tx.ce_model_id, estimate_model.uuid)
+        self.assertIsNone(item_tx.bill_model_id)
+        self.assertIsNone(item_tx.invoice_model_id)
+        self.assertIsNone(item_tx.po_model_id)
+        self.assertEqual(item_tx.item_model_id, setup["service_item"].uuid)
+        self.assertEqual(item_tx.ce_quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.ce_unit_cost_estimate, Decimal("30.00"))
+        self.assertEqual(item_tx.ce_unit_revenue_estimate, Decimal("75.00"))
+        self.assertEqual(item_tx.ce_cost_estimate, Decimal("60.00"))
+        self.assertEqual(item_tx.ce_revenue_estimate, Decimal("150.00"))
+
+    def test_purchase_order_item_transaction_belongs_only_to_purchase_order_document(self):
+        setup = self.create_entity_with_document_setup()
+        po_model = self.create_purchase_order(setup)
+
+        self.migrate_purchase_order_item(po_model, setup)
+
+        item_tx = ItemTransactionModel.objects.get(po_model=po_model)
+
+        self.assertEqual(item_tx.po_model_id, po_model.uuid)
+        self.assertIsNone(item_tx.bill_model_id)
+        self.assertIsNone(item_tx.invoice_model_id)
+        self.assertIsNone(item_tx.ce_model_id)
+        self.assertEqual(item_tx.item_model_id, setup["inventory_item"].uuid)
+        self.assertEqual(item_tx.po_quantity, Decimal("3.00"))
+        self.assertEqual(item_tx.po_unit_cost, Decimal("20.00"))
+        self.assertEqual(item_tx.po_total_amount, Decimal("60.00"))
+
+    def test_item_transaction_owner_fields_are_mutually_exclusive_for_document_migrations(self):
+        setup = self.create_entity_with_document_setup()
+
+        bill_model = self.create_bill(setup)
+        invoice_model = self.create_invoice(setup)
+        estimate_model = self.create_estimate(setup)
+        po_model = self.create_purchase_order(setup)
+
+        self.migrate_bill_item(bill_model, setup)
+        self.migrate_invoice_item(invoice_model, setup)
+        self.migrate_estimate_item(estimate_model, setup)
+        self.migrate_purchase_order_item(po_model, setup)
+
+        for item_tx in ItemTransactionModel.objects.all():
+            owner_count = sum(
+                [
+                    item_tx.bill_model_id is not None,
+                    item_tx.invoice_model_id is not None,
+                    item_tx.ce_model_id is not None,
+                    item_tx.po_model_id is not None,
+                ]
+            )
+
+            self.assertEqual(
+                owner_count,
+                1,
+                "Each migrated ItemTransactionModel should belong to exactly one document owner.",
+            )
+
+    def test_document_amounts_are_updated_from_item_transaction_totals(self):
+        setup = self.create_entity_with_document_setup()
+
+        bill_model = self.create_bill(setup)
+        invoice_model = self.create_invoice(setup)
+        estimate_model = self.create_estimate(setup)
+        po_model = self.create_purchase_order(setup)
+
+        bill_model = self.migrate_bill_item(bill_model, setup)
+        invoice_model = self.migrate_invoice_item(invoice_model, setup)
+        estimate_model = self.migrate_estimate_item(estimate_model, setup)
+        po_model = self.migrate_purchase_order_item(po_model, setup)
+
+        self.assertEqual(bill_model.amount_due, Decimal("100.00"))
+        self.assertEqual(invoice_model.amount_due, Decimal("150.00"))
+        self.assertEqual(estimate_model.revenue_estimate, Decimal("150.00"))
+        self.assertEqual(estimate_model.labor_estimate, Decimal("60.00"))
+        self.assertEqual(po_model.po_amount, Decimal("60.00"))

--- a/django_ledger/tests/api/test_item_transaction_inventory_api.py
+++ b/django_ledger/tests/api/test_item_transaction_inventory_api.py
@@ -1,0 +1,364 @@
+"""
+High-level API tests for ItemTransactionModel inventory helper behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import BillModel, InvoiceModel, ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class ItemTransactionInventoryAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_itemtx_inventory_admin",
+            email="api-itemtx-inventory-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API ItemTx Inventory Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = entity_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        receivable_account = entity_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = entity_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = entity_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = entity_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        unearned_account = entity_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        entity_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        entity_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = entity_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"ipi-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} Vendor description",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "prepaid_account": prepaid_account,
+            "inventory_account": inventory_account,
+            "payable_account": payable_account,
+            "unearned_account": unearned_account,
+            "uom_model": uom_model,
+            "vendor_model": vendor_model,
+            "customer_model": customer_model,
+            "inventory_item": inventory_item,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup):
+        return setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_ON_RECEIPT,
+            date_draft=date(2026, 1, 15),
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            payable_account=setup["payable_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+    def create_invoice(self, setup):
+        return setup["entity_model"].create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_ON_RECEIPT,
+            date_draft=date(2026, 1, 15),
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            payable_account=setup["unearned_account"],
+            coa_model=setup["coa_model"],
+            commit=True,
+        )
+
+    def create_approved_purchase_order(self, setup):
+        po_model = setup["entity_model"].create_purchase_order(
+            po_title="API ItemTx Inventory Purchase Order",
+            date_draft=date(2026, 1, 10),
+            commit=True,
+        )
+        po_model.po_status = PurchaseOrderModel.PO_STATUS_APPROVED
+        po_model.date_approved = date(2026, 1, 11)
+        po_model.save(update_fields=["po_status", "date_approved", "updated"])
+        return po_model
+
+    def create_inventory_bill_line(
+        self,
+        setup,
+        *,
+        item_model=None,
+        quantity=Decimal("3.000"),
+        unit_cost=Decimal("20.00"),
+        status=ItemTransactionModel.STATUS_RECEIVED,
+    ):
+        item_tx = ItemTransactionModel(
+            item_model=item_model or setup["inventory_item"],
+            po_model=self.create_approved_purchase_order(setup),
+            bill_model=self.create_bill(setup),
+            po_quantity=float(quantity),
+            po_unit_cost=float(unit_cost),
+            po_item_status=status,
+            quantity=float(quantity),
+            unit_cost=float(unit_cost),
+        )
+        item_tx.clean()
+        item_tx.save()
+        item_tx.refresh_from_db()
+        return item_tx
+
+    def create_inventory_invoice_line(
+        self,
+        setup,
+        *,
+        item_model=None,
+        quantity=Decimal("2.000"),
+        unit_cost=Decimal("25.00"),
+    ):
+        item_tx = ItemTransactionModel(
+            item_model=item_model or setup["inventory_item"],
+            invoice_model=self.create_invoice(setup),
+            quantity=float(quantity),
+            unit_cost=float(unit_cost),
+        )
+        item_tx.clean()
+        item_tx.save()
+        item_tx.refresh_from_db()
+        return item_tx
+
+    def test_create_item_inventory_accepts_explicit_account_without_explicit_coa(self):
+        setup = self.create_entity_setup()
+
+        item_model = setup["entity_model"].create_item_inventory(
+            name="API Explicit Account Inventory Item",
+            uom_model=setup["uom_model"],
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            inventory_account=setup["inventory_account"],
+            coa_model=None,
+            commit=True,
+        )
+
+        self.assertEqual(item_model.entity_id, setup["entity_model"].uuid)
+        self.assertEqual(item_model.inventory_account_id, setup["inventory_account"].uuid)
+        self.assertTrue(item_model.is_inventory())
+
+    def test_inventory_count_aggregates_received_and_invoiced_inventory(self):
+        setup = self.create_entity_setup()
+        item_model = setup["inventory_item"]
+        self.create_inventory_bill_line(
+            setup,
+            item_model=item_model,
+            quantity=Decimal("5.000"),
+            unit_cost=Decimal("10.00"),
+        )
+        self.create_inventory_invoice_line(
+            setup,
+            item_model=item_model,
+            quantity=Decimal("2.000"),
+            unit_cost=Decimal("20.00"),
+        )
+
+        inventory_count = ItemTransactionModel.objects.inventory_count(setup["entity_model"])
+        counted = inventory_count.get(item_model_id=item_model.uuid)
+
+        self.assertEqual(counted["quantity_received"], Decimal("5"))
+        self.assertEqual(counted["cost_received"], Decimal("50"))
+        self.assertEqual(counted["quantity_invoiced"], Decimal("2"))
+        self.assertEqual(counted["revenue_invoiced"], Decimal("40"))
+        self.assertEqual(counted["quantity_onhand"], Decimal("3"))
+        self.assertEqual(counted["cost_average"], Decimal("10"))
+        self.assertEqual(counted["value_onhand"], Decimal("30"))
+
+    def test_inventory_pipeline_filters_ordered_in_transit_and_received_rows(self):
+        setup = self.create_entity_setup()
+        ordered_item_tx = self.create_inventory_bill_line(setup, status=ItemTransactionModel.STATUS_ORDERED)
+        in_transit_item_tx = self.create_inventory_bill_line(setup, status=ItemTransactionModel.STATUS_IN_TRANSIT)
+        received_item_tx = self.create_inventory_bill_line(setup, status=ItemTransactionModel.STATUS_RECEIVED)
+        invoiced_item_tx = self.create_inventory_invoice_line(setup)
+
+        pipeline_qs = ItemTransactionModel.objects.inventory_pipeline(setup["entity_model"])
+
+        self.assertTrue(pipeline_qs.filter(uuid=ordered_item_tx.uuid).exists())
+        self.assertTrue(pipeline_qs.filter(uuid=in_transit_item_tx.uuid).exists())
+        self.assertTrue(pipeline_qs.filter(uuid=received_item_tx.uuid).exists())
+        self.assertFalse(pipeline_qs.filter(uuid=invoiced_item_tx.uuid).exists())
+
+        self.assertTrue(ItemTransactionModel.objects.inventory_pipeline_ordered(setup["entity_model"]).filter(uuid=ordered_item_tx.uuid).exists())
+        self.assertTrue(ItemTransactionModel.objects.inventory_pipeline_in_transit(setup["entity_model"]).filter(uuid=in_transit_item_tx.uuid).exists())
+        self.assertTrue(ItemTransactionModel.objects.inventory_pipeline_received(setup["entity_model"]).filter(uuid=received_item_tx.uuid).exists())
+
+    def test_inventory_pipeline_aggregate_reports_status_totals(self):
+        setup = self.create_entity_setup()
+        self.create_inventory_bill_line(
+            setup,
+            quantity=Decimal("2.000"),
+            unit_cost=Decimal("10.00"),
+            status=ItemTransactionModel.STATUS_ORDERED,
+        )
+        self.create_inventory_bill_line(
+            setup,
+            quantity=Decimal("3.000"),
+            unit_cost=Decimal("12.00"),
+            status=ItemTransactionModel.STATUS_IN_TRANSIT,
+        )
+        self.create_inventory_bill_line(
+            setup,
+            quantity=Decimal("4.000"),
+            unit_cost=Decimal("15.00"),
+            status=ItemTransactionModel.STATUS_RECEIVED,
+        )
+
+        aggregate_by_status = {
+            row["po_item_status"]: row
+            for row in ItemTransactionModel.objects.inventory_pipeline_aggregate(setup["entity_model"])
+        }
+
+        self.assertEqual(aggregate_by_status[ItemTransactionModel.STATUS_ORDERED]["total_quantity"], Decimal("2"))
+        self.assertEqual(aggregate_by_status[ItemTransactionModel.STATUS_ORDERED]["total_value"], Decimal("20"))
+        self.assertEqual(aggregate_by_status[ItemTransactionModel.STATUS_IN_TRANSIT]["total_quantity"], Decimal("3"))
+        self.assertEqual(aggregate_by_status[ItemTransactionModel.STATUS_IN_TRANSIT]["total_value"], Decimal("36"))
+        self.assertEqual(aggregate_by_status[ItemTransactionModel.STATUS_RECEIVED]["total_quantity"], Decimal("4"))
+        self.assertEqual(aggregate_by_status[ItemTransactionModel.STATUS_RECEIVED]["total_value"], Decimal("60"))
+
+    def test_inventory_invoiced_returns_only_invoiced_inventory_rows(self):
+        setup = self.create_entity_setup()
+        invoiced_item_tx = self.create_inventory_invoice_line(setup)
+        received_item_tx = self.create_inventory_bill_line(setup)
+        non_inventory_invoice_tx = self.create_inventory_invoice_line(
+            setup,
+            item_model=setup["expense_item"],
+        )
+
+        invoiced_qs = ItemTransactionModel.objects.inventory_invoiced(setup["entity_model"])
+
+        self.assertTrue(invoiced_qs.filter(uuid=invoiced_item_tx.uuid).exists())
+        self.assertFalse(invoiced_qs.filter(uuid=received_item_tx.uuid).exists())
+        self.assertFalse(invoiced_qs.filter(uuid=non_inventory_invoice_tx.uuid).exists())

--- a/django_ledger/tests/api/test_item_transaction_queryset_api.py
+++ b/django_ledger/tests/api/test_item_transaction_queryset_api.py
@@ -1,0 +1,489 @@
+"""
+High-level API tests for ItemTransactionModel manager and queryset behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    ASSET_CA_RECEIVABLES,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+    LIABILITY_CL_DEFERRED_REVENUE,
+)
+from django_ledger.models import (
+    BillModel,
+    EstimateModel,
+    InvoiceModel,
+    ItemTransactionModel,
+    PurchaseOrderModel,
+)
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel, ItemTransactionModelValidationError
+from django_ledger.models.vendor import VendorModel
+
+
+class ItemTransactionQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_itemtx_queryset_admin",
+            email="api-itemtx-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_itemtx_queryset_manager",
+            email="api-itemtx-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_itemtx_queryset_other_admin",
+            email="api-itemtx-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_itemtx_queryset_unrelated",
+            email="api-itemtx-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_itemtx_queryset_superuser",
+            email="api-itemtx-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API ItemTx Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role=ASSET_CA_RECEIVABLES,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        accounts_payable = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        unearned_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue",
+            role=LIABILITY_CL_DEFERRED_REVENUE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr=f"it-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "prepaid_account": prepaid_account,
+            "accounts_payable": accounts_payable,
+            "unearned_account": unearned_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "service_item": service_item,
+            "inventory_item": inventory_item,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["accounts_payable"],
+        )
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+        return bill_model
+
+    def create_invoice(self, setup):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["unearned_account"],
+        )
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.admin_user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+        return invoice_model
+
+    def create_estimate(self, setup):
+        estimate_model = EstimateModel(terms=EstimateModel.CONTRACT_TERMS_FIXED)
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.admin_user,
+            date_draft=date(2026, 1, 15),
+            estimate_title="API ItemTx Queryset Estimate",
+            commit=True,
+        )
+        return estimate_model
+
+    def create_purchase_order(self, setup):
+        po_model = PurchaseOrderModel()
+        po_model.configure(
+            entity_slug=setup["entity_model"],
+            po_title="API ItemTx Queryset Purchase Order",
+            user_model=self.admin_user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+        return po_model
+
+    def create_item_transaction(self, **kwargs):
+        item_tx = ItemTransactionModel(**kwargs)
+        item_tx.clean()
+        item_tx.save()
+        return item_tx
+
+    def create_bill_item_transaction(self, setup, bill_model):
+        return self.create_item_transaction(
+            item_model=setup["expense_item"],
+            bill_model=bill_model,
+            quantity=2.0,
+            unit_cost=50.0,
+        )
+
+    def create_invoice_item_transaction(self, setup, invoice_model):
+        return self.create_item_transaction(
+            item_model=setup["service_item"],
+            invoice_model=invoice_model,
+            quantity=3.0,
+            unit_cost=75.0,
+        )
+
+    def create_estimate_item_transaction(
+        self,
+        setup,
+        estimate_model,
+        *,
+        quantity=2.0,
+        unit_cost=30.0,
+        unit_revenue=75.0,
+    ):
+        return self.create_item_transaction(
+            item_model=setup["service_item"],
+            ce_model=estimate_model,
+            ce_quantity=quantity,
+            ce_unit_cost_estimate=unit_cost,
+            ce_unit_revenue_estimate=unit_revenue,
+        )
+
+    def create_po_item_transaction(self, setup, po_model, *, status=ItemTransactionModel.STATUS_ORDERED):
+        return self.create_item_transaction(
+            item_model=setup["inventory_item"],
+            po_model=po_model,
+            po_quantity=4.0,
+            po_unit_cost=20.0,
+            po_item_status=status,
+        )
+
+    def create_orphan_item_transaction(self, setup, *, status=None):
+        return self.create_item_transaction(
+            item_model=setup["inventory_item"],
+            po_item_status=status,
+        )
+
+    def assert_itemtx_uuids(self, queryset, expected_item_txs):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {item_tx.uuid for item_tx in expected_item_txs},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API ItemTx Entity A")
+        other_setup = self.create_entity_setup(
+            name="API ItemTx Entity B",
+            admin_user=self.other_admin_user,
+        )
+        item_tx = self.create_orphan_item_transaction(setup)
+        self.create_orphan_item_transaction(other_setup)
+
+        self.assert_itemtx_uuids(ItemTransactionModel.objects.for_entity(setup["entity_model"]), [item_tx])
+        self.assert_itemtx_uuids(ItemTransactionModel.objects.for_entity(setup["entity_model"].slug), [item_tx])
+        self.assert_itemtx_uuids(ItemTransactionModel.objects.for_entity(setup["entity_model"].uuid), [item_tx])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_orphan_item_transaction(self.create_entity_setup())
+
+        with self.assertRaises(ItemTransactionModelValidationError):
+            ItemTransactionModel.objects.for_entity(object())
+
+        self.assertFalse(ItemTransactionModel.objects.for_entity("missing-itemtx-entity-slug").exists())
+
+    def test_for_user_scopes_to_authorized_users_and_superuser(self):
+        setup = self.create_entity_setup(
+            name="API ItemTx Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API ItemTx Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        item_tx = self.create_orphan_item_transaction(setup)
+        other_item_tx = self.create_orphan_item_transaction(other_setup)
+
+        self.assert_itemtx_uuids(ItemTransactionModel.objects.all().for_user(self.admin_user), [item_tx])
+        self.assert_itemtx_uuids(ItemTransactionModel.objects.all().for_user(self.manager_user), [item_tx])
+        self.assertFalse(ItemTransactionModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_itemtx_uuids(
+            ItemTransactionModel.objects.all().for_user(self.superuser),
+            [item_tx, other_item_tx],
+        )
+
+    def test_document_relation_filters_return_only_matching_document_rows(self):
+        setup = self.create_entity_setup()
+        bill_model = self.create_bill(setup)
+        invoice_model = self.create_invoice(setup)
+        estimate_model = self.create_estimate(setup)
+        po_model = self.create_purchase_order(setup)
+        bill_item_tx = self.create_bill_item_transaction(setup, bill_model)
+        invoice_item_tx = self.create_invoice_item_transaction(setup, invoice_model)
+        estimate_item_tx = self.create_estimate_item_transaction(setup, estimate_model)
+        po_item_tx = self.create_po_item_transaction(setup, po_model)
+
+        self.assert_itemtx_uuids(
+            ItemTransactionModel.objects.for_bill(bill_model.uuid, setup["entity_model"]),
+            [bill_item_tx],
+        )
+        self.assert_itemtx_uuids(
+            ItemTransactionModel.objects.for_invoice(invoice_model.uuid, setup["entity_model"]),
+            [invoice_item_tx],
+        )
+        self.assert_itemtx_uuids(
+            ItemTransactionModel.objects.for_estimate(estimate_model.uuid, setup["entity_model"]),
+            [estimate_item_tx],
+        )
+        self.assert_itemtx_uuids(
+            ItemTransactionModel.objects.for_po(po_model.uuid, setup["entity_model"]),
+            [po_item_tx],
+        )
+
+    def test_for_contract_returns_direct_and_document_bound_estimate_rows(self):
+        setup = self.create_entity_setup()
+        estimate_model = self.create_estimate(setup)
+        bill_model = self.create_bill(setup)
+        invoice_model = self.create_invoice(setup)
+        po_model = self.create_purchase_order(setup)
+
+        bill_model.ce_model = estimate_model
+        bill_model.save(update_fields=["ce_model", "updated"])
+        invoice_model.ce_model = estimate_model
+        invoice_model.save(update_fields=["ce_model", "updated"])
+        po_model.ce_model = estimate_model
+        po_model.save(update_fields=["ce_model", "updated"])
+
+        estimate_item_tx = self.create_estimate_item_transaction(setup, estimate_model)
+        bill_item_tx = self.create_bill_item_transaction(setup, bill_model)
+        invoice_item_tx = self.create_invoice_item_transaction(setup, invoice_model)
+        po_item_tx = self.create_po_item_transaction(setup, po_model)
+        unrelated_bill_item_tx = self.create_bill_item_transaction(setup, self.create_bill(setup))
+
+        contract_qs = ItemTransactionModel.objects.for_contract(estimate_model.uuid, setup["entity_model"])
+
+        self.assert_itemtx_uuids(contract_qs, [estimate_item_tx, bill_item_tx, invoice_item_tx, po_item_tx])
+        self.assertFalse(contract_qs.filter(uuid=unrelated_bill_item_tx.uuid).exists())
+
+    def test_status_filters_return_matching_purchase_order_status_rows(self):
+        setup = self.create_entity_setup()
+        ordered_item_tx = self.create_orphan_item_transaction(
+            setup,
+            status=ItemTransactionModel.STATUS_ORDERED,
+        )
+        in_transit_item_tx = self.create_orphan_item_transaction(
+            setup,
+            status=ItemTransactionModel.STATUS_IN_TRANSIT,
+        )
+        received_item_tx = self.create_orphan_item_transaction(
+            setup,
+            status=ItemTransactionModel.STATUS_RECEIVED,
+        )
+        status_qs = ItemTransactionModel.objects.filter(
+            uuid__in=[ordered_item_tx.uuid, in_transit_item_tx.uuid, received_item_tx.uuid],
+        )
+
+        self.assert_itemtx_uuids(status_qs.is_ordered(), [ordered_item_tx])
+        self.assert_itemtx_uuids(status_qs.in_transit(), [in_transit_item_tx])
+        self.assert_itemtx_uuids(status_qs.is_received(), [received_item_tx])
+
+    def test_is_orphan_returns_only_rows_without_document_owner(self):
+        setup = self.create_entity_setup()
+        orphan_item_tx = self.create_orphan_item_transaction(setup)
+        bill_item_tx = self.create_bill_item_transaction(setup, self.create_bill(setup))
+        invoice_item_tx = self.create_invoice_item_transaction(setup, self.create_invoice(setup))
+        po_item_tx = self.create_po_item_transaction(setup, self.create_purchase_order(setup))
+        estimate_item_tx = self.create_estimate_item_transaction(setup, self.create_estimate(setup))
+        item_tx_qs = ItemTransactionModel.objects.filter(
+            uuid__in=[
+                orphan_item_tx.uuid,
+                bill_item_tx.uuid,
+                invoice_item_tx.uuid,
+                po_item_tx.uuid,
+                estimate_item_tx.uuid,
+            ],
+        )
+
+        self.assert_itemtx_uuids(item_tx_qs.is_orphan(), [orphan_item_tx])
+
+    def test_get_estimate_aggregate_returns_cost_revenue_and_count_totals(self):
+        setup = self.create_entity_setup()
+        estimate_model = self.create_estimate(setup)
+        first_item_tx = self.create_estimate_item_transaction(
+            setup,
+            estimate_model,
+            quantity=2.0,
+            unit_cost=30.0,
+            unit_revenue=75.0,
+        )
+        second_item_tx = self.create_estimate_item_transaction(
+            setup,
+            estimate_model,
+            quantity=1.0,
+            unit_cost=20.0,
+            unit_revenue=50.0,
+        )
+
+        aggregate = ItemTransactionModel.objects.filter(
+            uuid__in=[first_item_tx.uuid, second_item_tx.uuid],
+        ).get_estimate_aggregate()
+
+        self.assertEqual(aggregate["total_items"], 2)
+        self.assertEqual(aggregate["ce_cost_estimate__sum"], Decimal("80.00"))
+        self.assertEqual(aggregate["ce_revenue_estimate__sum"], Decimal("200"))

--- a/django_ledger/tests/api/test_journal_entry_activity_api.py
+++ b/django_ledger/tests/api/test_journal_entry_activity_api.py
@@ -1,0 +1,256 @@
+"""
+High-level API behavior tests for JournalEntryModel activity classification.
+
+These tests cover role extraction, cash involvement, activity classification,
+and generated activity state without exhaustively testing every role group.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io.roles import (
+    ASSET_CA_CASH,
+    ASSET_PPE_EQUIPMENT,
+    EQUITY_CAPITAL,
+    EXPENSE_OPERATIONAL,
+)
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+
+
+class JournalEntryActivityAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_activity_admin",
+            email="api-je-activity-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_with_activity_accounts(self, *, name="API JE Activity Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+        )
+        equipment_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Equipment",
+            role=ASSET_PPE_EQUIPMENT,
+            balance_type="debit",
+            active=True,
+        )
+        equity_account = coa_model.create_account(
+            code="3010",
+            name=f"{name} Equity Capital",
+            role=EQUITY_CAPITAL,
+            balance_type="credit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+        return {
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "equipment_account": equipment_account,
+            "equity_account": equity_account,
+            "ledger_model": ledger_model,
+        }
+
+    def create_journal_entry(self, ledger_model, *, description="API JE Activity Journal Entry"):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description=description,
+        )
+
+    def create_transaction(self, journal_entry, *, tx_type, account, amount=Decimal("100.00")):
+        return TransactionModel.objects.create(
+            tx_type=tx_type,
+            journal_entry=journal_entry,
+            account=account,
+            amount=amount,
+            description="Activity transaction.",
+        )
+
+    def add_cash_expense_transactions(self, journal_entry, *, cash_account, expense_account):
+        self.create_transaction(
+            journal_entry,
+            tx_type=TransactionModel.DEBIT,
+            account=expense_account,
+        )
+        self.create_transaction(
+            journal_entry,
+            tx_type=TransactionModel.CREDIT,
+            account=cash_account,
+        )
+
+    def test_get_txs_roles_returns_involved_account_roles(self):
+        setup = self.create_entity_with_activity_accounts(
+            name="API JE Activity Roles Entity",
+        )
+        journal_entry = self.create_journal_entry(setup["ledger_model"])
+        self.add_cash_expense_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+
+        self.assertEqual(
+            {ASSET_CA_CASH, EXPENSE_OPERATIONAL},
+            journal_entry.get_txs_roles(),
+        )
+
+    def test_get_txs_roles_can_exclude_cash_role(self):
+        setup = self.create_entity_with_activity_accounts(
+            name="API JE Activity Exclude Cash Entity",
+        )
+        journal_entry = self.create_journal_entry(setup["ledger_model"])
+        self.add_cash_expense_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+
+        self.assertEqual(
+            {EXPENSE_OPERATIONAL},
+            journal_entry.get_txs_roles(exclude_cash_role=True),
+        )
+
+    def test_is_cash_involved_is_true_when_cash_transaction_is_present(self):
+        setup = self.create_entity_with_activity_accounts(
+            name="API JE Activity Cash Involved Entity",
+        )
+        journal_entry = self.create_journal_entry(setup["ledger_model"])
+        self.add_cash_expense_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+
+        self.assertTrue(journal_entry.is_cash_involved())
+
+    def test_is_cash_involved_is_false_without_cash_transaction(self):
+        setup = self.create_entity_with_activity_accounts(
+            name="API JE Activity No Cash Entity",
+        )
+        journal_entry = self.create_journal_entry(setup["ledger_model"])
+        self.create_transaction(
+            journal_entry,
+            tx_type=TransactionModel.DEBIT,
+            account=setup["expense_account"],
+        )
+        self.create_transaction(
+            journal_entry,
+            tx_type=TransactionModel.CREDIT,
+            account=setup["equity_account"],
+        )
+
+        self.assertFalse(journal_entry.is_cash_involved())
+
+    def test_get_activity_from_roles_returns_operating_activity_for_operating_roles(self):
+        self.assertEqual(
+            JournalEntryModel.OPERATING_ACTIVITY,
+            JournalEntryModel.get_activity_from_roles({EXPENSE_OPERATIONAL}),
+        )
+
+    def test_get_activity_from_roles_returns_investing_activity_for_investing_roles(self):
+        self.assertEqual(
+            JournalEntryModel.INVESTING_PPE,
+            JournalEntryModel.get_activity_from_roles({ASSET_PPE_EQUIPMENT}),
+        )
+
+    def test_get_activity_from_roles_returns_financing_activity_for_financing_roles(self):
+        self.assertEqual(
+            JournalEntryModel.FINANCING_EQUITY,
+            JournalEntryModel.get_activity_from_roles({EQUITY_CAPITAL}),
+        )
+
+    def test_get_activity_from_roles_raises_for_mixed_incompatible_activity_roles(self):
+        with self.assertRaises(JournalEntryValidationError):
+            JournalEntryModel.get_activity_from_roles(
+                {EXPENSE_OPERATIONAL, ASSET_PPE_EQUIPMENT},
+            )
+
+    def test_generate_activity_sets_activity_for_cash_involved_balanced_entry(self):
+        setup = self.create_entity_with_activity_accounts(
+            name="API JE Activity Generate Entity",
+        )
+        journal_entry = self.create_journal_entry(setup["ledger_model"])
+        self.add_cash_expense_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+
+        activity = journal_entry.generate_activity()
+
+        self.assertEqual(JournalEntryModel.OPERATING_ACTIVITY, activity)
+        self.assertEqual(JournalEntryModel.OPERATING_ACTIVITY, journal_entry.activity)
+
+    def test_activity_helpers_reflect_generated_activity(self):
+        setup = self.create_entity_with_activity_accounts(
+            name="API JE Activity Helper Entity",
+        )
+        journal_entry = self.create_journal_entry(setup["ledger_model"])
+        self.add_cash_expense_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+        journal_entry.generate_activity()
+
+        self.assertTrue(journal_entry.has_activity())
+        self.assertEqual("op", journal_entry.get_activity_name())
+        self.assertTrue(journal_entry.is_operating())
+        self.assertFalse(journal_entry.is_financing())
+        self.assertFalse(journal_entry.is_investing())
+
+        journal_entry.activity = JournalEntryModel.FINANCING_EQUITY
+        self.assertEqual("fin", journal_entry.get_activity_name())
+        self.assertTrue(journal_entry.is_financing())
+        self.assertFalse(journal_entry.is_operating())
+        self.assertFalse(journal_entry.is_investing())
+
+        journal_entry.activity = JournalEntryModel.INVESTING_PPE
+        self.assertEqual("inv", journal_entry.get_activity_name())
+        self.assertTrue(journal_entry.is_investing())
+        self.assertFalse(journal_entry.is_operating())
+        self.assertFalse(journal_entry.is_financing())

--- a/django_ledger/tests/api/test_journal_entry_delete_api.py
+++ b/django_ledger/tests/api/test_journal_entry_delete_api.py
@@ -1,0 +1,154 @@
+"""
+High-level API behavior tests for JournalEntryModel delete guards.
+
+These tests cover public delete eligibility without exercising transaction,
+posting, or signal behavior.
+"""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+
+
+class JournalEntryDeleteAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_delete_admin",
+            email="api-je-delete-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self, year=2026, month=1, day=15):
+        if settings.USE_TZ:
+            return datetime(year, month, day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, 12, 0)
+
+    def create_entity(
+        self,
+        *,
+        name="API JE Delete Entity",
+        last_closing_date=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if last_closing_date is not None:
+            entity_model.last_closing_date = last_closing_date
+            entity_model.save(update_fields=["last_closing_date", "updated"])
+        return entity_model
+
+    def create_ledger(self, entity_model, *, name="API JE Delete Ledger"):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API JE Delete Journal Entry",
+        timestamp=None,
+        posted=False,
+        locked=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": timestamp if timestamp is not None else self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+            "locked": locked,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def assert_delete_is_rejected(self, journal_entry):
+        journal_entry_uuid = journal_entry.uuid
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.delete()
+
+        self.assertTrue(JournalEntryModel.objects.filter(uuid=journal_entry_uuid).exists())
+
+    def test_unposted_unlocked_journal_entry_can_be_deleted(self):
+        entity_model = self.create_entity(name="API JE Delete Allowed Entity")
+        ledger_model = self.create_ledger(entity_model, name="API JE Delete Allowed Ledger")
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Delete Allowed",
+        )
+
+        journal_entry_uuid = journal_entry.uuid
+        journal_entry.delete()
+
+        self.assertFalse(JournalEntryModel.objects.filter(uuid=journal_entry_uuid).exists())
+
+    def test_posted_journal_entry_cannot_be_deleted(self):
+        entity_model = self.create_entity(name="API JE Delete Posted Entity")
+        ledger_model = self.create_ledger(entity_model, name="API JE Delete Posted Ledger")
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Delete Posted",
+            posted=True,
+            force_create=True,
+        )
+
+        self.assert_delete_is_rejected(journal_entry)
+
+    def test_explicitly_locked_journal_entry_cannot_be_deleted(self):
+        entity_model = self.create_entity(name="API JE Delete Locked Entity")
+        ledger_model = self.create_ledger(entity_model, name="API JE Delete Locked Ledger")
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Delete Locked",
+            locked=True,
+        )
+
+        self.assert_delete_is_rejected(journal_entry)
+
+    def test_journal_entry_in_locked_period_cannot_be_deleted(self):
+        entity_model = self.create_entity(
+            name="API JE Delete Locked Period Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(entity_model, name="API JE Delete Locked Period Ledger")
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Delete Locked Period",
+            timestamp=self.make_timestamp(2026, 1, 15),
+        )
+
+        self.assert_delete_is_rejected(journal_entry)
+
+    def test_delete_failure_leaves_journal_entry_in_database(self):
+        entity_model = self.create_entity(name="API JE Delete Failure Entity")
+        ledger_model = self.create_ledger(entity_model, name="API JE Delete Failure Ledger")
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Delete Failure",
+            posted=True,
+            force_create=True,
+        )
+        journal_entry_uuid = journal_entry.uuid
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.delete()
+
+        persisted_journal_entry = JournalEntryModel.objects.get(uuid=journal_entry_uuid)
+        self.assertTrue(persisted_journal_entry.posted)

--- a/django_ledger/tests/api/test_journal_entry_lifecycle_api.py
+++ b/django_ledger/tests/api/test_journal_entry_lifecycle_api.py
@@ -1,0 +1,299 @@
+"""
+High-level API behavior tests for JournalEntryModel lifecycle transitions.
+
+These tests cover direct public state changes without locked-period or signal
+behavior.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+
+
+class JournalEntryLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_lifecycle_admin",
+            email="api-je-lifecycle-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_with_accounting_setup(self, *, name="API JE Lifecycle Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+        return {
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+        }
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API JE Lifecycle Journal Entry",
+        posted=False,
+        locked=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+            "locked": locked,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def add_balanced_transactions(self, journal_entry, *, cash_account, expense_account):
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=expense_account,
+            amount=Decimal("100.00"),
+            description="Expense debit.",
+        )
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=cash_account,
+            amount=Decimal("100.00"),
+            description="Cash credit.",
+        )
+
+    def create_balanced_journal_entry(self, setup, *, description, locked=False):
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description=description,
+            locked=False,
+        )
+        self.add_balanced_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+        if locked:
+            journal_entry.locked = True
+            journal_entry.save(verify=False, update_fields=["locked", "updated"])
+        return journal_entry
+
+    def test_mark_as_locked_commit_false_updates_only_in_memory_state(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Lock Commit False Entity",
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Lock Commit False",
+        )
+
+        journal_entry.mark_as_locked(commit=False)
+
+        self.assertTrue(journal_entry.locked)
+
+        journal_entry.refresh_from_db()
+        self.assertFalse(journal_entry.locked)
+
+    def test_lock_commit_true_persists_locked_state(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Lock Commit True Entity",
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Lock Commit True",
+        )
+
+        journal_entry.lock(commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertTrue(journal_entry.locked)
+
+    def test_unlock_commit_true_persists_unlocked_state_for_explicitly_locked_entry(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Unlock Commit True Entity",
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Unlock Commit True",
+            locked=True,
+        )
+
+        journal_entry.unlock(commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertFalse(journal_entry.locked)
+
+    def test_mark_as_posted_commit_true_persists_posted_state_for_balanced_locked_entry(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Post Commit True Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(
+            setup,
+            description="API JE Post Commit True",
+            locked=True,
+        )
+
+        journal_entry.mark_as_posted(commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertTrue(journal_entry.posted)
+        self.assertTrue(journal_entry.has_activity())
+
+    def test_unpost_commit_true_persists_unposted_state_and_clears_activity(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Unpost Commit True Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(
+            setup,
+            description="API JE Unpost Commit True",
+            locked=True,
+        )
+        journal_entry.mark_as_posted(commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertTrue(journal_entry.posted)
+        self.assertTrue(journal_entry.has_activity())
+
+        journal_entry.unpost(commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertFalse(journal_entry.posted)
+        self.assertIsNone(journal_entry.activity)
+
+    def test_post_force_lock_commit_true_locks_and_posts_balanced_entry(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Force Lock Post Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(
+            setup,
+            description="API JE Force Lock Post",
+            locked=False,
+        )
+
+        journal_entry.post(force_lock=True, commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertTrue(journal_entry.locked)
+        self.assertTrue(journal_entry.posted)
+
+    def test_invalid_transitions_with_raise_exception_false_are_noops(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Invalid No Raise Entity",
+        )
+        already_locked = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Already Locked",
+            locked=True,
+        )
+        unlocked = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Already Unlocked",
+            locked=False,
+        )
+        posted = self.create_balanced_journal_entry(
+            setup,
+            description="API JE Already Posted",
+            locked=True,
+        )
+        posted.mark_as_posted(commit=True)
+        unposted = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Already Unposted",
+            posted=False,
+        )
+
+        already_locked.mark_as_locked(commit=True, raise_exception=False)
+        unlocked.mark_as_unlocked(commit=True, raise_exception=False)
+        posted.mark_as_posted(commit=True, raise_exception=False)
+        unposted.mark_as_unposted(commit=True, raise_exception=False)
+
+        already_locked.refresh_from_db()
+        unlocked.refresh_from_db()
+        posted.refresh_from_db()
+        unposted.refresh_from_db()
+
+        self.assertTrue(already_locked.locked)
+        self.assertFalse(unlocked.locked)
+        self.assertTrue(posted.posted)
+        self.assertFalse(unposted.posted)
+
+    def test_invalid_transitions_with_raise_exception_true_raise_validation_error(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Invalid Raise Entity",
+        )
+        already_locked = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Invalid Already Locked",
+            locked=True,
+        )
+        unlocked = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Invalid Already Unlocked",
+            locked=False,
+        )
+        posted = self.create_balanced_journal_entry(
+            setup,
+            description="API JE Invalid Already Posted",
+            locked=True,
+        )
+        posted.mark_as_posted(commit=True)
+        unposted = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Invalid Already Unposted",
+            posted=False,
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            already_locked.mark_as_locked(commit=True, raise_exception=True)
+        with self.assertRaises(JournalEntryValidationError):
+            unlocked.mark_as_unlocked(commit=True, raise_exception=True)
+        with self.assertRaises(JournalEntryValidationError):
+            posted.mark_as_posted(commit=True, raise_exception=True)
+        with self.assertRaises(JournalEntryValidationError):
+            unposted.mark_as_unposted(commit=True, raise_exception=True)

--- a/django_ledger/tests/api/test_journal_entry_locked_period_api.py
+++ b/django_ledger/tests/api/test_journal_entry_locked_period_api.py
@@ -1,0 +1,250 @@
+"""
+High-level API behavior tests for JournalEntryModel locked-period predicates.
+
+These tests cover public state and capability checks without exercising
+lifecycle transitions or signals.
+"""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityModel
+
+
+class JournalEntryLockedPeriodAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_locked_period_admin",
+            email="api-je-locked-period-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self, year=2026, month=1, day=15):
+        if settings.USE_TZ:
+            return datetime(year, month, day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, 12, 0)
+
+    def create_entity(
+        self,
+        *,
+        name="API JE Locked Period Entity",
+        last_closing_date=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if last_closing_date is not None:
+            entity_model.last_closing_date = last_closing_date
+            entity_model.save(update_fields=["last_closing_date", "updated"])
+        return entity_model
+
+    def create_ledger(self, entity_model, *, name="API JE Locked Period Ledger"):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API JE Locked Period Journal Entry",
+        timestamp=None,
+        posted=False,
+        locked=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": timestamp or self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+            "locked": locked,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def test_is_in_locked_period_is_false_without_entity_last_closing_date(self):
+        entity_model = self.create_entity(
+            name="API JE No Closing Date Entity",
+        )
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            timestamp=self.make_timestamp(2026, 1, 15),
+        )
+
+        self.assertFalse(journal_entry.is_in_locked_period())
+
+    def test_is_in_locked_period_is_true_on_or_before_last_closing_date(self):
+        entity_model = self.create_entity(
+            name="API JE Closing Date Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(entity_model)
+        before_closing = self.create_journal_entry(
+            ledger_model,
+            description="API JE Before Closing",
+            timestamp=self.make_timestamp(2026, 1, 15),
+        )
+        on_closing = self.create_journal_entry(
+            ledger_model,
+            description="API JE On Closing",
+            timestamp=self.make_timestamp(2026, 1, 31),
+        )
+        after_closing = self.create_journal_entry(
+            ledger_model,
+            description="API JE After Closing",
+            timestamp=self.make_timestamp(2026, 2, 1),
+        )
+
+        self.assertTrue(before_closing.is_in_locked_period())
+        self.assertTrue(on_closing.is_in_locked_period())
+        self.assertFalse(after_closing.is_in_locked_period())
+
+    def test_is_in_locked_period_accepts_date_and_datetime_override(self):
+        entity_model = self.create_entity(
+            name="API JE Closing Date Override Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            timestamp=self.make_timestamp(2026, 2, 15),
+        )
+
+        self.assertTrue(journal_entry.is_in_locked_period(new_timestamp=date(2026, 1, 31)))
+        self.assertTrue(journal_entry.is_in_locked_period(new_timestamp=self.make_timestamp(2026, 1, 31)))
+        self.assertFalse(journal_entry.is_in_locked_period(new_timestamp=date(2026, 2, 1)))
+        self.assertFalse(journal_entry.is_in_locked_period(new_timestamp=self.make_timestamp(2026, 2, 1)))
+
+    def test_is_locked_reflects_posted_explicit_ledger_and_period_locks(self):
+        current_entity = self.create_entity(
+            name="API JE Is Locked Current Entity",
+        )
+        current_ledger = self.create_ledger(current_entity)
+
+        posted_journal_entry = self.create_journal_entry(
+            current_ledger,
+            description="API JE Posted Lock",
+            posted=True,
+            force_create=True,
+        )
+        explicit_locked_journal_entry = self.create_journal_entry(
+            current_ledger,
+            description="API JE Explicit Lock",
+            locked=True,
+        )
+        ledger_locked_journal_entry = self.create_journal_entry(
+            current_ledger,
+            description="API JE Ledger Lock",
+        )
+        current_ledger.locked = True
+        current_ledger.save(update_fields=["locked", "updated"])
+
+        locked_period_entity = self.create_entity(
+            name="API JE Is Locked Period Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        locked_period_ledger = self.create_ledger(locked_period_entity)
+        locked_period_journal_entry = self.create_journal_entry(
+            locked_period_ledger,
+            description="API JE Locked Period Lock",
+            timestamp=self.make_timestamp(2026, 1, 15),
+        )
+
+        self.assertTrue(posted_journal_entry.is_locked())
+        self.assertTrue(explicit_locked_journal_entry.is_locked())
+        self.assertTrue(ledger_locked_journal_entry.is_locked())
+        self.assertTrue(ledger_locked_journal_entry.ledger_is_locked())
+        self.assertTrue(locked_period_journal_entry.is_locked())
+
+    def test_capability_predicates_reflect_locked_period_restrictions(self):
+        entity_model = self.create_entity(
+            name="API JE Locked Period Capability Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(entity_model)
+        locked_unposted = self.create_journal_entry(
+            ledger_model,
+            description="API JE Locked Period Unposted",
+            timestamp=self.make_timestamp(2026, 1, 15),
+            locked=True,
+        )
+        posted = self.create_journal_entry(
+            ledger_model,
+            description="API JE Locked Period Posted",
+            timestamp=self.make_timestamp(2026, 1, 15),
+            posted=True,
+            force_create=True,
+        )
+
+        self.assertFalse(locked_unposted.can_post())
+        self.assertFalse(posted.can_unpost())
+        self.assertFalse(locked_unposted.can_lock())
+        self.assertFalse(locked_unposted.can_unlock())
+        self.assertFalse(locked_unposted.can_delete())
+        self.assertFalse(locked_unposted.can_edit())
+
+    def test_capability_predicates_reflect_ledger_lock_restrictions(self):
+        entity_model = self.create_entity(
+            name="API JE Ledger Lock Capability Entity",
+        )
+        ledger_model = self.create_ledger(entity_model)
+        unposted = self.create_journal_entry(
+            ledger_model,
+            description="API JE Ledger Lock Unposted",
+        )
+        locked_unposted = self.create_journal_entry(
+            ledger_model,
+            description="API JE Ledger Lock Explicitly Locked",
+            locked=True,
+        )
+        posted = self.create_journal_entry(
+            ledger_model,
+            description="API JE Ledger Lock Posted",
+            posted=True,
+            force_create=True,
+        )
+
+        ledger_model.locked = True
+        ledger_model.save(update_fields=["locked", "updated"])
+
+        self.assertFalse(locked_unposted.can_post())
+        self.assertFalse(posted.can_unpost())
+        self.assertFalse(unposted.can_lock())
+        self.assertFalse(locked_unposted.can_unlock())
+        self.assertFalse(unposted.can_delete())
+        self.assertFalse(unposted.can_edit())
+
+    def test_capability_predicates_allow_current_unlocked_unposted_entries(self):
+        entity_model = self.create_entity(
+            name="API JE Current Capability Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            timestamp=self.make_timestamp(2026, 2, 15),
+        )
+
+        self.assertTrue(journal_entry.can_lock())
+        self.assertTrue(journal_entry.can_delete())
+        self.assertTrue(journal_entry.can_edit())
+
+        journal_entry.locked = True
+        self.assertTrue(journal_entry.can_post())
+        self.assertTrue(journal_entry.can_unlock())

--- a/django_ledger/tests/api/test_journal_entry_numbering_api.py
+++ b/django_ledger/tests/api/test_journal_entry_numbering_api.py
@@ -1,0 +1,197 @@
+"""
+High-level API behavior tests for JournalEntryModel numbering and pre-save.
+
+These tests cover journal-entry number generation, fiscal-year sequencing, and
+the locked-ledger creation guard.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+from django_ledger.settings import (
+    DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING,
+    DJANGO_LEDGER_JE_NUMBER_NO_UNIT_PREFIX,
+    DJANGO_LEDGER_JE_NUMBER_PREFIX,
+)
+
+
+class JournalEntryNumberingAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_numbering_admin",
+            email="api-je-numbering-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self, year=2026, month=1, day=15):
+        if settings.USE_TZ:
+            return datetime(year, month, day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, 12, 0)
+
+    def create_entity(self, *, name="API JE Numbering Entity", fy_start_month=1):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=fy_start_month,
+        )
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API JE Numbering Ledger",
+        locked=False,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+            locked=locked,
+        )
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API JE Numbering Journal Entry",
+        timestamp=None,
+    ):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=timestamp if timestamp is not None else self.make_timestamp(),
+            description=description,
+        )
+
+    def assert_je_number(self, number, *, fiscal_year, sequence):
+        self.assertTrue(number)
+        self.assertTrue(number.startswith(f"{DJANGO_LEDGER_JE_NUMBER_PREFIX}-"))
+        self.assertIn(f"-{fiscal_year}-", number)
+        self.assertIn(f"-{DJANGO_LEDGER_JE_NUMBER_NO_UNIT_PREFIX}-", number)
+        self.assertTrue(
+            number.endswith(str(sequence).zfill(DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING))
+        )
+
+    def clear_je_number(self, journal_entry):
+        JournalEntryModel.objects.filter(uuid=journal_entry.uuid).update(je_number="")
+        journal_entry.refresh_from_db()
+
+    def test_can_generate_je_number_is_true_with_ledger_and_no_number(self):
+        entity_model = self.create_entity(name="API JE Can Generate Entity")
+        ledger_model = self.create_ledger(entity_model)
+        unsaved_journal_entry = JournalEntryModel(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API JE Unsaved Can Generate",
+        )
+        saved_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Saved Can Generate",
+        )
+        self.clear_je_number(saved_journal_entry)
+
+        self.assertTrue(unsaved_journal_entry.can_generate_je_number())
+        self.assertTrue(saved_journal_entry.can_generate_je_number())
+
+    def test_generate_je_number_commit_false_assigns_number_in_memory_without_saving_entry(self):
+        entity_model = self.create_entity(name="API JE Generate Commit False Entity")
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = JournalEntryModel(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API JE Generate Commit False",
+        )
+
+        number = journal_entry.generate_je_number(commit=False)
+
+        self.assertEqual(number, journal_entry.je_number)
+        self.assert_je_number(number, fiscal_year=2026, sequence=1)
+        self.assertFalse(JournalEntryModel.objects.filter(uuid=journal_entry.uuid).exists())
+
+    def test_generate_je_number_commit_true_persists_generated_number(self):
+        entity_model = self.create_entity(name="API JE Generate Commit True Entity")
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Generate Commit True",
+        )
+        self.clear_je_number(journal_entry)
+
+        number = journal_entry.generate_je_number(commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertEqual(number, journal_entry.je_number)
+        self.assert_je_number(number, fiscal_year=2026, sequence=2)
+
+    def test_je_number_is_automatically_generated_on_create(self):
+        entity_model = self.create_entity(name="API JE Pre Save Number Entity")
+        ledger_model = self.create_ledger(entity_model)
+
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Pre Save Number",
+        )
+
+        self.assert_je_number(journal_entry.je_number, fiscal_year=2026, sequence=1)
+        self.assertFalse(journal_entry.can_generate_je_number())
+
+    def test_sequential_je_numbers_advance_within_entity_fiscal_year_and_no_unit_scope(self):
+        entity_model = self.create_entity(name="API JE Sequential Entity")
+        ledger_model = self.create_ledger(entity_model)
+
+        first_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Sequential First",
+        )
+        second_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Sequential Second",
+        )
+
+        self.assertNotEqual(first_journal_entry.je_number, second_journal_entry.je_number)
+        self.assert_je_number(first_journal_entry.je_number, fiscal_year=2026, sequence=1)
+        self.assert_je_number(second_journal_entry.je_number, fiscal_year=2026, sequence=2)
+
+    def test_je_numbering_uses_separate_sequences_across_fiscal_years(self):
+        entity_model = self.create_entity(name="API JE Fiscal Year Sequence Entity")
+        ledger_model = self.create_ledger(entity_model)
+
+        fy_2026_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE FY 2026",
+            timestamp=self.make_timestamp(2026, 12, 31),
+        )
+        fy_2027_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE FY 2027",
+            timestamp=self.make_timestamp(2027, 1, 1),
+        )
+
+        self.assert_je_number(fy_2026_journal_entry.je_number, fiscal_year=2026, sequence=1)
+        self.assert_je_number(fy_2027_journal_entry.je_number, fiscal_year=2027, sequence=1)
+
+    def test_creating_journal_entry_under_locked_ledger_raises_validation_error(self):
+        entity_model = self.create_entity(name="API JE Locked Ledger Guard Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            name="API JE Locked Ledger Guard",
+            locked=True,
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            self.create_journal_entry(
+                ledger_model,
+                description="API JE Locked Ledger Rejected",
+            )
+
+        self.assertFalse(JournalEntryModel.objects.filter(ledger=ledger_model).exists())

--- a/django_ledger/tests/api/test_journal_entry_queryset_api.py
+++ b/django_ledger/tests/api/test_journal_entry_queryset_api.py
@@ -1,0 +1,295 @@
+"""
+High-level API behavior tests for JournalEntryModel manager and queryset helpers.
+
+These tests cover entity/user scoping, public queryset filters, ledger scoping,
+and annotated property fallbacks without requiring transaction fixtures.
+"""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityManagementModel, EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+
+
+class JournalEntryQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_queryset_admin",
+            email="api-je-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_je_queryset_other_admin",
+            email="api-je-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_je_queryset_manager",
+            email="api-je-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_je_queryset_unrelated",
+            email="api-je-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_je_queryset_superuser",
+            email="api-je-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity(
+        self,
+        *,
+        name="API Journal Entry QuerySet Entity",
+        admin=None,
+        last_closing_date=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if last_closing_date is not None:
+            entity_model.last_closing_date = last_closing_date
+            entity_model.save(update_fields=["last_closing_date", "updated"])
+        return entity_model
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Journal Entry QuerySet Ledger",
+        ledger_xid="api-je-queryset-ledger",
+        locked=False,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            locked=locked,
+        )
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API Journal Entry QuerySet Journal Entry",
+        posted=False,
+        locked=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+            "locked": locked,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity(name="API JE For Entity A")
+        other_entity = self.create_entity(
+            name="API JE For Entity B",
+            admin=self.other_admin_user,
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-je-for-entity-a",
+        )
+        other_ledger = self.create_ledger(
+            other_entity,
+            ledger_xid="api-je-for-entity-b",
+        )
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE For Entity A",
+        )
+        other_journal_entry = self.create_journal_entry(
+            other_ledger,
+            description="API JE For Entity B",
+        )
+
+        for entity_lookup in (entity_model, entity_model.slug, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                journal_entry_qs = JournalEntryModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(journal_entry_qs.filter(uuid=journal_entry.uuid).exists())
+                self.assertFalse(journal_entry_qs.filter(uuid=other_journal_entry.uuid).exists())
+
+    def test_for_entity_rejects_invalid_input(self):
+        with self.assertRaises(JournalEntryValidationError):
+            JournalEntryModel.objects.for_entity(object())
+
+    def test_for_user_scopes_journal_entries_by_entity_access(self):
+        entity_model = self.create_entity(name="API JE User Scope Entity")
+        other_entity = self.create_entity(
+            name="API JE Other User Scope Entity",
+            admin=self.other_admin_user,
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-je-user-scope",
+        )
+        other_ledger = self.create_ledger(
+            other_entity,
+            ledger_xid="api-je-other-user-scope",
+        )
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE User Scope",
+        )
+        other_journal_entry = self.create_journal_entry(
+            other_ledger,
+            description="API JE Other User Scope",
+        )
+
+        EntityManagementModel.objects.create(
+            entity=entity_model,
+            user=self.manager_user,
+            permission_level="read",
+        )
+
+        admin_qs = JournalEntryModel.objects.for_user(self.admin_user)
+        manager_qs = JournalEntryModel.objects.for_user(self.manager_user)
+        unrelated_qs = JournalEntryModel.objects.for_user(self.unrelated_user)
+        superuser_qs = JournalEntryModel.objects.for_user(self.superuser)
+
+        self.assertTrue(admin_qs.filter(uuid=journal_entry.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_journal_entry.uuid).exists())
+
+        self.assertTrue(manager_qs.filter(uuid=journal_entry.uuid).exists())
+        self.assertFalse(manager_qs.filter(uuid=other_journal_entry.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=journal_entry.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_journal_entry.uuid).exists())
+
+        self.assertTrue(superuser_qs.filter(uuid=journal_entry.uuid).exists())
+        self.assertTrue(superuser_qs.filter(uuid=other_journal_entry.uuid).exists())
+
+    def test_queryset_filters_return_matching_journal_entries(self):
+        entity_model = self.create_entity(name="API JE Filter Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-je-filter-ledger",
+        )
+        posted_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API Posted JE",
+            posted=True,
+            locked=False,
+            force_create=True,
+        )
+        unposted_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API Unposted JE",
+            posted=False,
+        )
+        locked_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API Locked JE",
+            locked=True,
+        )
+        unlocked_journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API Unlocked JE",
+            locked=False,
+        )
+
+        journal_entry_qs = JournalEntryModel.objects.for_entity(entity_model)
+
+        self.assertTrue(journal_entry_qs.posted().filter(uuid=posted_journal_entry.uuid).exists())
+        self.assertFalse(journal_entry_qs.posted().filter(uuid=unposted_journal_entry.uuid).exists())
+
+        self.assertTrue(journal_entry_qs.unposted().filter(uuid=unposted_journal_entry.uuid).exists())
+        self.assertFalse(journal_entry_qs.unposted().filter(uuid=posted_journal_entry.uuid).exists())
+
+        self.assertTrue(journal_entry_qs.locked().filter(uuid=locked_journal_entry.uuid).exists())
+        self.assertFalse(journal_entry_qs.locked().filter(uuid=unlocked_journal_entry.uuid).exists())
+
+        self.assertTrue(journal_entry_qs.unlocked().filter(uuid=unlocked_journal_entry.uuid).exists())
+        self.assertFalse(journal_entry_qs.unlocked().filter(uuid=locked_journal_entry.uuid).exists())
+
+    def test_for_ledger_accepts_model_uuid_and_uuid_string(self):
+        entity_model = self.create_entity(name="API JE For Ledger Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-je-for-ledger-a",
+        )
+        other_ledger = self.create_ledger(
+            entity_model,
+            ledger_xid="api-je-for-ledger-b",
+        )
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE For Ledger A",
+        )
+        other_journal_entry = self.create_journal_entry(
+            other_ledger,
+            description="API JE For Ledger B",
+        )
+
+        for ledger_lookup in (ledger_model, ledger_model.uuid, str(ledger_model.uuid)):
+            with self.subTest(ledger_lookup=ledger_lookup):
+                journal_entry_qs = JournalEntryModel.objects.for_ledger(ledger_lookup)
+
+                self.assertTrue(journal_entry_qs.filter(uuid=journal_entry.uuid).exists())
+                self.assertFalse(journal_entry_qs.filter(uuid=other_journal_entry.uuid).exists())
+
+    def test_manager_annotations_and_property_fallbacks_expose_entity_and_ledger_state(self):
+        entity_model = self.create_entity(
+            name="API JE Annotation Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-je-annotation-ledger",
+            locked=False,
+        )
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description="API JE Annotation",
+        )
+        ledger_model.locked = True
+        ledger_model.save(update_fields=["locked", "updated"])
+
+        annotated_journal_entry = JournalEntryModel.objects.get(uuid=journal_entry.uuid)
+        direct_journal_entry = JournalEntryModel(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API Direct JE Annotation",
+        )
+
+        self.assertEqual(annotated_journal_entry.entity_uuid, entity_model.uuid)
+        self.assertEqual(direct_journal_entry.entity_uuid, entity_model.uuid)
+
+        self.assertEqual(annotated_journal_entry.entity_slug, entity_model.slug)
+        self.assertEqual(direct_journal_entry.entity_slug, entity_model.slug)
+
+        self.assertEqual(annotated_journal_entry.entity_last_closing_date, date(2026, 1, 31))
+        self.assertEqual(direct_journal_entry.entity_last_closing_date, date(2026, 1, 31))
+
+        self.assertTrue(annotated_journal_entry.ledger_is_locked())
+        self.assertTrue(direct_journal_entry.ledger_is_locked())
+
+        self.assertTrue(hasattr(annotated_journal_entry, "txs_count"))
+        self.assertEqual(annotated_journal_entry.txs_count, 0)

--- a/django_ledger/tests/api/test_journal_entry_signals_api.py
+++ b/django_ledger/tests/api/test_journal_entry_signals_api.py
@@ -1,0 +1,215 @@
+"""
+Smoke tests for JournalEntryModel lifecycle signals.
+
+These tests verify that public lifecycle methods emit their corresponding
+signals without asserting unrelated payload details.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.signals import (
+    journal_entry_locked,
+    journal_entry_posted,
+    journal_entry_unlocked,
+    journal_entry_unposted,
+)
+
+
+class JournalEntrySignalsAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_signals_admin",
+            email="api-je-signals-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_with_accounting_setup(self, *, name="API JE Signals Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+        return {
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+        }
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API JE Signals Journal Entry",
+        posted=False,
+        locked=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+            "locked": locked,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def add_balanced_transactions(self, journal_entry, *, cash_account, expense_account):
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=expense_account,
+            amount=Decimal("100.00"),
+            description="Expense debit.",
+        )
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=cash_account,
+            amount=Decimal("100.00"),
+            description="Cash credit.",
+        )
+
+    def create_balanced_journal_entry(self, setup, *, description, locked=False):
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description=description,
+        )
+        self.add_balanced_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+        if locked:
+            journal_entry.locked = True
+            journal_entry.save(verify=False, update_fields=["locked", "updated"])
+        return journal_entry
+
+    def collect_signal_calls(self, signal):
+        calls = []
+        dispatch_uid = f"{self.id()}-{id(signal)}"
+
+        def receiver(sender, **kwargs):
+            calls.append(kwargs)
+
+        signal.connect(
+            receiver,
+            sender=JournalEntryModel,
+            weak=False,
+            dispatch_uid=dispatch_uid,
+        )
+        self.addCleanup(
+            signal.disconnect,
+            sender=JournalEntryModel,
+            dispatch_uid=dispatch_uid,
+        )
+        return calls
+
+    def assert_signal_received_once(self, calls, journal_entry, *, commit):
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0]["instance"], journal_entry)
+        self.assertEqual(calls[0]["commited"], commit)
+
+    def test_mark_as_posted_emits_journal_entry_posted_signal(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Posted Signal Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(
+            setup,
+            description="API JE Posted Signal",
+            locked=True,
+        )
+        calls = self.collect_signal_calls(journal_entry_posted)
+
+        journal_entry.mark_as_posted(commit=True)
+
+        self.assert_signal_received_once(calls, journal_entry, commit=True)
+
+    def test_mark_as_unposted_emits_journal_entry_unposted_signal(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Unposted Signal Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(
+            setup,
+            description="API JE Unposted Signal",
+            locked=True,
+        )
+        journal_entry.mark_as_posted(commit=True)
+        calls = self.collect_signal_calls(journal_entry_unposted)
+
+        journal_entry.mark_as_unposted(commit=True)
+
+        self.assert_signal_received_once(calls, journal_entry, commit=True)
+
+    def test_mark_as_locked_emits_journal_entry_locked_signal(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Locked Signal Entity",
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Locked Signal",
+            locked=False,
+        )
+        calls = self.collect_signal_calls(journal_entry_locked)
+
+        journal_entry.mark_as_locked(commit=True)
+
+        self.assert_signal_received_once(calls, journal_entry, commit=True)
+
+    def test_mark_as_unlocked_emits_journal_entry_unlocked_signal(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Unlocked Signal Entity",
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Unlocked Signal",
+            locked=True,
+        )
+        calls = self.collect_signal_calls(journal_entry_unlocked)
+
+        journal_entry.mark_as_unlocked(commit=True)
+
+        self.assert_signal_received_once(calls, journal_entry, commit=True)

--- a/django_ledger/tests/api/test_journal_entry_url_helpers_api.py
+++ b/django_ledger/tests/api/test_journal_entry_url_helpers_api.py
@@ -1,0 +1,127 @@
+"""
+Smoke tests for JournalEntryModel URL and message helpers.
+
+These tests verify that model helpers resolve to entity-scoped, ledger-scoped,
+and journal-entry-scoped strings without exercising view permissions or HTTP
+responses.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityModel
+
+
+class JournalEntryURLHelpersAPITest(TestCase):
+    LEDGER_SCOPED_URL_HELPERS = (
+        "get_journal_entry_list_url",
+        "get_journal_entry_create_url",
+    )
+    JOURNAL_ENTRY_SCOPED_URL_HELPERS = (
+        "get_absolute_url",
+        "get_detail_url",
+        "get_detail_txs_url",
+        "get_unlock_url",
+        "get_lock_url",
+        "get_post_url",
+        "get_unpost_url",
+        "get_action_post_url",
+        "get_action_unpost_url",
+        "get_action_lock_url",
+        "get_action_unlock_url",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_url_helpers_admin",
+            email="api-je-url-helpers-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.entity_model = EntityModel.create_entity(
+            name="API Journal Entry URL Helpers Entity",
+            admin=cls.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        cls.ledger_model = LedgerModel.objects.create(
+            name="API Journal Entry URL Helpers Ledger",
+            ledger_xid="api-je-url-helpers-ledger",
+            entity=cls.entity_model,
+        )
+        cls.journal_entry = JournalEntryModel.objects.create(
+            ledger=cls.ledger_model,
+            timestamp=cls.make_timestamp(),
+            description="API Journal Entry URL Helpers Journal Entry",
+        )
+
+    @classmethod
+    def make_timestamp(cls):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def assert_url_contains_entity_slug(self, url):
+        self.assertIsInstance(url, str)
+        self.assertTrue(url)
+        self.assertIn(self.entity_model.slug, url)
+
+    def assert_url_contains_ledger_uuid(self, url):
+        self.assertIn(str(self.ledger_model.uuid), url)
+
+    def assert_url_contains_journal_entry_uuid(self, url):
+        self.assertIn(str(self.journal_entry.uuid), url)
+
+    def test_ledger_scoped_url_helpers_return_entity_and_ledger_urls(self):
+        for helper_name in self.LEDGER_SCOPED_URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(self.journal_entry, helper_name)()
+
+                self.assert_url_contains_entity_slug(url)
+                self.assert_url_contains_ledger_uuid(url)
+
+    def test_journal_entry_scoped_url_helpers_return_entity_ledger_and_entry_urls(self):
+        for helper_name in self.JOURNAL_ENTRY_SCOPED_URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(self.journal_entry, helper_name)()
+
+                self.assert_url_contains_entity_slug(url)
+                self.assert_url_contains_ledger_uuid(url)
+                self.assert_url_contains_journal_entry_uuid(url)
+
+    def test_detail_url_matches_absolute_url(self):
+        self.assertEqual(
+            self.journal_entry.get_absolute_url(),
+            self.journal_entry.get_detail_url(),
+        )
+
+    def test_action_url_aliases_match_matching_url_helpers(self):
+        self.assertEqual(
+            self.journal_entry.get_post_url(),
+            self.journal_entry.get_action_post_url(),
+        )
+        self.assertEqual(
+            self.journal_entry.get_unpost_url(),
+            self.journal_entry.get_action_unpost_url(),
+        )
+        self.assertEqual(
+            self.journal_entry.get_lock_url(),
+            self.journal_entry.get_action_lock_url(),
+        )
+        self.assertEqual(
+            self.journal_entry.get_unlock_url(),
+            self.journal_entry.get_action_unlock_url(),
+        )
+
+    def test_get_delete_message_includes_journal_entry_number_and_ledger_name(self):
+        message = str(self.journal_entry.get_delete_message())
+
+        self.assertIn(self.journal_entry.je_number, message)
+        self.assertIn(self.ledger_model.name, message)

--- a/django_ledger/tests/api/test_journal_entry_validation_api.py
+++ b/django_ledger/tests/api/test_journal_entry_validation_api.py
@@ -1,0 +1,279 @@
+"""
+High-level API behavior tests for JournalEntryModel transaction validation.
+
+These tests cover transaction queryset, balance, and chart-of-accounts
+validation without exercising save, clean, or posting behavior.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+
+
+class JournalEntryValidationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_validation_admin",
+            email="api-je-validation-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_with_accounting_setup(self, *, name="API JE Validation Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description=f"{name} Journal Entry",
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+            "journal_entry": journal_entry,
+        }
+
+    def create_journal_entry(self, ledger_model, *, description):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description=description,
+        )
+
+    def add_transactions(
+        self,
+        journal_entry,
+        *,
+        debit_account,
+        credit_account,
+        debit_amount=Decimal("100.00"),
+        credit_amount=Decimal("100.00"),
+    ):
+        debit_tx = TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=debit_account,
+            amount=debit_amount,
+            description="Validation debit.",
+        )
+        credit_tx = TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=credit_account,
+            amount=credit_amount,
+            description="Validation credit.",
+        )
+        return debit_tx, credit_tx
+
+    def test_get_transaction_queryset_returns_this_entries_transactions_with_or_without_accounts(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation QuerySet Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        debit_tx, credit_tx = self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+        )
+        expected_tx_ids = [debit_tx.uuid, credit_tx.uuid]
+
+        with_accounts_qs = journal_entry.get_transaction_queryset(select_accounts=True)
+        without_accounts_qs = journal_entry.get_transaction_queryset(select_accounts=False)
+
+        self.assertCountEqual(
+            expected_tx_ids,
+            list(with_accounts_qs.values_list("uuid", flat=True)),
+        )
+        self.assertCountEqual(
+            expected_tx_ids,
+            list(without_accounts_qs.values_list("uuid", flat=True)),
+        )
+
+    def test_get_txs_balances_returns_debit_and_credit_totals(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation Balances Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+        )
+
+        balance_dict = journal_entry.get_txs_balances(as_dict=True)
+        balance_rows = journal_entry.get_txs_balances(as_dict=False)
+        balance_row_dict = {
+            row["tx_type"]: row["amount__sum"]
+            for row in balance_rows
+        }
+
+        self.assertEqual(Decimal("100.00"), balance_dict[TransactionModel.DEBIT])
+        self.assertEqual(Decimal("100.00"), balance_dict[TransactionModel.CREDIT])
+        self.assertEqual(balance_dict, balance_row_dict)
+
+    def test_is_balance_valid_returns_true_for_balanced_transactions(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation Balanced Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+        )
+
+        self.assertTrue(journal_entry.is_balance_valid(journal_entry.get_transaction_queryset()))
+
+    def test_is_balance_valid_returns_false_without_raising_for_imbalanced_transactions(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation Imbalanced No Raise Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+            debit_amount=Decimal("100.00"),
+            credit_amount=Decimal("90.00"),
+        )
+
+        self.assertFalse(
+            journal_entry.is_balance_valid(
+                journal_entry.get_transaction_queryset(),
+                raise_exception=False,
+            )
+        )
+
+    def test_is_balance_valid_raises_for_imbalanced_transactions_by_default(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation Imbalanced Raise Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+            debit_amount=Decimal("100.00"),
+            credit_amount=Decimal("90.00"),
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.is_balance_valid(journal_entry.get_transaction_queryset())
+
+    def test_is_txs_qs_valid_accepts_this_entries_transaction_queryset(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation Own QuerySet Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+        )
+
+        self.assertTrue(journal_entry.is_txs_qs_valid(journal_entry.get_transaction_queryset()))
+
+    def test_is_txs_qs_valid_rejects_another_entries_transaction_queryset(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation Other QuerySet Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        other_journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Validation Other Journal Entry",
+        )
+        self.add_transactions(
+            other_journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.is_txs_qs_valid(other_journal_entry.get_transaction_queryset())
+
+    def test_is_txs_qs_coa_valid_accepts_transactions_from_one_coa(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation One CoA Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+        )
+
+        self.assertTrue(journal_entry.is_txs_qs_coa_valid(journal_entry.get_transaction_queryset()))
+
+    def test_is_txs_qs_coa_valid_rejects_transactions_spanning_multiple_coas(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Validation Mixed CoA Entity",
+        )
+        entity_model = setup["entity_model"]
+        other_coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API JE Validation Other CoA",
+            commit=True,
+            assign_as_default=False,
+        )
+        other_cash_account = other_coa_model.create_account(
+            code="1010",
+            name="API JE Validation Other Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        journal_entry = setup["journal_entry"]
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=other_cash_account,
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.is_txs_qs_coa_valid(journal_entry.get_transaction_queryset())

--- a/django_ledger/tests/api/test_journal_entry_verify_api.py
+++ b/django_ledger/tests/api/test_journal_entry_verify_api.py
@@ -1,0 +1,259 @@
+"""
+High-level API behavior tests for JournalEntryModel verify, clean, and save.
+
+These tests cover verification and save-time verification flows without
+exercising lifecycle signals or detailed activity classification.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+
+
+class JournalEntryVerifyAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_je_verify_admin",
+            email="api-je-verify-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self, *, year=2026, month=1, day=15):
+        if settings.USE_TZ:
+            return datetime(year, month, day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, 12, 0)
+
+    def create_entity_with_accounting_setup(self, *, name="API JE Verify Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description=f"{name} Journal Entry",
+        )
+
+        return {
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+            "journal_entry": journal_entry,
+        }
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API JE Verify Journal Entry",
+        timestamp=None,
+        posted=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": timestamp or self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def add_transactions(
+        self,
+        journal_entry,
+        *,
+        debit_account,
+        credit_account,
+        debit_amount=Decimal("100.00"),
+        credit_amount=Decimal("100.00"),
+    ):
+        debit_tx = TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=debit_account,
+            amount=debit_amount,
+            description="Verify debit.",
+        )
+        credit_tx = TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=credit_account,
+            amount=credit_amount,
+            description="Verify credit.",
+        )
+        return debit_tx, credit_tx
+
+    def create_balanced_journal_entry(self, setup, *, description="API JE Verify Balanced"):
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description=description,
+        )
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+        )
+        return journal_entry
+
+    def create_imbalanced_journal_entry(self, setup, *, description="API JE Verify Imbalanced"):
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description=description,
+        )
+        self.add_transactions(
+            journal_entry,
+            debit_account=setup["expense_account"],
+            credit_account=setup["cash_account"],
+            debit_amount=Decimal("100.00"),
+            credit_amount=Decimal("90.00"),
+        )
+        return journal_entry
+
+    def test_verify_marks_balanced_entry_verified_and_returns_transactions(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Verify Balanced Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(setup)
+
+        txs_qs, verified = journal_entry.verify()
+
+        self.assertEqual(2, txs_qs.count())
+        self.assertTrue(verified)
+        self.assertTrue(journal_entry.is_verified())
+        self.assertTrue(journal_entry.has_activity())
+
+    def test_verify_force_verify_revalidates_after_entry_was_already_verified(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Force Verify Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(setup)
+        journal_entry.verify()
+        credit_tx = journal_entry.get_transaction_queryset().get(tx_type=TransactionModel.CREDIT)
+        credit_tx.amount = Decimal("90.00")
+        credit_tx.save()
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.verify(force_verify=True)
+
+    def test_verify_raises_for_imbalanced_transactions(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Verify Imbalanced Entity",
+        )
+        journal_entry = self.create_imbalanced_journal_entry(setup)
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.verify()
+
+    def test_clean_without_verify_returns_transactions_and_current_verified_state(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Clean No Verify Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(setup)
+
+        txs_qs, verified = journal_entry.clean(verify=False)
+
+        self.assertTrue(journal_entry.je_number)
+        self.assertEqual(2, txs_qs.count())
+        self.assertFalse(verified)
+        self.assertFalse(journal_entry.is_verified())
+
+    def test_clean_with_verify_verifies_balanced_entry(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Clean Verify Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(setup)
+
+        txs_qs, verified = journal_entry.clean(verify=True)
+
+        self.assertEqual(2, txs_qs.count())
+        self.assertTrue(verified)
+        self.assertTrue(journal_entry.is_verified())
+
+    def test_clean_rejects_posted_entry_with_future_timestamp(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Clean Future Posted Entity",
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API JE Future Posted",
+            timestamp=self.make_timestamp(year=2099),
+            posted=True,
+            force_create=True,
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.clean()
+
+    def test_save_verify_false_allows_saving_unverified_entry(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Save No Verify Entity",
+        )
+        journal_entry = setup["journal_entry"]
+        journal_entry.description = "API JE Save No Verify Updated"
+
+        journal_entry.save(verify=False)
+
+        journal_entry.refresh_from_db()
+        self.assertEqual("API JE Save No Verify Updated", journal_entry.description)
+
+    def test_save_verify_true_rejects_invalid_entry(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Save Verify Invalid Entity",
+        )
+        journal_entry = self.create_imbalanced_journal_entry(setup)
+        journal_entry.description = "API JE Save Verify Invalid Updated"
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.save(verify=True)
+
+    def test_save_post_on_verify_posts_and_locks_balanced_entry(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API JE Save Post On Verify Entity",
+        )
+        journal_entry = self.create_balanced_journal_entry(setup)
+
+        journal_entry.save(verify=True, post_on_verify=True)
+
+        journal_entry.refresh_from_db()
+        self.assertTrue(journal_entry.posted)
+        self.assertTrue(journal_entry.locked)
+        self.assertTrue(journal_entry.activity)

--- a/django_ledger/tests/api/test_ledger_capability_predicates_api.py
+++ b/django_ledger/tests/api/test_ledger_capability_predicates_api.py
@@ -1,0 +1,222 @@
+"""
+High-level API behavior tests for LedgerModel capability predicates.
+
+These tests cover direct action availability predicates and default invalid
+transition exceptions without locked-period or signal behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import LedgerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.ledger import LedgerModelValidationError
+
+
+class LedgerCapabilityPredicatesAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_capability_admin",
+            email="api-ledger-capability-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Ledger Capability Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Ledger Capability Ledger",
+        ledger_xid="api-ledger-capability-ledger",
+        posted=False,
+        locked=False,
+        hidden=False,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            posted=posted,
+            locked=locked,
+            hidden=hidden,
+        )
+
+    def test_can_post_is_true_only_for_unposted_unlocked_ledger(self):
+        entity_model = self.create_entity(name="API Ledger Can Post Entity")
+        unposted_unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-can-post",
+            posted=False,
+            locked=False,
+        )
+        posted_unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-post-posted",
+            posted=True,
+            locked=False,
+        )
+        unposted_locked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-post-locked",
+            posted=False,
+            locked=True,
+        )
+
+        self.assertTrue(unposted_unlocked.can_post())
+        self.assertFalse(posted_unlocked.can_post())
+        self.assertFalse(unposted_locked.can_post())
+
+    def test_can_unpost_is_true_only_for_posted_unlocked_ledger(self):
+        entity_model = self.create_entity(name="API Ledger Can Unpost Entity")
+        posted_unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-can-unpost",
+            posted=True,
+            locked=False,
+        )
+        unposted_unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-unpost-unposted",
+            posted=False,
+            locked=False,
+        )
+        posted_locked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-unpost-locked",
+            posted=True,
+            locked=True,
+        )
+
+        self.assertTrue(posted_unlocked.can_unpost())
+        self.assertFalse(unposted_unlocked.can_unpost())
+        self.assertFalse(posted_locked.can_unpost())
+
+    def test_can_lock_is_true_only_for_posted_unlocked_ledger(self):
+        entity_model = self.create_entity(name="API Ledger Can Lock Entity")
+        posted_unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-can-lock",
+            posted=True,
+            locked=False,
+        )
+        unposted_unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-lock-unposted",
+            posted=False,
+            locked=False,
+        )
+        posted_locked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-lock-locked",
+            posted=True,
+            locked=True,
+        )
+
+        self.assertTrue(posted_unlocked.can_lock())
+        self.assertFalse(unposted_unlocked.can_lock())
+        self.assertFalse(posted_locked.can_lock())
+
+    def test_can_unlock_is_true_only_for_posted_locked_ledger(self):
+        entity_model = self.create_entity(name="API Ledger Can Unlock Entity")
+        posted_locked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-can-unlock",
+            posted=True,
+            locked=True,
+        )
+        posted_unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-unlock-unlocked",
+            posted=True,
+            locked=False,
+        )
+        unposted_locked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-cannot-unlock-unposted",
+            posted=False,
+            locked=True,
+        )
+
+        self.assertTrue(posted_locked.can_unlock())
+        self.assertFalse(posted_unlocked.can_unlock())
+        self.assertFalse(unposted_locked.can_unlock())
+
+    def test_can_hide_and_can_unhide_reflect_hidden_state(self):
+        entity_model = self.create_entity(name="API Ledger Can Hide Entity")
+        visible_ledger = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-can-hide",
+            hidden=False,
+        )
+        hidden_ledger = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-can-unhide",
+            hidden=True,
+        )
+
+        self.assertTrue(visible_ledger.can_hide())
+        self.assertFalse(visible_ledger.can_unhide())
+
+        self.assertFalse(hidden_ledger.can_hide())
+        self.assertTrue(hidden_ledger.can_unhide())
+
+    def test_invalid_lifecycle_transitions_raise_by_default(self):
+        entity_model = self.create_entity(name="API Ledger Invalid Capability Entity")
+        already_posted = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-invalid-post",
+            posted=True,
+            locked=False,
+        )
+        unposted = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-invalid-unpost",
+            posted=False,
+            locked=False,
+        )
+        unposted_for_lock = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-invalid-lock",
+            posted=False,
+            locked=False,
+        )
+        unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-invalid-unlock",
+            posted=True,
+            locked=False,
+        )
+        hidden = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-invalid-hide",
+            hidden=True,
+        )
+        visible = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-invalid-unhide",
+            hidden=False,
+        )
+
+        invalid_actions = (
+            already_posted.post,
+            unposted.unpost,
+            unposted_for_lock.lock,
+            unlocked.unlock,
+            hidden.hide,
+            visible.unhide,
+        )
+
+        for action in invalid_actions:
+            with self.subTest(action=action.__qualname__):
+                with self.assertRaises(LedgerModelValidationError):
+                    action()

--- a/django_ledger/tests/api/test_ledger_delete_api.py
+++ b/django_ledger/tests/api/test_ledger_delete_api.py
@@ -1,0 +1,161 @@
+"""
+High-level API behavior tests for LedgerModel delete guards.
+
+These tests cover public delete eligibility without exercising wrapper model
+lifecycles or signals.
+"""
+
+from datetime import date, datetime
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.ledger import LedgerModelValidationError
+
+
+class LedgerDeleteAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_delete_admin",
+            email="api-ledger-delete-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(
+        self,
+        *,
+        name="API Ledger Delete Entity",
+        last_closing_date=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if last_closing_date is not None:
+            entity_model.last_closing_date = last_closing_date
+            entity_model.save(update_fields=["last_closing_date", "updated"])
+        return entity_model
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Ledger Delete Ledger",
+        ledger_xid="api-ledger-delete-ledger",
+        posted=False,
+        locked=False,
+        additional_info=None,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            posted=posted,
+            locked=locked,
+            additional_info={} if additional_info is None else additional_info,
+        )
+
+    def make_timestamp(self, year, month, day):
+        if settings.USE_TZ:
+            return datetime(year, month, day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, 12, 0)
+
+    def create_posted_journal_entry(self, ledger_model, *, tx_date):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(tx_date.year, tx_date.month, tx_date.day),
+            description=f"API Delete Posted Journal Entry {tx_date.isoformat()}",
+            posted=True,
+            force_create=True,
+        )
+
+    def assert_delete_is_rejected(self, ledger_model):
+        self.assertFalse(ledger_model.can_delete())
+
+        with self.assertRaises(LedgerModelValidationError):
+            ledger_model.delete()
+
+        self.assertTrue(LedgerModel.objects.filter(uuid=ledger_model.uuid).exists())
+
+    def test_unposted_unlocked_non_wrapped_ledger_without_locked_period_journal_entries_can_delete(self):
+        entity_model = self.create_entity(name="API Ledger Delete Allowed Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-delete-allowed",
+            posted=False,
+            locked=False,
+        )
+
+        self.assertTrue(ledger_model.can_delete())
+
+        ledger_uuid = ledger_model.uuid
+        ledger_model.delete()
+
+        self.assertFalse(LedgerModel.objects.filter(uuid=ledger_uuid).exists())
+
+    def test_posted_ledger_cannot_delete(self):
+        entity_model = self.create_entity(name="API Ledger Delete Posted Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-delete-posted",
+            posted=True,
+            locked=False,
+        )
+
+        self.assert_delete_is_rejected(ledger_model)
+
+    def test_locked_ledger_cannot_delete(self):
+        entity_model = self.create_entity(name="API Ledger Delete Locked Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-delete-locked",
+            posted=False,
+            locked=True,
+        )
+
+        self.assert_delete_is_rejected(ledger_model)
+
+    def test_wrapped_ledger_metadata_prevents_delete(self):
+        entity_model = self.create_entity(name="API Ledger Delete Wrapped Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-delete-wrapped",
+            posted=False,
+            locked=False,
+            additional_info={
+                "wrapped_model": {
+                    "model": "billmodel",
+                    "uuid": uuid4(),
+                }
+            },
+        )
+
+        self.assert_delete_is_rejected(ledger_model)
+
+    def test_ledger_with_posted_journal_entry_in_locked_period_cannot_delete(self):
+        entity_model = self.create_entity(
+            name="API Ledger Delete Locked Period Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-delete-locked-period",
+            posted=False,
+            locked=False,
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 1, 15),
+        )
+
+        self.assert_delete_is_rejected(ledger_model)

--- a/django_ledger/tests/api/test_ledger_journal_entry_api.py
+++ b/django_ledger/tests/api/test_ledger_journal_entry_api.py
@@ -1,0 +1,186 @@
+"""
+High-level API behavior tests for LedgerModel and JournalEntryModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import FieldError
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+from django_ledger.models.entity import EntityModel
+
+
+class LedgerJournalEntryHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for LedgerModel and JournalEntryModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document small, deterministic accounting lifecycle invariants
+    that should remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_ledger_contract_user",
+            email="api-ledger-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Ledger Contract Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_entity_with_default_coa(self):
+        entity_model = self.create_entity()
+        entity_model.create_chart_of_accounts(
+            coa_name="API Ledger Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        entity_model.refresh_from_db()
+        return entity_model
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_ledger(self, entity_model, *, posted=False, locked=False):
+        return LedgerModel.objects.create(
+            name="API Contract Ledger",
+            ledger_xid="api-contract-ledger",
+            entity=entity_model,
+            posted=posted,
+            locked=locked,
+        )
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        posted=False,
+        locked=False,
+        description="API Contract Journal Entry",
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+            "locked": locked,
+        }
+
+        if force_create:
+            create_kwargs["force_create"] = True
+
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def test_ledger_is_created_under_entity_context(self):
+        entity_model = self.create_entity_with_default_coa()
+
+        ledger_model = self.create_ledger(entity_model)
+
+        self.assertIsNotNone(ledger_model.uuid)
+        self.assertEqual(ledger_model.entity_id, entity_model.uuid)
+        self.assertEqual(ledger_model.name, "API Contract Ledger")
+        self.assertFalse(ledger_model.posted)
+        self.assertFalse(ledger_model.locked)
+
+    def test_journal_entry_is_created_unposted_by_default(self):
+        entity_model = self.create_entity_with_default_coa()
+        ledger_model = self.create_ledger(entity_model)
+
+        journal_entry = self.create_journal_entry(ledger_model)
+
+        self.assertIsNotNone(journal_entry.uuid)
+        self.assertEqual(journal_entry.ledger_id, ledger_model.uuid)
+        self.assertFalse(journal_entry.posted)
+        self.assertFalse(journal_entry.locked)
+        self.assertFalse(journal_entry.is_locked())
+        self.assertTrue(journal_entry.can_edit())
+        self.assertTrue(journal_entry.can_delete())
+
+    def test_journal_entry_cannot_be_created_posted_without_force_create(self):
+        entity_model = self.create_entity_with_default_coa()
+        ledger_model = self.create_ledger(entity_model)
+
+        with self.assertRaises(FieldError):
+            self.create_journal_entry(
+                ledger_model,
+                posted=True,
+                locked=False,
+            )
+
+    def test_empty_journal_entry_is_not_marked_posted(self):
+        entity_model = self.create_entity_with_default_coa()
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = self.create_journal_entry(ledger_model)
+
+        result = journal_entry.mark_as_posted(commit=True)
+
+        journal_entry.refresh_from_db()
+        self.assertIsNone(result)
+        self.assertFalse(journal_entry.posted)
+        self.assertFalse(journal_entry.is_locked())
+
+    def test_posted_journal_entry_is_considered_locked(self):
+        entity_model = self.create_entity_with_default_coa()
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            posted=True,
+            locked=False,
+            force_create=True,
+        )
+
+        self.assertTrue(journal_entry.posted)
+        self.assertFalse(journal_entry.locked)
+        self.assertTrue(journal_entry.is_locked())
+        self.assertFalse(journal_entry.can_edit())
+        self.assertFalse(journal_entry.can_delete())
+
+    def test_explicitly_locked_journal_entry_cannot_be_edited_or_deleted(self):
+        entity_model = self.create_entity_with_default_coa()
+        ledger_model = self.create_ledger(entity_model)
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            posted=False,
+            locked=True,
+        )
+
+        self.assertFalse(journal_entry.posted)
+        self.assertTrue(journal_entry.locked)
+        self.assertTrue(journal_entry.is_locked())
+        self.assertFalse(journal_entry.can_edit())
+        self.assertFalse(journal_entry.can_delete())
+
+    def test_journal_entry_cannot_be_created_under_locked_ledger(self):
+        entity_model = self.create_entity_with_default_coa()
+        ledger_model = self.create_ledger(entity_model, locked=True)
+
+        with self.assertRaises(JournalEntryValidationError):
+            self.create_journal_entry(
+                ledger_model,
+                posted=False,
+                locked=False,
+            )
+
+        self.assertTrue(ledger_model.locked)

--- a/django_ledger/tests/api/test_ledger_journal_entry_batch_api.py
+++ b/django_ledger/tests/api/test_ledger_journal_entry_batch_api.py
@@ -1,0 +1,244 @@
+"""
+High-level API behavior tests for LedgerModel journal-entry batch helpers.
+
+These tests cover public batch posting and locking behavior without exercising
+signals.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+
+
+class LedgerJournalEntryBatchAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_je_batch_admin",
+            email="api-ledger-je-batch-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_with_accounting_setup(self, *, name="API Ledger JE Batch Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+        }
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API Ledger JE Batch Journal Entry",
+        posted=False,
+        locked=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+            "locked": locked,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def add_balanced_transactions(self, journal_entry, *, cash_account, expense_account):
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=expense_account,
+            amount=Decimal("100.00"),
+            description="Expense debit.",
+        )
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=cash_account,
+            amount=Decimal("100.00"),
+            description="Cash credit.",
+        )
+
+    def create_postable_journal_entry(self, setup, *, description):
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description=description,
+            posted=False,
+            locked=False,
+        )
+        self.add_balanced_transactions(
+            journal_entry,
+            cash_account=setup["cash_account"],
+            expense_account=setup["expense_account"],
+        )
+        journal_entry.locked = True
+        journal_entry.save(update_fields=["locked", "updated"])
+        return journal_entry
+
+    def test_post_journal_entries_commit_false_posts_unposted_entries_in_memory_only(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API Ledger JE Batch Post Commit False Entity"
+        )
+        journal_entry = self.create_postable_journal_entry(
+            setup,
+            description="API Batch Post Commit False JE",
+        )
+
+        posted_entries = list(setup["ledger_model"].post_journal_entries(commit=False))
+
+        self.assertEqual([journal_entry.uuid], [entry.uuid for entry in posted_entries])
+        self.assertTrue(posted_entries[0].posted)
+
+        journal_entry.refresh_from_db()
+        self.assertFalse(journal_entry.posted)
+
+    def test_post_journal_entries_commit_true_persists_posted_state(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API Ledger JE Batch Post Commit True Entity"
+        )
+        journal_entry = self.create_postable_journal_entry(
+            setup,
+            description="API Batch Post Commit True JE",
+        )
+
+        posted_entries = list(setup["ledger_model"].post_journal_entries(commit=True))
+
+        self.assertEqual([journal_entry.uuid], [entry.uuid for entry in posted_entries])
+
+        journal_entry.refresh_from_db()
+        self.assertTrue(journal_entry.posted)
+
+    def test_post_journal_entries_does_not_change_already_posted_entries(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API Ledger JE Batch Already Posted Entity"
+        )
+        posted_journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API Batch Already Posted JE",
+            posted=True,
+            locked=False,
+            force_create=True,
+        )
+        unposted_journal_entry = self.create_postable_journal_entry(
+            setup,
+            description="API Batch Newly Posted JE",
+        )
+
+        posted_entries = list(setup["ledger_model"].post_journal_entries(commit=True))
+
+        self.assertEqual([unposted_journal_entry.uuid], [entry.uuid for entry in posted_entries])
+
+        posted_journal_entry.refresh_from_db()
+        self.assertTrue(posted_journal_entry.posted)
+        self.assertFalse(posted_journal_entry.locked)
+
+    def test_lock_journal_entries_commit_false_locks_unlocked_entries_in_memory_only(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API Ledger JE Batch Lock Commit False Entity"
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API Batch Lock Commit False JE",
+            posted=False,
+            locked=False,
+        )
+
+        locked_entries = list(setup["ledger_model"].lock_journal_entries(commit=False))
+
+        self.assertEqual([journal_entry.uuid], [entry.uuid for entry in locked_entries])
+        self.assertTrue(locked_entries[0].locked)
+
+        journal_entry.refresh_from_db()
+        self.assertFalse(journal_entry.locked)
+
+    def test_lock_journal_entries_commit_true_persists_locked_state(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API Ledger JE Batch Lock Commit True Entity"
+        )
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API Batch Lock Commit True JE",
+            posted=False,
+            locked=False,
+        )
+
+        locked_entries = list(setup["ledger_model"].lock_journal_entries(commit=True))
+
+        self.assertEqual([journal_entry.uuid], [entry.uuid for entry in locked_entries])
+
+        journal_entry.refresh_from_db()
+        self.assertTrue(journal_entry.locked)
+
+    def test_lock_journal_entries_does_not_change_already_locked_entries(self):
+        setup = self.create_entity_with_accounting_setup(
+            name="API Ledger JE Batch Already Locked Entity"
+        )
+        locked_journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API Batch Already Locked JE",
+            posted=False,
+            locked=True,
+        )
+        unlocked_journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API Batch Newly Locked JE",
+            posted=False,
+            locked=False,
+        )
+
+        locked_entries = list(setup["ledger_model"].lock_journal_entries(commit=True))
+
+        self.assertEqual([unlocked_journal_entry.uuid], [entry.uuid for entry in locked_entries])
+
+        locked_journal_entry.refresh_from_db()
+        self.assertTrue(locked_journal_entry.locked)

--- a/django_ledger/tests/api/test_ledger_lifecycle_api.py
+++ b/django_ledger/tests/api/test_ledger_lifecycle_api.py
@@ -1,0 +1,208 @@
+"""
+High-level API behavior tests for LedgerModel lifecycle transitions.
+
+These tests cover direct public state changes without closing-period, delete,
+or signal behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import LedgerModel
+from django_ledger.models.entity import EntityModel
+
+
+class LedgerLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_lifecycle_admin",
+            email="api-ledger-lifecycle-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Ledger Lifecycle Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Ledger Lifecycle Ledger",
+        ledger_xid="api-ledger-lifecycle-ledger",
+        posted=False,
+        locked=False,
+        hidden=False,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            posted=posted,
+            locked=locked,
+            hidden=hidden,
+        )
+
+    def test_post_commit_false_updates_only_in_memory_state(self):
+        entity_model = self.create_entity(name="API Ledger Post Commit False Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-post-commit-false",
+            posted=False,
+            locked=False,
+        )
+
+        ledger_model.post(commit=False)
+
+        self.assertTrue(ledger_model.posted)
+
+        ledger_model.refresh_from_db()
+        self.assertFalse(ledger_model.posted)
+
+    def test_post_commit_true_persists_posted_state(self):
+        entity_model = self.create_entity(name="API Ledger Post Commit True Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-post-commit-true",
+            posted=False,
+            locked=False,
+        )
+
+        ledger_model.post(commit=True)
+
+        ledger_model.refresh_from_db()
+        self.assertTrue(ledger_model.posted)
+
+    def test_unpost_commit_true_persists_unposted_state(self):
+        entity_model = self.create_entity(name="API Ledger Unpost Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unpost",
+            posted=True,
+            locked=False,
+        )
+
+        ledger_model.unpost(commit=True)
+
+        ledger_model.refresh_from_db()
+        self.assertFalse(ledger_model.posted)
+
+    def test_lock_commit_true_persists_locked_state(self):
+        entity_model = self.create_entity(name="API Ledger Lock Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-lock",
+            posted=True,
+            locked=False,
+        )
+
+        ledger_model.lock(commit=True)
+
+        ledger_model.refresh_from_db()
+        self.assertTrue(ledger_model.locked)
+
+    def test_unlock_commit_true_persists_unlocked_state(self):
+        entity_model = self.create_entity(name="API Ledger Unlock Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unlock",
+            posted=True,
+            locked=True,
+        )
+
+        ledger_model.unlock(commit=True)
+
+        ledger_model.refresh_from_db()
+        self.assertFalse(ledger_model.locked)
+
+    def test_hide_commit_true_persists_hidden_state(self):
+        entity_model = self.create_entity(name="API Ledger Hide Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-hide",
+            hidden=False,
+        )
+
+        ledger_model.hide(commit=True)
+
+        ledger_model.refresh_from_db()
+        self.assertTrue(ledger_model.hidden)
+
+    def test_unhide_commit_true_persists_visible_state(self):
+        entity_model = self.create_entity(name="API Ledger Unhide Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unhide",
+            hidden=True,
+        )
+
+        ledger_model.unhide(commit=True)
+
+        ledger_model.refresh_from_db()
+        self.assertFalse(ledger_model.hidden)
+
+    def test_invalid_transitions_with_raise_exception_false_are_noops(self):
+        entity_model = self.create_entity(name="API Ledger Invalid Transition Entity")
+
+        already_posted = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-already-posted",
+            posted=True,
+            locked=False,
+        )
+        unposted = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unposted-transition",
+            posted=False,
+            locked=False,
+        )
+        unposted_for_lock = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unposted-lock",
+            posted=False,
+            locked=False,
+        )
+        unlocked = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unlocked-transition",
+            posted=True,
+            locked=False,
+        )
+        hidden = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-hidden-transition",
+            hidden=True,
+        )
+        visible = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-visible-transition",
+            hidden=False,
+        )
+
+        already_posted.post(commit=True, raise_exception=False)
+        unposted.unpost(commit=True, raise_exception=False)
+        unposted_for_lock.lock(commit=True, raise_exception=False)
+        unlocked.unlock(commit=True, raise_exception=False)
+        hidden.hide(commit=True, raise_exception=False)
+        visible.unhide(commit=True, raise_exception=False)
+
+        already_posted.refresh_from_db()
+        unposted.refresh_from_db()
+        unposted_for_lock.refresh_from_db()
+        unlocked.refresh_from_db()
+        hidden.refresh_from_db()
+        visible.refresh_from_db()
+
+        self.assertTrue(already_posted.posted)
+        self.assertFalse(unposted.posted)
+        self.assertFalse(unposted_for_lock.locked)
+        self.assertFalse(unlocked.locked)
+        self.assertTrue(hidden.hidden)
+        self.assertFalse(visible.hidden)

--- a/django_ledger/tests/api/test_ledger_locked_period_api.py
+++ b/django_ledger/tests/api/test_ledger_locked_period_api.py
@@ -1,0 +1,192 @@
+"""
+High-level API behavior tests for LedgerModel current and locked-period helpers.
+
+These tests cover the public current-ledger queryset contract and locked-period
+detection without exercising closing-entry creation.
+"""
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel
+from django_ledger.models.entity import EntityModel
+
+
+class LedgerLockedPeriodAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_locked_period_admin",
+            email="api-ledger-locked-period-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(
+        self,
+        *,
+        name="API Ledger Locked Period Entity",
+        last_closing_date=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if last_closing_date is not None:
+            entity_model.last_closing_date = last_closing_date
+            entity_model.save(update_fields=["last_closing_date", "updated"])
+        return entity_model
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Ledger Locked Period Ledger",
+        ledger_xid="api-ledger-locked-period-ledger",
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+        )
+
+    def make_timestamp(self, year, month, day):
+        if settings.USE_TZ:
+            return datetime(year, month, day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, 12, 0)
+
+    def create_posted_journal_entry(self, ledger_model, *, tx_date):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(tx_date.year, tx_date.month, tx_date.day),
+            description=f"API Posted Journal Entry {tx_date.isoformat()}",
+            posted=True,
+            force_create=True,
+        )
+
+    def test_current_includes_ledgers_with_no_posted_journal_entries(self):
+        entity_model = self.create_entity(
+            name="API Current No Activity Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-current-no-activity",
+        )
+
+        current_qs = LedgerModel.objects.for_entity(entity_model).current()
+
+        self.assertTrue(current_qs.filter(uuid=ledger_model.uuid).exists())
+
+    def test_current_includes_ledgers_with_posted_activity_after_last_closing_date(self):
+        entity_model = self.create_entity(
+            name="API Current After Closing Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-current-after-closing",
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 2, 1),
+        )
+
+        current_qs = LedgerModel.objects.for_entity(entity_model).current()
+
+        self.assertTrue(current_qs.filter(uuid=ledger_model.uuid).exists())
+
+    def test_current_excludes_ledgers_with_posted_activity_on_or_before_last_closing_date(self):
+        entity_model = self.create_entity(
+            name="API Current Closed Activity Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-current-closed-activity",
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 1, 31),
+        )
+
+        current_qs = LedgerModel.objects.for_entity(entity_model).current()
+
+        self.assertFalse(current_qs.filter(uuid=ledger_model.uuid).exists())
+
+    def test_current_includes_posted_activity_when_entity_has_no_closing_date(self):
+        entity_model = self.create_entity(name="API Current No Closing Date Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-current-no-closing-date",
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 1, 31),
+        )
+
+        current_qs = LedgerModel.objects.for_entity(entity_model).current()
+
+        self.assertTrue(current_qs.filter(uuid=ledger_model.uuid).exists())
+
+    def test_has_jes_in_locked_period_returns_false_without_closing_date(self):
+        entity_model = self.create_entity(name="API Locked Period No Closing Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-locked-period-no-closing",
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 1, 31),
+        )
+
+        self.assertFalse(ledger_model.has_jes_in_locked_period())
+
+    def test_has_jes_in_locked_period_uses_annotated_earliest_posted_timestamp(self):
+        entity_model = self.create_entity(
+            name="API Locked Period Annotated Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-locked-period-annotated",
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 1, 15),
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 2, 15),
+        )
+
+        annotated_ledger = LedgerModel.objects.get(uuid=ledger_model.uuid)
+
+        self.assertTrue(annotated_ledger.has_jes_in_locked_period())
+
+    def test_has_jes_in_locked_period_force_evaluation_detects_any_posted_je_on_or_before_closing_date(self):
+        entity_model = self.create_entity(
+            name="API Locked Period Force Evaluation Entity",
+            last_closing_date=date(2026, 1, 31),
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-locked-period-force-evaluation",
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 1, 15),
+        )
+        self.create_posted_journal_entry(
+            ledger_model,
+            tx_date=date(2026, 2, 15),
+        )
+
+        self.assertTrue(ledger_model.has_jes_in_locked_period())

--- a/django_ledger/tests/api/test_ledger_queryset_api.py
+++ b/django_ledger/tests/api/test_ledger_queryset_api.py
@@ -1,0 +1,203 @@
+"""
+High-level API behavior tests for LedgerModel manager and queryset helpers.
+
+These tests cover entity/user scoping, public queryset filters, and entity slug
+access without requiring accounting fixtures.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import LedgerModel
+from django_ledger.models.entity import EntityManagementModel, EntityModel
+from django_ledger.models.ledger import LedgerModelValidationError
+
+
+class LedgerQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_queryset_admin",
+            email="api-ledger-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_ledger_queryset_other_admin",
+            email="api-ledger-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_ledger_queryset_manager",
+            email="api-ledger-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_ledger_queryset_unrelated",
+            email="api-ledger-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_ledger_queryset_superuser",
+            email="api-ledger-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Ledger QuerySet Entity", admin=None):
+        return EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Ledger QuerySet Ledger",
+        ledger_xid="api-ledger-queryset-ledger",
+        posted=False,
+        locked=False,
+        hidden=False,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            posted=posted,
+            locked=locked,
+            hidden=hidden,
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity(name="API Ledger For Entity A")
+        other_entity = self.create_entity(
+            name="API Ledger For Entity B",
+            admin=self.other_admin_user,
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-for-entity-a",
+        )
+        other_ledger = self.create_ledger(
+            other_entity,
+            ledger_xid="api-ledger-for-entity-b",
+        )
+
+        for entity_lookup in (entity_model, entity_model.slug, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                ledger_qs = LedgerModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(ledger_qs.filter(uuid=ledger_model.uuid).exists())
+                self.assertFalse(ledger_qs.filter(uuid=other_ledger.uuid).exists())
+
+    def test_for_entity_rejects_invalid_input(self):
+        with self.assertRaises(LedgerModelValidationError):
+            LedgerModel.objects.for_entity(object())
+
+    def test_for_user_scopes_ledgers_by_entity_access(self):
+        entity_model = self.create_entity(name="API Ledger User Scope Entity")
+        other_entity = self.create_entity(
+            name="API Ledger Other User Scope Entity",
+            admin=self.other_admin_user,
+        )
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-user-scope",
+        )
+        other_ledger = self.create_ledger(
+            other_entity,
+            ledger_xid="api-ledger-other-user-scope",
+        )
+
+        EntityManagementModel.objects.create(
+            entity=entity_model,
+            user=self.manager_user,
+            permission_level="read",
+        )
+
+        admin_qs = LedgerModel.objects.for_user(self.admin_user)
+        manager_qs = LedgerModel.objects.for_user(self.manager_user)
+        unrelated_qs = LedgerModel.objects.for_user(self.unrelated_user)
+        superuser_qs = LedgerModel.objects.for_user(self.superuser)
+
+        self.assertTrue(admin_qs.filter(uuid=ledger_model.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_ledger.uuid).exists())
+
+        self.assertTrue(manager_qs.filter(uuid=ledger_model.uuid).exists())
+        self.assertFalse(manager_qs.filter(uuid=other_ledger.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=ledger_model.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_ledger.uuid).exists())
+
+        self.assertTrue(superuser_qs.filter(uuid=ledger_model.uuid).exists())
+        self.assertTrue(superuser_qs.filter(uuid=other_ledger.uuid).exists())
+
+    def test_queryset_filters_return_matching_ledgers(self):
+        entity_model = self.create_entity(name="API Ledger Filter Entity")
+        locked_ledger = self.create_ledger(
+            entity_model,
+            name="API Locked Ledger",
+            ledger_xid="api-locked-ledger",
+            locked=True,
+        )
+        unlocked_ledger = self.create_ledger(
+            entity_model,
+            name="API Unlocked Ledger",
+            ledger_xid="api-unlocked-ledger",
+            locked=False,
+        )
+        posted_ledger = self.create_ledger(
+            entity_model,
+            name="API Posted Ledger",
+            ledger_xid="api-posted-ledger",
+            posted=True,
+        )
+        hidden_ledger = self.create_ledger(
+            entity_model,
+            name="API Hidden Ledger",
+            ledger_xid="api-hidden-ledger",
+            hidden=True,
+        )
+        visible_ledger = self.create_ledger(
+            entity_model,
+            name="API Visible Ledger",
+            ledger_xid="api-visible-ledger",
+            hidden=False,
+        )
+
+        ledger_qs = LedgerModel.objects.for_entity(entity_model)
+
+        self.assertTrue(ledger_qs.locked().filter(uuid=locked_ledger.uuid).exists())
+        self.assertFalse(ledger_qs.locked().filter(uuid=unlocked_ledger.uuid).exists())
+
+        self.assertTrue(ledger_qs.unlocked().filter(uuid=unlocked_ledger.uuid).exists())
+        self.assertFalse(ledger_qs.unlocked().filter(uuid=locked_ledger.uuid).exists())
+
+        self.assertTrue(ledger_qs.posted().filter(uuid=posted_ledger.uuid).exists())
+        self.assertFalse(ledger_qs.posted().filter(uuid=unlocked_ledger.uuid).exists())
+
+        self.assertTrue(ledger_qs.hidden().filter(uuid=hidden_ledger.uuid).exists())
+        self.assertFalse(ledger_qs.hidden().filter(uuid=visible_ledger.uuid).exists())
+
+        self.assertTrue(ledger_qs.visible().filter(uuid=visible_ledger.uuid).exists())
+        self.assertFalse(ledger_qs.visible().filter(uuid=hidden_ledger.uuid).exists())
+
+    def test_entity_slug_uses_manager_annotation_and_direct_instance_fallback(self):
+        entity_model = self.create_entity(name="API Ledger Entity Slug Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-entity-slug",
+        )
+
+        annotated_ledger = LedgerModel.objects.get(uuid=ledger_model.uuid)
+        direct_ledger = LedgerModel(
+            name="API Direct Entity Slug Ledger",
+            ledger_xid="api-direct-entity-slug",
+            entity=entity_model,
+        )
+
+        self.assertEqual(annotated_ledger.entity_slug, entity_model.slug)
+        self.assertEqual(direct_ledger.entity_slug, entity_model.slug)

--- a/django_ledger/tests/api/test_ledger_queryset_api.py
+++ b/django_ledger/tests/api/test_ledger_queryset_api.py
@@ -185,6 +185,26 @@ class LedgerQuerySetAPITest(TestCase):
         self.assertTrue(ledger_qs.visible().filter(uuid=visible_ledger.uuid).exists())
         self.assertFalse(ledger_qs.visible().filter(uuid=hidden_ledger.uuid).exists())
 
+    def test_unposted_filter_returns_only_unposted_ledgers(self):
+        entity_model = self.create_entity(name="API Ledger Unposted Filter Entity")
+        posted_ledger = self.create_ledger(
+            entity_model,
+            name="API Posted Filter Ledger",
+            ledger_xid="api-posted-filter-ledger",
+            posted=True,
+        )
+        unposted_ledger = self.create_ledger(
+            entity_model,
+            name="API Unposted Filter Ledger",
+            ledger_xid="api-unposted-filter-ledger",
+            posted=False,
+        )
+
+        unposted_qs = LedgerModel.objects.for_entity(entity_model).unposted()
+
+        self.assertTrue(unposted_qs.filter(uuid=unposted_ledger.uuid).exists())
+        self.assertFalse(unposted_qs.filter(uuid=posted_ledger.uuid).exists())
+
     def test_entity_slug_uses_manager_annotation_and_direct_instance_fallback(self):
         entity_model = self.create_entity(name="API Ledger Entity Slug Entity")
         ledger_model = self.create_ledger(

--- a/django_ledger/tests/api/test_ledger_signals_api.py
+++ b/django_ledger/tests/api/test_ledger_signals_api.py
@@ -1,0 +1,166 @@
+"""
+Smoke tests for LedgerModel lifecycle signals.
+
+These tests verify that public lifecycle methods emit their corresponding
+signals without asserting unrelated payload details.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import LedgerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.signals import (
+    ledger_hidden,
+    ledger_locked,
+    ledger_posted,
+    ledger_unhidden,
+    ledger_unlocked,
+    ledger_unposted,
+)
+
+
+class LedgerSignalsAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_signals_admin",
+            email="api-ledger-signals-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Ledger Signals Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Ledger Signals Ledger",
+        ledger_xid="api-ledger-signals-ledger",
+        posted=False,
+        locked=False,
+        hidden=False,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            posted=posted,
+            locked=locked,
+            hidden=hidden,
+        )
+
+    def collect_signal_calls(self, signal):
+        calls = []
+        dispatch_uid = f"{self.id()}-{id(signal)}"
+
+        def receiver(sender, **kwargs):
+            calls.append(kwargs)
+
+        signal.connect(
+            receiver,
+            sender=LedgerModel,
+            weak=False,
+            dispatch_uid=dispatch_uid,
+        )
+        self.addCleanup(
+            signal.disconnect,
+            sender=LedgerModel,
+            dispatch_uid=dispatch_uid,
+        )
+        return calls
+
+    def assert_signal_received_once(self, calls, ledger_model, *, commit):
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0]["instance"], ledger_model)
+        self.assertEqual(calls[0]["commited"], commit)
+
+    def test_post_emits_ledger_posted_signal(self):
+        entity_model = self.create_entity(name="API Ledger Posted Signal Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-posted-signal",
+            posted=False,
+            locked=False,
+        )
+        calls = self.collect_signal_calls(ledger_posted)
+
+        ledger_model.post(commit=True)
+
+        self.assert_signal_received_once(calls, ledger_model, commit=True)
+
+    def test_unpost_emits_ledger_unposted_signal(self):
+        entity_model = self.create_entity(name="API Ledger Unposted Signal Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unposted-signal",
+            posted=True,
+            locked=False,
+        )
+        calls = self.collect_signal_calls(ledger_unposted)
+
+        ledger_model.unpost(commit=True)
+
+        self.assert_signal_received_once(calls, ledger_model, commit=True)
+
+    def test_lock_emits_ledger_locked_signal(self):
+        entity_model = self.create_entity(name="API Ledger Locked Signal Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-locked-signal",
+            posted=True,
+            locked=False,
+        )
+        calls = self.collect_signal_calls(ledger_locked)
+
+        ledger_model.lock(commit=True)
+
+        self.assert_signal_received_once(calls, ledger_model, commit=True)
+
+    def test_unlock_emits_ledger_unlocked_signal(self):
+        entity_model = self.create_entity(name="API Ledger Unlocked Signal Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unlocked-signal",
+            posted=True,
+            locked=True,
+        )
+        calls = self.collect_signal_calls(ledger_unlocked)
+
+        ledger_model.unlock(commit=True)
+
+        self.assert_signal_received_once(calls, ledger_model, commit=True)
+
+    def test_hide_emits_ledger_hidden_signal(self):
+        entity_model = self.create_entity(name="API Ledger Hidden Signal Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-hidden-signal",
+            hidden=False,
+        )
+        calls = self.collect_signal_calls(ledger_hidden)
+
+        ledger_model.hide(commit=True)
+
+        self.assert_signal_received_once(calls, ledger_model, commit=True)
+
+    def test_unhide_emits_ledger_unhidden_signal(self):
+        entity_model = self.create_entity(name="API Ledger Unhidden Signal Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-unhidden-signal",
+            hidden=True,
+        )
+        calls = self.collect_signal_calls(ledger_unhidden)
+
+        ledger_model.unhide(commit=True)
+
+        self.assert_signal_received_once(calls, ledger_model, commit=True)

--- a/django_ledger/tests/api/test_ledger_url_helpers_api.py
+++ b/django_ledger/tests/api/test_ledger_url_helpers_api.py
@@ -1,0 +1,80 @@
+"""
+Smoke tests for LedgerModel URL and message helpers.
+
+These tests verify that model helpers resolve to entity-scoped, ledger-scoped
+strings without exercising view permissions or HTTP responses.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import LedgerModel
+from django_ledger.models.entity import EntityModel
+
+
+class LedgerURLHelpersAPITest(TestCase):
+    ENTITY_SCOPED_URL_HELPERS = (
+        "get_create_url",
+        "get_list_url",
+    )
+    LEDGER_SCOPED_URL_HELPERS = (
+        "get_absolute_url",
+        "get_update_url",
+        "get_journal_entry_list_url",
+        "get_journal_entry_create_url",
+        "get_balance_sheet_url",
+        "get_income_statement_url",
+        "get_cash_flow_statement_url",
+        "get_action_post_journal_entries_url",
+        "get_action_lock_journal_entries_url",
+    )
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_url_helpers_admin",
+            email="api-ledger-url-helpers-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.entity_model = EntityModel.create_entity(
+            name="API Ledger URL Helpers Entity",
+            admin=cls.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        cls.ledger_model = LedgerModel.objects.create(
+            name="API Ledger URL Helpers Ledger",
+            ledger_xid="api-ledger-url-helpers-ledger",
+            entity=cls.entity_model,
+        )
+
+    def assert_url_contains_entity_slug(self, url):
+        self.assertIsInstance(url, str)
+        self.assertTrue(url)
+        self.assertIn(self.entity_model.slug, url)
+
+    def assert_url_contains_ledger_uuid(self, url):
+        self.assertIn(str(self.ledger_model.uuid), url)
+
+    def test_entity_scoped_url_helpers_return_entity_urls(self):
+        for helper_name in self.ENTITY_SCOPED_URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(self.ledger_model, helper_name)()
+
+                self.assert_url_contains_entity_slug(url)
+
+    def test_ledger_scoped_url_helpers_return_entity_and_ledger_urls(self):
+        for helper_name in self.LEDGER_SCOPED_URL_HELPERS:
+            with self.subTest(helper_name=helper_name):
+                url = getattr(self.ledger_model, helper_name)()
+
+                self.assert_url_contains_entity_slug(url)
+                self.assert_url_contains_ledger_uuid(url)
+
+    def test_get_delete_message_includes_ledger_and_entity_names(self):
+        message = str(self.ledger_model.get_delete_message())
+
+        self.assertIn(self.ledger_model.name, message)
+        self.assertIn(self.entity_model.name, message)

--- a/django_ledger/tests/api/test_ledger_wrapper_api.py
+++ b/django_ledger/tests/api/test_ledger_wrapper_api.py
@@ -1,0 +1,120 @@
+"""
+High-level API behavior tests for LedgerModel wrapper metadata helpers.
+
+These tests cover wrapper metadata storage and delete eligibility without
+exercising bill or invoice lifecycle behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import BillModel, InvoiceModel, LedgerModel
+from django_ledger.models.entity import EntityModel
+
+
+class LedgerWrapperAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_ledger_wrapper_admin",
+            email="api-ledger-wrapper-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Ledger Wrapper Entity"):
+        return EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Ledger Wrapper Ledger",
+        ledger_xid="api-ledger-wrapper-ledger",
+        additional_info=None,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            additional_info={} if additional_info is None else additional_info,
+        )
+
+    def test_configure_for_wrapper_model_stores_wrapped_model_metadata(self):
+        entity_model = self.create_entity(name="API Ledger Wrapper Configure Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-wrapper-configure",
+        )
+        bill_model = BillModel()
+
+        ledger_model.configure_for_wrapper_model(bill_model)
+
+        wrapped_info = ledger_model.additional_info["wrapped_model"]
+        self.assertEqual(wrapped_info["model"], "billmodel")
+        self.assertEqual(wrapped_info["uuid"], bill_model.uuid)
+
+    def test_has_wrapped_model_info_returns_true_after_metadata_is_configured(self):
+        entity_model = self.create_entity(name="API Ledger Wrapper Has Info Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-wrapper-has-info",
+        )
+
+        ledger_model.configure_for_wrapper_model(BillModel())
+
+        self.assertTrue(ledger_model.has_wrapped_model_info())
+
+    def test_remove_wrapped_model_info_removes_only_wrapped_metadata(self):
+        entity_model = self.create_entity(name="API Ledger Wrapper Remove Info Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-wrapper-remove-info",
+            additional_info={"preserved": "value"},
+        )
+        ledger_model.configure_for_wrapper_model(BillModel())
+
+        ledger_model.remove_wrapped_model_info()
+
+        self.assertEqual(ledger_model.additional_info, {"preserved": "value"})
+
+    def test_has_wrapped_model_info_returns_false_after_metadata_removal(self):
+        entity_model = self.create_entity(name="API Ledger Wrapper Removed Info Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-wrapper-removed-info",
+        )
+        ledger_model.configure_for_wrapper_model(BillModel())
+
+        ledger_model.remove_wrapped_model_info()
+
+        self.assertFalse(ledger_model.has_wrapped_model_info())
+
+    def test_get_wrapper_info_exposes_supported_wrapper_model_mapping(self):
+        entity_model = self.create_entity(name="API Ledger Wrapper Mapping Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-wrapper-mapping",
+        )
+
+        wrapper_info = ledger_model.get_wrapper_info
+
+        self.assertEqual(wrapper_info[BillModel], "billmodel")
+        self.assertEqual(wrapper_info[InvoiceModel], "invoicemodel")
+
+    def test_can_delete_is_false_when_wrapped_model_metadata_exists(self):
+        entity_model = self.create_entity(name="API Ledger Wrapper Delete Entity")
+        ledger_model = self.create_ledger(
+            entity_model,
+            ledger_xid="api-ledger-wrapper-delete",
+        )
+
+        ledger_model.configure_for_wrapper_model(BillModel())
+
+        self.assertFalse(ledger_model.can_delete())

--- a/django_ledger/tests/api/test_model_infrastructure_api.py
+++ b/django_ledger/tests/api/test_model_infrastructure_api.py
@@ -1,0 +1,101 @@
+"""
+Smoke-level API tests for Django Ledger model infrastructure helpers.
+"""
+
+from django.test import SimpleTestCase
+
+from django_ledger.models.accounts import AccountModel
+from django_ledger.models.bank_account import BankAccountModel
+from django_ledger.models.bill import BillModel
+from django_ledger.models.chart_of_accounts import ChartOfAccountModel
+from django_ledger.models.closing_entry import ClosingEntryModel, ClosingEntryTransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.data_import import StagedTransactionModel
+from django_ledger.models.entity import EntityModel, EntityStateModel
+from django_ledger.models.estimate import EstimateModel
+from django_ledger.models.invoice import InvoiceModel
+from django_ledger.models.items import ItemModel, ItemTransactionModel, UnitOfMeasureModel
+from django_ledger.models.journal_entry import JournalEntryModel
+from django_ledger.models.ledger import LedgerModel
+from django_ledger.models.purchase_order import PurchaseOrderModel
+from django_ledger.models.receipt import ReceiptModel
+from django_ledger.models.schemas import (
+    SCHEMA_DIGEST,
+    SCHEMA_NET_PAYABLES,
+    SCHEMA_NET_RECEIVABLE,
+    SCHEMA_PNL,
+)
+from django_ledger.models.transactions import TransactionModel
+from django_ledger.models.unit import EntityUnitModel
+from django_ledger.models.utils import lazy_loader
+from django_ledger.models.vendor import VendorModel
+from django_ledger.report.balance_sheet import BalanceSheetReport
+from django_ledger.report.cash_flow_statement import CashFlowStatementReport
+from django_ledger.report.income_statement import IncomeStatementReport
+
+
+class ModelInfrastructureAPITest(SimpleTestCase):
+    def test_lazy_loader_resolves_public_model_classes(self):
+        loader_cases = (
+            (lazy_loader.get_entity_model, EntityModel),
+            (lazy_loader.get_entity_unit_model, EntityUnitModel),
+            (lazy_loader.get_entity_state_model, EntityStateModel),
+            (lazy_loader.get_bank_account_model, BankAccountModel),
+            (lazy_loader.get_account_model, AccountModel),
+            (lazy_loader.get_coa_model, ChartOfAccountModel),
+            (lazy_loader.get_txs_model, TransactionModel),
+            (lazy_loader.get_staged_txs_model, StagedTransactionModel),
+            (lazy_loader.get_purchase_order_model, PurchaseOrderModel),
+            (lazy_loader.get_ledger_model, LedgerModel),
+            (lazy_loader.get_journal_entry_model, JournalEntryModel),
+            (lazy_loader.get_item_model, ItemModel),
+            (lazy_loader.get_item_transaction_model, ItemTransactionModel),
+            (lazy_loader.get_receipt_model, ReceiptModel),
+            (lazy_loader.get_customer_model, CustomerModel),
+            (lazy_loader.get_bill_model, BillModel),
+            (lazy_loader.get_invoice_model, InvoiceModel),
+            (lazy_loader.get_uom_model, UnitOfMeasureModel),
+            (lazy_loader.get_vendor_model, VendorModel),
+            (lazy_loader.get_estimate_model, EstimateModel),
+            (lazy_loader.get_closing_entry_model, ClosingEntryModel),
+            (lazy_loader.get_closing_entry_transaction_model, ClosingEntryTransactionModel),
+        )
+
+        for getter, expected_model_class in loader_cases:
+            with self.subTest(getter=getter.__name__):
+                self.assertIs(getter(), expected_model_class)
+
+    def test_lazy_loader_resolves_report_classes(self):
+        report_cases = (
+            (lazy_loader.get_balance_sheet_report_class, BalanceSheetReport),
+            (lazy_loader.get_income_statement_report_class, IncomeStatementReport),
+            (lazy_loader.get_cash_flow_statement_report_class, CashFlowStatementReport),
+        )
+
+        for getter, expected_report_class in report_cases:
+            with self.subTest(getter=getter.__name__):
+                self.assertIs(getter(), expected_report_class)
+
+    def test_public_schema_constants_expose_stable_top_level_shape(self):
+        schema_cases = (
+            (
+                SCHEMA_DIGEST,
+                {
+                    "accounts",
+                    "role_account",
+                    "role_balance",
+                    "group_account",
+                    "group_balance",
+                },
+            ),
+            (SCHEMA_PNL, {"entity_slug", "entity_name", "pnl_data"}),
+            (SCHEMA_NET_PAYABLES, {"entity_slug", "entity_name", "net_payable_data"}),
+            (SCHEMA_NET_RECEIVABLE, {"entity_slug", "entity_name", "net_receivable_data"}),
+        )
+
+        for schema, expected_property_keys in schema_cases:
+            with self.subTest(schema=schema):
+                self.assertIsInstance(schema, dict)
+                self.assertEqual(schema["type"], "object")
+                self.assertIsInstance(schema["properties"], dict)
+                self.assertTrue(expected_property_keys.issubset(schema["properties"].keys()))

--- a/django_ledger/tests/api/test_purchase_order_api.py
+++ b/django_ledger/tests/api/test_purchase_order_api.py
@@ -1,0 +1,278 @@
+"""
+High-level API behavior tests for PurchaseOrderModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.purchase_order import PurchaseOrderModelValidationError
+from django_ledger.models.vendor import VendorModel
+
+
+class PurchaseOrderHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for PurchaseOrderModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic purchase order/vendor/item lifecycle
+    invariants that should remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_purchase_order_contract_user",
+            email="api-purchase-order-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_with_purchase_order_setup(
+        self,
+        *,
+        name="API Purchase Order Contract Entity",
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Purchase Order Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name="API Purchase Order Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name="API Purchase Order COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name="API Purchase Order Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name="API Purchase Order Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        uom_model = entity_model.create_uom(
+            name="API Purchase Order Unit",
+            unit_abbr="api-po",
+            active=True,
+            commit=True,
+        )
+
+        vendor_model = VendorModel(
+            vendor_name="API Purchase Order Vendor",
+            entity_model=entity_model,
+            description="API Purchase Order Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        inventory_item = entity_model.create_item_inventory(
+            name="API Purchase Order Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        expense_item = entity_model.create_item_expense(
+            name="API Purchase Order Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "inventory_account": inventory_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "uom_model": uom_model,
+            "vendor_model": vendor_model,
+            "inventory_item": inventory_item,
+            "expense_item": expense_item,
+        }
+
+    def create_configured_purchase_order(self, setup):
+        po_model = PurchaseOrderModel()
+        po_model.configure(
+            entity_slug=setup["entity_model"],
+            po_title="API Purchase Order Contract",
+            user_model=self.user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+        return po_model
+
+    def migrate_inventory_item(
+        self,
+        po_model,
+        setup,
+        *,
+        quantity="3.00",
+        unit_cost="20.00",
+    ):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+
+        itemtxs = {
+            setup["inventory_item"].item_number: {
+                "quantity": quantity,
+                "unit_cost": unit_cost,
+                "total_amount": quantity * unit_cost,
+            }
+        }
+
+        po_model.migrate_itemtxs(
+            itemtxs=itemtxs,
+            operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        po_model.refresh_from_db()
+        return po_model
+
+    def test_purchase_order_configure_creates_draft_po_under_entity(self):
+        setup = self.create_entity_with_purchase_order_setup()
+
+        po_model = self.create_configured_purchase_order(setup)
+
+        self.assertIsInstance(po_model, PurchaseOrderModel)
+        self.assertIsNotNone(po_model.uuid)
+        self.assertEqual(po_model.entity_id, setup["entity_model"].uuid)
+        self.assertTrue(po_model.is_draft())
+        self.assertFalse(po_model.is_approved())
+        self.assertTrue(po_model.po_number)
+
+    def test_purchase_order_item_migration_creates_item_transaction(self):
+        setup = self.create_entity_with_purchase_order_setup()
+        po_model = self.create_configured_purchase_order(setup)
+
+        self.migrate_inventory_item(po_model, setup)
+
+        item_txs = ItemTransactionModel.objects.filter(po_model=po_model)
+
+        self.assertEqual(item_txs.count(), 1)
+
+        item_tx = item_txs.get()
+
+        self.assertEqual(item_tx.item_model_id, setup["inventory_item"].uuid)
+        self.assertEqual(item_tx.po_quantity, Decimal("3.00"))
+        self.assertEqual(item_tx.po_unit_cost, Decimal("20.00"))
+        self.assertEqual(item_tx.po_total_amount, Decimal("60.00"))
+
+    def test_purchase_order_item_migration_updates_po_amount(self):
+        setup = self.create_entity_with_purchase_order_setup()
+        po_model = self.create_configured_purchase_order(setup)
+
+        po_model = self.migrate_inventory_item(po_model, setup)
+
+        self.assertEqual(po_model.po_amount, Decimal("60.00"))
+
+    def test_purchase_order_for_entity_queryset_limits_scope(self):
+        setup = self.create_entity_with_purchase_order_setup(
+            name="API Purchase Order Entity A",
+        )
+        other_setup = self.create_entity_with_purchase_order_setup(
+            name="API Purchase Order Entity B",
+        )
+
+        po_model = self.create_configured_purchase_order(setup)
+        other_po_model = self.create_configured_purchase_order(other_setup)
+
+        scoped_qs = PurchaseOrderModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=po_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_po_model.uuid).exists())
+
+    def test_purchase_order_can_move_from_draft_to_review(self):
+        setup = self.create_entity_with_purchase_order_setup()
+        po_model = self.create_configured_purchase_order(setup)
+        po_model = self.migrate_inventory_item(po_model, setup)
+
+        po_model.mark_as_review(commit=True)
+        po_model.refresh_from_db()
+
+        self.assertTrue(po_model.is_review())
+        self.assertFalse(po_model.is_draft())
+
+    def test_purchase_order_can_move_from_review_to_approved(self):
+        setup = self.create_entity_with_purchase_order_setup()
+        po_model = self.create_configured_purchase_order(setup)
+        po_model = self.migrate_inventory_item(po_model, setup)
+
+        po_model.mark_as_review(commit=True)
+        po_model.refresh_from_db()
+
+        po_model.mark_as_approved(commit=True)
+        po_model.refresh_from_db()
+
+        self.assertTrue(po_model.is_approved())
+        self.assertFalse(po_model.is_draft())
+
+    def test_approved_purchase_order_with_unbilled_items_cannot_be_marked_fulfilled(self):
+        setup = self.create_entity_with_purchase_order_setup()
+        po_model = self.create_configured_purchase_order(setup)
+        po_model = self.migrate_inventory_item(po_model, setup)
+
+        po_model.mark_as_review(commit=True)
+        po_model.refresh_from_db()
+
+        po_model.mark_as_approved(commit=True)
+        po_model.refresh_from_db()
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            po_model.mark_as_fulfilled(commit=True)
+
+        po_model.refresh_from_db()
+
+        self.assertTrue(po_model.is_approved())
+        self.assertFalse(po_model.is_fulfilled())

--- a/django_ledger/tests/api/test_purchase_order_binding_api.py
+++ b/django_ledger/tests/api/test_purchase_order_binding_api.py
@@ -1,0 +1,364 @@
+"""
+High-level API tests for PurchaseOrderModel estimate and bill binding behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel, EstimateModel, ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.bill import BillModelValidationError
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.purchase_order import PurchaseOrderModelValidationError
+
+
+class PurchaseOrderBindingAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_purchase_order_binding_user",
+            email="api-purchase-order-binding-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Purchase Order Binding Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"PO Bind Unit {str(entity_model.uuid)[:6]}",
+            unit_abbr=f"pb-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} customer.",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "payable_account": payable_account,
+            "service_item": service_item,
+            "inventory_item": inventory_item,
+        }
+
+    def create_estimate(self, setup, *, title="API Purchase Order Binding Estimate"):
+        estimate_model = setup["entity_model"].create_estimate(
+            estimate_title=title,
+            contract_terms=EstimateModel.CONTRACT_TERMS_FIXED,
+            customer_model=setup["customer_model"],
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_estimate_item(self, estimate_model, setup):
+        estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": Decimal("100.00"),
+                    "unit_revenue": Decimal("150.00"),
+                    "total_amount": Decimal("150.00"),
+                }
+            },
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_review_estimate(self, setup, *, title="API Purchase Order Binding Review Estimate"):
+        estimate_model = self.migrate_estimate_item(self.create_estimate(setup, title=title), setup)
+        estimate_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def make_approved_estimate(self, setup, *, title="API Purchase Order Binding Approved Estimate"):
+        estimate_model = self.make_review_estimate(setup, title=title)
+        estimate_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def create_purchase_order(self, setup, *, title="API Purchase Order Binding PO", date_draft=date(2025, 1, 18)):
+        po_model = setup["entity_model"].create_purchase_order(
+            po_title=title,
+            date_draft=date_draft,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def make_approved_purchase_order(
+        self,
+        setup,
+        *,
+        title="API Purchase Order Binding Approved PO",
+        date_approved=date(2025, 1, 20),
+    ):
+        po_model = self.create_purchase_order(setup, title=title, date_draft=date(2025, 1, 18))
+        self.migrate_purchase_order_item(po_model, setup)
+        po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 19))
+        po_model.refresh_from_db()
+        po_model.mark_as_approved(commit=True, date_approved=date_approved)
+        po_model.refresh_from_db()
+        return po_model
+
+    def migrate_purchase_order_item(self, po_model, setup):
+        po_model.migrate_itemtxs(
+            itemtxs={
+                setup["inventory_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": Decimal("100.00"),
+                    "total_amount": Decimal("100.00"),
+                }
+            },
+            operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def create_bill(self, setup, *, date_draft=date(2025, 1, 21)):
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_ON_RECEIPT,
+            date_draft=date_draft,
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            payable_account=setup["payable_account"],
+            commit=True,
+        )
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def test_approved_same_entity_estimate_can_bind_to_purchase_order(self):
+        setup = self.create_entity_setup()
+        estimate_model = self.make_approved_estimate(setup)
+        po_model = self.create_purchase_order(setup)
+
+        self.assertTrue(po_model.can_bind_estimate(estimate_model))
+
+        po_model.action_bind_estimate(estimate_model, commit=True)
+        po_model.refresh_from_db()
+
+        self.assertEqual(po_model.ce_model_id, estimate_model.uuid)
+        self.assertTrue(po_model.is_contract_bound())
+        self.assertTrue(estimate_model.purchaseordermodel_set.filter(uuid=po_model.uuid).exists())
+
+    def test_unapproved_estimate_cannot_bind_to_purchase_order(self):
+        setup = self.create_entity_setup(name="API Purchase Order Binding Unapproved Entity")
+        draft_estimate = self.create_estimate(setup, title="API Draft Estimate")
+        review_estimate = self.make_review_estimate(setup)
+        po_model = self.create_purchase_order(setup)
+
+        self.assertFalse(po_model.can_bind_estimate(draft_estimate))
+        self.assertFalse(po_model.can_bind_estimate(review_estimate))
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            po_model.action_bind_estimate(draft_estimate, commit=True)
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            po_model.action_bind_estimate(review_estimate, commit=True)
+
+        po_model.refresh_from_db()
+        self.assertIsNone(po_model.ce_model_id)
+
+    def test_cross_entity_estimate_cannot_bind_to_purchase_order(self):
+        setup = self.create_entity_setup(name="API Purchase Order Binding Entity A")
+        other_setup = self.create_entity_setup(name="API Purchase Order Binding Entity B")
+        other_estimate = self.make_approved_estimate(other_setup)
+        po_model = self.create_purchase_order(setup)
+
+        self.assertFalse(po_model.can_bind_estimate(other_estimate))
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            po_model.action_bind_estimate(other_estimate, commit=True)
+
+        po_model.refresh_from_db()
+        self.assertIsNone(po_model.ce_model_id)
+
+    def test_already_bound_purchase_order_rejects_second_estimate(self):
+        setup = self.create_entity_setup(name="API Purchase Order Binding Already Bound Entity")
+        first_estimate = self.make_approved_estimate(setup, title="API First Estimate")
+        second_estimate = self.make_approved_estimate(setup, title="API Second Estimate")
+        po_model = self.create_purchase_order(setup)
+        po_model.action_bind_estimate(first_estimate, commit=True)
+        po_model.refresh_from_db()
+
+        self.assertFalse(po_model.can_bind_estimate(second_estimate))
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            po_model.action_bind_estimate(second_estimate, commit=True)
+
+        po_model.refresh_from_db()
+        self.assertEqual(po_model.ce_model_id, first_estimate.uuid)
+
+    def test_configure_can_bind_approved_estimate_at_creation_time(self):
+        setup = self.create_entity_setup(name="API Purchase Order Binding Configure Entity")
+        estimate_model = self.make_approved_estimate(setup)
+
+        po_model = setup["entity_model"].create_purchase_order(
+            po_title="API Purchase Order Configured With Estimate",
+            estimate_model=estimate_model,
+            date_draft=date(2025, 1, 18),
+            commit=True,
+        )
+        po_model.refresh_from_db()
+
+        self.assertEqual(po_model.ce_model_id, estimate_model.uuid)
+        self.assertTrue(po_model.is_contract_bound())
+
+    def test_bill_can_bind_approved_purchase_order_and_link_po_items(self):
+        setup = self.create_entity_setup(name="API Purchase Order Binding Bill Entity")
+        po_model = self.make_approved_purchase_order(setup)
+        bill_model = self.create_bill(setup)
+
+        self.assertTrue(bill_model.can_bind_po(po_model))
+
+        item_tx = po_model.itemtransactionmodel_set.get()
+        item_tx.bill_model = bill_model
+        item_tx.save(update_fields=["bill_model", "updated"])
+
+        self.assertTrue(po_model.get_po_bill_queryset().filter(uuid=bill_model.uuid).exists())
+
+    def test_bill_rejects_unapproved_or_late_approved_purchase_order(self):
+        setup = self.create_entity_setup(name="API Purchase Order Binding Bill Rejection Entity")
+        draft_po = self.create_purchase_order(setup)
+        review_po = self.migrate_purchase_order_item(
+            self.create_purchase_order(setup, title="API Review PO"),
+            setup,
+        )
+        review_po.mark_as_review(commit=True, date_in_review=date(2025, 1, 19))
+        review_po.refresh_from_db()
+        bill_model = self.create_bill(setup, date_draft=date(2025, 1, 21))
+
+        self.assertFalse(bill_model.can_bind_po(draft_po))
+        self.assertFalse(bill_model.can_bind_po(review_po))
+
+        with self.assertRaises(BillModelValidationError):
+            bill_model.can_bind_po(draft_po, raise_exception=True)
+        with self.assertRaises(BillModelValidationError):
+            bill_model.can_bind_po(review_po, raise_exception=True)
+
+        late_po = self.make_approved_purchase_order(
+            setup,
+            title="API Late Approved PO",
+            date_approved=date(2025, 1, 22),
+        )
+
+        self.assertFalse(bill_model.can_bind_po(late_po))
+        with self.assertRaises(BillModelValidationError):
+            bill_model.can_bind_po(late_po, raise_exception=True)
+
+    def test_cross_entity_bill_cannot_bind_purchase_order(self):
+        setup = self.create_entity_setup(name="API Purchase Order Binding Bill Entity A")
+        other_setup = self.create_entity_setup(name="API Purchase Order Binding Bill Entity B")
+        po_model = self.make_approved_purchase_order(setup)
+        other_bill = self.create_bill(other_setup)
+
+        self.assertFalse(other_bill.can_bind_po(po_model))
+
+        with self.assertRaises(BillModelValidationError):
+            other_bill.can_bind_po(po_model, raise_exception=True)

--- a/django_ledger/tests/api/test_purchase_order_configure_itemization_api.py
+++ b/django_ledger/tests/api/test_purchase_order_configure_itemization_api.py
@@ -1,0 +1,380 @@
+"""
+High-level API tests for PurchaseOrderModel configuration and itemization behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.http import Http404
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_INVENTORY,
+    COGS,
+    EXPENSE_OPERATIONAL,
+    INCOME_OPERATIONAL,
+)
+from django_ledger.models import ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.entity import EntityModel, EntityStateModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.purchase_order import PurchaseOrderModelValidationError
+from django_ledger.settings import DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING
+
+
+class PurchaseOrderConfigureItemizationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_purchase_order_configure_user",
+            email="api-purchase-order-configure-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_purchase_order_configure_unrelated",
+            email="api-purchase-order-configure-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Purchase Order Configure Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role=EXPENSE_OPERATIONAL,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"PO Unit {str(entity_model.uuid)[:6]}",
+            unit_abbr=f"po-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        product_item = entity_model.create_item_product(
+            name=f"{name} Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "inventory_item": inventory_item,
+            "product_item": product_item,
+            "service_item": service_item,
+            "expense_item": expense_item,
+        }
+
+    def configure_purchase_order(
+        self,
+        setup,
+        *,
+        entity_input=None,
+        user_model=None,
+        draft_date=date(2026, 1, 15),
+        commit=True,
+        title="API Purchase Order Configure PO",
+    ):
+        po_model = PurchaseOrderModel()
+        po_model.configure(
+            entity_slug=setup["entity_model"] if entity_input is None else entity_input,
+            po_title=title,
+            user_model=self.user if user_model is None else user_model,
+            draft_date=draft_date,
+            commit=commit,
+        )
+        if commit:
+            po_model.refresh_from_db()
+        return po_model
+
+    def migrate_inventory_item(
+        self,
+        po_model,
+        setup,
+        *,
+        quantity="2.00",
+        unit_cost="50.00",
+        operation=None,
+    ):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        itemtxs_batch = po_model.migrate_itemtxs(
+            itemtxs={
+                setup["inventory_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=operation or PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model, itemtxs_batch
+
+    def migrate_product_item(self, po_model, setup, *, quantity="1.00", unit_cost="20.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        itemtxs_batch = po_model.migrate_itemtxs(
+            itemtxs={
+                setup["product_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=PurchaseOrderModel.ITEMIZE_APPEND,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model, itemtxs_batch
+
+    def assert_number_ends_with_sequence(self, number, sequence):
+        self.assertTrue(
+            number.endswith(str(sequence).zfill(DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING)),
+            msg=f"{number!r} does not end with sequence {sequence}",
+        )
+
+    def test_configure_accepts_entity_model_and_authorized_slug_but_not_uuid(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        by_model = self.configure_purchase_order(setup, entity_input=entity_model)
+        by_slug = self.configure_purchase_order(setup, entity_input=entity_model.slug)
+
+        self.assertEqual(by_model.entity_id, entity_model.uuid)
+        self.assertEqual(by_slug.entity_id, entity_model.uuid)
+        self.assertTrue(by_model.po_number)
+        self.assertTrue(by_slug.po_number)
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            self.configure_purchase_order(setup, entity_input=entity_model.uuid)
+
+    def test_configure_rejects_slug_without_user_and_unauthorized_slug(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Rejection Entity")
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            PurchaseOrderModel().configure(
+                entity_slug=setup["entity_model"].slug,
+                po_title="API Rejected Purchase Order",
+            )
+
+        with self.assertRaises(Http404):
+            self.configure_purchase_order(
+                setup,
+                entity_input=setup["entity_model"].slug,
+                user_model=self.unrelated_user,
+            )
+
+    def test_configure_commit_false_generates_number_and_state_without_persisting_purchase_order(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Commit False Entity")
+
+        po_model = self.configure_purchase_order(setup, commit=False)
+
+        self.assertTrue(po_model.is_configured())
+        self.assertTrue(po_model.po_number)
+        self.assertEqual(po_model.date_draft, date(2026, 1, 15))
+        self.assertFalse(PurchaseOrderModel.objects.filter(uuid=po_model.uuid).exists())
+
+        state_model = EntityStateModel.objects.get(
+            entity_model=setup["entity_model"],
+            entity_unit__isnull=True,
+            fiscal_year=2026,
+            key=EntityStateModel.KEY_PURCHASE_ORDER,
+        )
+        self.assertEqual(state_model.sequence, 1)
+        self.assert_number_ends_with_sequence(po_model.po_number, 1)
+
+    def test_generate_po_number_commit_false_and_true_behaviors(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Number Entity")
+        manual_po = PurchaseOrderModel.objects.create(
+            entity=setup["entity_model"],
+            po_title="API Manual Number Purchase Order",
+            po_status=PurchaseOrderModel.PO_STATUS_DRAFT,
+            date_draft=date(2026, 1, 15),
+            po_number="manual-po-1",
+        )
+        manual_po.po_number = ""
+
+        self.assertTrue(manual_po.can_generate_po_number())
+        generated_number = manual_po.generate_po_number(commit=False)
+
+        self.assertTrue(generated_number)
+        self.assertEqual(
+            PurchaseOrderModel.objects.get(uuid=manual_po.uuid).po_number,
+            "manual-po-1",
+        )
+
+        persisted_po = PurchaseOrderModel.objects.create(
+            entity=setup["entity_model"],
+            po_title="API Persisted Number Purchase Order",
+            po_status=PurchaseOrderModel.PO_STATUS_DRAFT,
+            date_draft=date(2026, 1, 15),
+            po_number="manual-po-2",
+        )
+        persisted_po.po_number = ""
+
+        persisted_number = persisted_po.generate_po_number(commit=True)
+
+        self.assertTrue(persisted_number)
+        self.assertEqual(
+            PurchaseOrderModel.objects.get(uuid=persisted_po.uuid).po_number,
+            persisted_number,
+        )
+
+    def test_get_item_model_qs_returns_purchase_order_eligible_items(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Item Query Entity")
+        po_model = self.configure_purchase_order(setup)
+
+        item_qs = po_model.get_item_model_qs()
+
+        self.assertTrue(item_qs.filter(uuid=setup["inventory_item"].uuid).exists())
+        self.assertTrue(item_qs.filter(uuid=setup["product_item"].uuid).exists())
+        self.assertFalse(item_qs.filter(uuid=setup["service_item"].uuid).exists())
+        self.assertFalse(item_qs.filter(uuid=setup["expense_item"].uuid).exists())
+
+    def test_migrate_itemtxs_replace_and_append_create_purchase_order_items_and_update_amounts(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Item Migration Entity")
+        po_model = self.configure_purchase_order(setup)
+
+        po_model, itemtxs_batch = self.migrate_inventory_item(po_model, setup)
+
+        self.assertEqual(len(itemtxs_batch), 1)
+        item_tx = ItemTransactionModel.objects.get(po_model=po_model)
+        self.assertEqual(item_tx.item_model_id, setup["inventory_item"].uuid)
+        self.assertEqual(item_tx.po_quantity, Decimal("2.00"))
+        self.assertEqual(item_tx.po_unit_cost, Decimal("50.00"))
+        self.assertEqual(item_tx.po_total_amount, Decimal("100.00"))
+        self.assertEqual(po_model.po_amount, Decimal("100.00"))
+
+        po_model, appended_batch = self.migrate_product_item(po_model, setup)
+
+        self.assertEqual(len(appended_batch), 2)
+        self.assertEqual(ItemTransactionModel.objects.filter(po_model=po_model).count(), 2)
+        self.assertEqual(po_model.po_amount, Decimal("120.00"))
+
+        po_model, replacement_batch = self.migrate_inventory_item(
+            po_model,
+            setup,
+            quantity="1.00",
+            unit_cost="25.00",
+        )
+
+        self.assertEqual(len(replacement_batch), 1)
+        self.assertEqual(ItemTransactionModel.objects.filter(po_model=po_model).count(), 1)
+        self.assertEqual(po_model.po_amount, Decimal("25.00"))
+
+    def test_can_migrate_itemtxs_allows_draft_purchase_orders_only(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Can Migrate Entity")
+        po_model = self.configure_purchase_order(setup)
+
+        self.assertTrue(po_model.can_migrate_itemtxs())
+
+        po_model, _itemtxs_batch = self.migrate_inventory_item(po_model, setup)
+        po_model.mark_as_review(date_in_review=date(2026, 1, 16), commit=True)
+        po_model.refresh_from_db()
+
+        self.assertFalse(po_model.can_migrate_itemtxs())
+        self.assertIsNone(
+            po_model.migrate_itemtxs(
+                itemtxs={
+                    setup["inventory_item"].item_number: {
+                        "quantity": Decimal("1.00"),
+                        "unit_cost": Decimal("10.00"),
+                        "total_amount": Decimal("10.00"),
+                    }
+                },
+                operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+                commit=True,
+            )
+        )
+
+    def test_validate_item_transaction_qs_rejects_transactions_from_another_purchase_order(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Validate ItemTx Entity")
+        po_model = self.configure_purchase_order(setup)
+        other_po_model = self.configure_purchase_order(setup, title="API Other Purchase Order")
+        other_po_model, _itemtxs_batch = self.migrate_inventory_item(other_po_model, setup)
+        other_itemtxs = ItemTransactionModel.objects.filter(po_model=other_po_model)
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            po_model.validate_item_transaction_qs(other_itemtxs)
+
+    def test_get_itemtxs_data_reports_purchase_order_amounts(self):
+        setup = self.create_entity_setup(name="API Purchase Order Configure Item Data Entity")
+        po_model = self.configure_purchase_order(setup)
+        po_model, _itemtxs_batch = self.migrate_inventory_item(po_model, setup)
+
+        itemtxs_qs, itemtxs_data = po_model.get_itemtxs_data()
+
+        self.assertEqual(itemtxs_qs.count(), 1)
+        self.assertEqual(itemtxs_data["total_items"], 1)
+        self.assertEqual(itemtxs_data["po_total_amount__sum"], Decimal("100.00"))
+
+        aggregate_qs, aggregate_data = po_model.get_itemtxs_data(aggregate_on_db=True)
+
+        self.assertEqual(aggregate_qs.count(), 1)
+        self.assertEqual(Decimal(str(aggregate_data["po_total_amount__sum"])), Decimal("100.0"))
+        self.assertEqual(aggregate_data["total_items"], 1)
+
+        _lazy_qs, lazy_data = po_model.get_itemtxs_data(lazy_agg=True)
+
+        self.assertIsNone(lazy_data)

--- a/django_ledger/tests/api/test_purchase_order_edge_api.py
+++ b/django_ledger/tests/api/test_purchase_order_edge_api.py
@@ -1,0 +1,214 @@
+"""
+Focused edge-case API tests for PurchaseOrderModel.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel, ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+
+
+class PurchaseOrderEdgeAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_purchase_order_edge_user",
+            email="api-purchase-order-edge-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Purchase Order Edge Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"PO Edge Unit {str(entity_model.uuid)[:6]}",
+            unit_abbr=f"pe-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "vendor_model": vendor_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "payable_account": payable_account,
+            "inventory_item": inventory_item,
+        }
+
+    def create_purchase_order(self, setup, *, title="API Purchase Order Edge PO"):
+        po_model = setup["entity_model"].create_purchase_order(
+            po_title=title,
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def migrate_inventory_item(self, po_model, setup):
+        po_model.migrate_itemtxs(
+            itemtxs={
+                setup["inventory_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": Decimal("100.00"),
+                    "total_amount": Decimal("100.00"),
+                }
+            },
+            operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def make_approved_purchase_order(self, setup, *, title="API Purchase Order Edge Approved PO"):
+        po_model = self.migrate_inventory_item(self.create_purchase_order(setup, title=title), setup)
+        po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        po_model.refresh_from_db()
+        po_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        po_model.refresh_from_db()
+        return po_model
+
+    def create_paid_bill(self, setup):
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_ON_RECEIPT,
+            date_draft=date(2025, 1, 18),
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            payable_account=setup["payable_account"],
+            commit=True,
+        )
+        bill_model.bill_status = BillModel.BILL_STATUS_PAID
+        bill_model.amount_due = Decimal("100.00")
+        bill_model.amount_paid = Decimal("100.00")
+        bill_model.save(update_fields=["bill_status", "amount_due", "amount_paid", "updated"])
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def attach_bill_to_po_item(self, po_model, bill_model):
+        item_tx = po_model.itemtransactionmodel_set.get()
+        item_tx.bill_model = bill_model
+        item_tx.po_item_status = ItemTransactionModel.STATUS_RECEIVED
+        item_tx.save(update_fields=["bill_model", "po_item_status", "updated"])
+        return item_tx
+
+    def assert_bill_uuids(self, queryset, expected_bills):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {bill_model.uuid for bill_model in expected_bills},
+        )
+
+    def test_mark_as_fulfilled_accepts_prefetched_item_transaction_list(self):
+        setup = self.create_entity_setup(name="API Purchase Order Edge Fulfill List Entity")
+        po_model = self.make_approved_purchase_order(setup)
+        bill_model = self.create_paid_bill(setup)
+        self.attach_bill_to_po_item(po_model, bill_model)
+        po_items = list(po_model.itemtransactionmodel_set.all())
+
+        po_model.mark_as_fulfilled(po_items=po_items, commit=True, date_fulfilled=date(2025, 1, 19))
+        po_model.refresh_from_db()
+
+        self.assertTrue(po_model.is_fulfilled())
+        self.assertEqual(po_model.date_fulfilled, date(2025, 1, 19))
+        self.assertEqual(po_model.po_amount_received, po_model.po_amount)
+        self.assertEqual(
+            set(po_model.itemtransactionmodel_set.values_list("po_item_status", flat=True)),
+            {ItemTransactionModel.STATUS_RECEIVED},
+        )
+
+    def test_get_po_bill_queryset_only_returns_bills_linked_to_this_purchase_order(self):
+        setup = self.create_entity_setup(name="API Purchase Order Edge Bill Query Entity")
+        po_model = self.make_approved_purchase_order(setup, title="API Purchase Order Edge Linked PO")
+        other_po_model = self.make_approved_purchase_order(setup, title="API Purchase Order Edge Other PO")
+        bill_model = self.create_paid_bill(setup)
+        self.attach_bill_to_po_item(po_model, bill_model)
+
+        self.assert_bill_uuids(po_model.get_po_bill_queryset(), [bill_model])
+        self.assertFalse(other_po_model.get_po_bill_queryset().exists())

--- a/django_ledger/tests/api/test_purchase_order_lifecycle_api.py
+++ b/django_ledger/tests/api/test_purchase_order_lifecycle_api.py
@@ -1,0 +1,390 @@
+"""
+High-level API tests for PurchaseOrderModel lifecycle transitions.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel, ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.purchase_order import PurchaseOrderModelValidationError
+
+
+class PurchaseOrderLifecycleAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_purchase_order_lifecycle_user",
+            email="api-purchase-order-lifecycle-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Purchase Order Lifecycle Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"PO Life Unit {str(entity_model.uuid)[:6]}",
+            unit_abbr=f"pl-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "vendor_model": vendor_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "payable_account": payable_account,
+            "inventory_item": inventory_item,
+        }
+
+    def create_purchase_order(self, setup, *, date_draft=date(2025, 1, 15), title="API PO Lifecycle Order"):
+        po_model = setup["entity_model"].create_purchase_order(
+            po_title=title,
+            date_draft=date_draft,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def migrate_inventory_item(self, po_model, setup, *, quantity="2.00", unit_cost="50.00"):
+        quantity = Decimal(quantity)
+        unit_cost = Decimal(unit_cost)
+        po_model.migrate_itemtxs(
+            itemtxs={
+                setup["inventory_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def make_review_purchase_order(self, setup):
+        po_model = self.migrate_inventory_item(self.create_purchase_order(setup), setup)
+        po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        po_model.refresh_from_db()
+        return po_model
+
+    def make_approved_purchase_order(self, setup):
+        po_model = self.make_review_purchase_order(setup)
+        po_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        po_model.refresh_from_db()
+        return po_model
+
+    def create_paid_bill_for_purchase_order(self, setup):
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_ON_RECEIPT,
+            date_draft=date(2025, 1, 18),
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            payable_account=setup["payable_account"],
+            commit=True,
+        )
+        bill_model.bill_status = BillModel.BILL_STATUS_PAID
+        bill_model.amount_due = Decimal("100.00")
+        bill_model.amount_paid = Decimal("100.00")
+        bill_model.save(update_fields=["bill_status", "amount_due", "amount_paid", "updated"])
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_fulfilled_purchase_order(self, setup):
+        po_model = self.make_approved_purchase_order(setup)
+        bill_model = self.create_paid_bill_for_purchase_order(setup)
+        item_tx = po_model.itemtransactionmodel_set.get()
+        item_tx.bill_model = bill_model
+        item_tx.po_item_status = ItemTransactionModel.STATUS_RECEIVED
+        item_tx.save(update_fields=["bill_model", "po_item_status", "updated"])
+
+        po_model.mark_as_fulfilled(commit=True)
+        po_model.refresh_from_db()
+        return po_model
+
+    def test_valid_review_and_approval_transitions_set_dates_and_item_statuses(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Valid Entity")
+        po_model = self.migrate_inventory_item(self.create_purchase_order(setup), setup)
+
+        po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        po_model.refresh_from_db()
+        self.assertTrue(po_model.is_review())
+        self.assertEqual(po_model.date_in_review, date(2025, 1, 16))
+
+        po_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        po_model.refresh_from_db()
+        self.assertTrue(po_model.is_approved())
+        self.assertEqual(po_model.date_approved, date(2025, 1, 17))
+        self.assertEqual(
+            set(po_model.itemtransactionmodel_set.values_list("po_item_status", flat=True)),
+            {ItemTransactionModel.STATUS_NOT_ORDERED},
+        )
+
+    def test_draft_review_cancel_and_approved_void_set_terminal_status_dates(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Terminal Entity")
+
+        draft_po = self.create_purchase_order(setup)
+        draft_po.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        draft_po.refresh_from_db()
+        self.assertTrue(draft_po.is_canceled())
+        self.assertEqual(draft_po.date_canceled, date(2025, 1, 20))
+
+        review_po = self.make_review_purchase_order(setup)
+        review_po.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 21))
+        review_po.refresh_from_db()
+        self.assertTrue(review_po.is_canceled())
+        self.assertEqual(review_po.date_canceled, date(2025, 1, 21))
+
+        approved_po = self.make_approved_purchase_order(setup)
+        approved_po.mark_as_void(commit=True, void_date=date(2025, 1, 22))
+        approved_po.refresh_from_db()
+        self.assertTrue(approved_po.is_void())
+        self.assertEqual(approved_po.date_void, date(2025, 1, 22))
+
+    def test_review_can_return_to_draft_and_persist_explicit_draft_date(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Back To Draft Entity")
+        po_model = self.make_review_purchase_order(setup)
+
+        po_model.mark_as_draft(commit=True, date_draft=date(2025, 1, 23))
+        po_model.refresh_from_db()
+
+        self.assertTrue(po_model.is_draft())
+        self.assertEqual(po_model.date_draft, date(2025, 1, 23))
+
+    def test_fulfill_sets_status_date_and_received_amount_when_preconditions_are_met(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Fulfilled Entity")
+
+        po_model = self.make_fulfilled_purchase_order(setup)
+
+        self.assertTrue(po_model.is_fulfilled())
+        self.assertIsNotNone(po_model.date_fulfilled)
+        self.assertEqual(po_model.po_amount_received, po_model.po_amount)
+        self.assertEqual(
+            set(po_model.itemtransactionmodel_set.values_list("po_item_status", flat=True)),
+            {ItemTransactionModel.STATUS_RECEIVED},
+        )
+
+    def test_invalid_transitions_raise_validation_errors(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Invalid Entity")
+        draft_po = self.create_purchase_order(setup)
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            draft_po.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            draft_po.mark_as_fulfilled(commit=True)
+
+        canceled_po = self.create_purchase_order(setup, title="API Canceled PO")
+        canceled_po.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            canceled_po.mark_as_review(commit=True, date_in_review=date(2025, 1, 21))
+
+        void_po = self.make_approved_purchase_order(setup)
+        void_po.mark_as_void(commit=True, void_date=date(2025, 1, 22))
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            void_po.mark_as_review(commit=True, date_in_review=date(2025, 1, 23))
+
+        fulfilled_po = self.make_fulfilled_purchase_order(setup)
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            fulfilled_po.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 24))
+
+    def test_review_requires_items_and_amount(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Review Requirement Entity")
+        po_model = self.create_purchase_order(setup)
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        zero_amount_po = self.migrate_inventory_item(
+            self.create_purchase_order(setup, title="API Zero Amount PO"),
+            setup,
+            unit_cost="0.00",
+        )
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            zero_amount_po.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+    def test_fulfillment_rejects_unbilled_unpaid_or_unreceived_items(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Fulfillment Requirement Entity")
+
+        unbilled_po = self.make_approved_purchase_order(setup)
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            unbilled_po.mark_as_fulfilled(commit=True)
+
+        unpaid_po = self.make_approved_purchase_order(setup)
+        unpaid_bill = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_ON_RECEIPT,
+            date_draft=date(2025, 1, 18),
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            payable_account=setup["payable_account"],
+            commit=True,
+        )
+        unpaid_item_tx = unpaid_po.itemtransactionmodel_set.get()
+        unpaid_item_tx.bill_model = unpaid_bill
+        unpaid_item_tx.po_item_status = ItemTransactionModel.STATUS_RECEIVED
+        unpaid_item_tx.save(update_fields=["bill_model", "po_item_status", "updated"])
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            unpaid_po.mark_as_fulfilled(commit=True)
+
+        unreceived_po = self.make_approved_purchase_order(setup)
+        paid_bill = self.create_paid_bill_for_purchase_order(setup)
+        unreceived_item_tx = unreceived_po.itemtransactionmodel_set.get()
+        unreceived_item_tx.bill_model = paid_bill
+        unreceived_item_tx.po_item_status = ItemTransactionModel.STATUS_ORDERED
+        unreceived_item_tx.save(update_fields=["bill_model", "po_item_status", "updated"])
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            unreceived_po.mark_as_fulfilled(commit=True)
+
+    def test_can_predicates_reflect_purchase_order_statuses(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Predicate Entity")
+
+        draft_po = self.create_purchase_order(setup)
+        self.assertFalse(draft_po.can_draft())
+        self.assertTrue(draft_po.can_review())
+        self.assertFalse(draft_po.can_approve())
+        self.assertFalse(draft_po.can_fulfill())
+        self.assertTrue(draft_po.can_cancel())
+        self.assertFalse(draft_po.can_void())
+        self.assertTrue(draft_po.can_delete())
+        self.assertTrue(draft_po.can_edit_items())
+
+        review_po = self.make_review_purchase_order(setup)
+        self.assertTrue(review_po.can_draft())
+        self.assertFalse(review_po.can_review())
+        self.assertTrue(review_po.can_approve())
+        self.assertFalse(review_po.can_fulfill())
+        self.assertTrue(review_po.can_cancel())
+        self.assertFalse(review_po.can_void())
+        self.assertTrue(review_po.can_delete())
+        self.assertFalse(review_po.can_edit_items())
+
+        approved_po = self.make_approved_purchase_order(setup)
+        self.assertFalse(approved_po.can_draft())
+        self.assertFalse(approved_po.can_approve())
+        self.assertTrue(approved_po.can_fulfill())
+        self.assertFalse(approved_po.can_cancel())
+        self.assertTrue(approved_po.can_void())
+        self.assertFalse(approved_po.can_delete())
+        self.assertFalse(approved_po.can_edit_items())
+
+        fulfilled_po = self.make_fulfilled_purchase_order(setup)
+        self.assertFalse(fulfilled_po.can_fulfill())
+        self.assertFalse(fulfilled_po.can_cancel())
+        self.assertFalse(fulfilled_po.can_void())
+        self.assertFalse(fulfilled_po.can_delete())
+        self.assertFalse(fulfilled_po.can_edit_items())
+
+    def test_commit_false_transitions_mutate_in_memory_without_persisting(self):
+        setup = self.create_entity_setup(name="API PO Lifecycle Commit False Entity")
+        po_model = self.migrate_inventory_item(self.create_purchase_order(setup), setup)
+
+        po_model.mark_as_review(commit=False, date_in_review=date(2025, 1, 16))
+        self.assertTrue(po_model.is_review())
+        self.assertEqual(po_model.date_in_review, date(2025, 1, 16))
+        db_po = PurchaseOrderModel.objects.get(uuid=po_model.uuid)
+        self.assertTrue(db_po.is_draft())
+        self.assertIsNone(db_po.date_in_review)
+
+        po_model.refresh_from_db()
+        po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        po_model.refresh_from_db()
+        po_model.mark_as_approved(commit=False, date_approved=date(2025, 1, 17))
+        self.assertTrue(po_model.is_approved())
+        self.assertEqual(po_model.date_approved, date(2025, 1, 17))
+        db_po = PurchaseOrderModel.objects.get(uuid=po_model.uuid)
+        self.assertTrue(db_po.is_review())
+        self.assertIsNone(db_po.date_approved)
+        self.assertEqual(
+            set(db_po.itemtransactionmodel_set.values_list("po_item_status", flat=True)),
+            {ItemTransactionModel.STATUS_NOT_ORDERED},
+        )

--- a/django_ledger/tests/api/test_purchase_order_queryset_api.py
+++ b/django_ledger/tests/api/test_purchase_order_queryset_api.py
@@ -1,0 +1,143 @@
+"""
+High-level API tests for PurchaseOrderModel queryset and manager behavior.
+"""
+
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import PurchaseOrderModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.purchase_order import PurchaseOrderModelValidationError
+
+
+class PurchaseOrderQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_purchase_order_queryset_admin",
+            email="api-purchase-order-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_purchase_order_queryset_manager",
+            email="api-purchase-order-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_purchase_order_queryset_other_admin",
+            email="api-purchase-order-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_purchase_order_queryset_unrelated",
+            email="api-purchase-order-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_purchase_order_queryset_superuser",
+            email="api-purchase-order-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API Purchase Order Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+        return entity_model
+
+    def create_purchase_order(
+        self,
+        entity_model,
+        *,
+        title="API Purchase Order Queryset PO",
+        status=PurchaseOrderModel.PO_STATUS_DRAFT,
+    ):
+        po_model = PurchaseOrderModel()
+        po_model.configure(
+            entity_slug=entity_model,
+            po_title=title,
+            user_model=self.admin_user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+        if status != PurchaseOrderModel.PO_STATUS_DRAFT:
+            po_model.po_status = status
+            po_model.save(update_fields=["po_status", "updated"])
+            po_model.refresh_from_db()
+        return po_model
+
+    def assert_po_uuids(self, queryset, expected_purchase_orders):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {po_model.uuid for po_model in expected_purchase_orders},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity(name="API Purchase Order Queryset Entity A")
+        other_entity_model = self.create_entity(
+            name="API Purchase Order Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        po_model = self.create_purchase_order(entity_model)
+        self.create_purchase_order(other_entity_model, title="API Other Purchase Order Queryset PO")
+
+        self.assert_po_uuids(PurchaseOrderModel.objects.for_entity(entity_model), [po_model])
+        self.assert_po_uuids(PurchaseOrderModel.objects.for_entity(entity_model.slug), [po_model])
+        self.assert_po_uuids(PurchaseOrderModel.objects.for_entity(entity_model.uuid), [po_model])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_purchase_order(self.create_entity())
+
+        with self.assertRaises(PurchaseOrderModelValidationError):
+            PurchaseOrderModel.objects.for_entity(object())
+
+        self.assertFalse(PurchaseOrderModel.objects.for_entity("missing-purchase-order-entity-slug").exists())
+
+    def test_for_user_scopes_to_authorized_users_and_superuser(self):
+        entity_model = self.create_entity(
+            name="API Purchase Order Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_entity_model = self.create_entity(
+            name="API Purchase Order Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        po_model = self.create_purchase_order(entity_model)
+        other_po_model = self.create_purchase_order(other_entity_model, title="API Other Access Purchase Order")
+
+        self.assert_po_uuids(PurchaseOrderModel.objects.all().for_user(self.admin_user), [po_model])
+        self.assert_po_uuids(PurchaseOrderModel.objects.all().for_user(self.manager_user), [po_model])
+        self.assertFalse(PurchaseOrderModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assert_po_uuids(
+            PurchaseOrderModel.objects.all().for_user(self.superuser),
+            [po_model, other_po_model],
+        )
+
+    def test_status_filters_return_purchase_orders_by_public_status(self):
+        entity_model = self.create_entity(name="API Purchase Order Queryset Status Entity")
+        draft_po = self.create_purchase_order(entity_model, title="API Draft Purchase Order")
+        approved_po = self.create_purchase_order(
+            entity_model,
+            title="API Approved Purchase Order",
+            status=PurchaseOrderModel.PO_STATUS_APPROVED,
+        )
+        fulfilled_po = self.create_purchase_order(
+            entity_model,
+            title="API Fulfilled Purchase Order",
+            status=PurchaseOrderModel.PO_STATUS_FULFILLED,
+        )
+
+        purchase_order_qs = PurchaseOrderModel.objects.for_entity(entity_model)
+
+        self.assert_po_uuids(purchase_order_qs.draft(), [draft_po])
+        self.assert_po_uuids(purchase_order_qs.approved(), [approved_po])
+        self.assert_po_uuids(purchase_order_qs.fulfilled(), [fulfilled_po])
+        self.assert_po_uuids(purchase_order_qs.active(), [approved_po, fulfilled_po])

--- a/django_ledger/tests/api/test_purchase_order_url_signal_api.py
+++ b/django_ledger/tests/api/test_purchase_order_url_signal_api.py
@@ -1,0 +1,358 @@
+"""
+Smoke tests for PurchaseOrderModel URL, display, and lifecycle signal behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import (
+    ASSET_CA_CASH,
+    ASSET_CA_INVENTORY,
+    ASSET_CA_PREPAID,
+    COGS,
+    INCOME_OPERATIONAL,
+    LIABILITY_CL_ACC_PAYABLE,
+)
+from django_ledger.models import BillModel, ItemTransactionModel, PurchaseOrderModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.signals import (
+    po_status_approved,
+    po_status_canceled,
+    po_status_draft,
+    po_status_fulfilled,
+    po_status_in_review,
+    po_status_void,
+)
+
+
+class PurchaseOrderURLSignalAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_purchase_order_url_signal_user",
+            email="api-purchase-order-url-signal-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Purchase Order URL Signal Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role=ASSET_CA_PREPAID,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role=LIABILITY_CL_ACC_PAYABLE,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        inventory_account = coa_model.create_account(
+            code="1410",
+            name=f"{name} Inventory Account",
+            role=ASSET_CA_INVENTORY,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role=COGS,
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role=INCOME_OPERATIONAL,
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        uom_model = entity_model.create_uom(
+            name=f"PO URL Unit {str(entity_model.uuid)[:6]}",
+            unit_abbr=f"pu-{str(entity_model.uuid)[:6]}",
+            active=True,
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor.",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+        return {
+            "entity_model": entity_model,
+            "vendor_model": vendor_model,
+            "cash_account": cash_account,
+            "prepaid_account": prepaid_account,
+            "payable_account": payable_account,
+            "inventory_item": inventory_item,
+        }
+
+    def create_purchase_order(self, setup, *, title="API Purchase Order URL Signal PO"):
+        po_model = setup["entity_model"].create_purchase_order(
+            po_title=title,
+            date_draft=date(2025, 1, 15),
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def migrate_inventory_item(self, po_model, setup):
+        po_model.migrate_itemtxs(
+            itemtxs={
+                setup["inventory_item"].item_number: {
+                    "quantity": Decimal("1.00"),
+                    "unit_cost": Decimal("100.00"),
+                    "total_amount": Decimal("100.00"),
+                }
+            },
+            operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+        po_model.refresh_from_db()
+        return po_model
+
+    def make_review_purchase_order(self, setup):
+        po_model = self.migrate_inventory_item(self.create_purchase_order(setup), setup)
+        po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+        po_model.refresh_from_db()
+        return po_model
+
+    def make_approved_purchase_order(self, setup):
+        po_model = self.make_review_purchase_order(setup)
+        po_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+        po_model.refresh_from_db()
+        return po_model
+
+    def create_paid_bill_for_purchase_order(self, setup):
+        bill_model = setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_ON_RECEIPT,
+            date_draft=date(2025, 1, 18),
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            payable_account=setup["payable_account"],
+            commit=True,
+        )
+        bill_model.bill_status = BillModel.BILL_STATUS_PAID
+        bill_model.amount_due = Decimal("100.00")
+        bill_model.amount_paid = Decimal("100.00")
+        bill_model.save(update_fields=["bill_status", "amount_due", "amount_paid", "updated"])
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def make_fulfilled_purchase_order(self, setup):
+        po_model = self.make_approved_purchase_order(setup)
+        bill_model = self.create_paid_bill_for_purchase_order(setup)
+        item_tx = po_model.itemtransactionmodel_set.get()
+        item_tx.bill_model = bill_model
+        item_tx.po_item_status = ItemTransactionModel.STATUS_RECEIVED
+        item_tx.save(update_fields=["bill_model", "po_item_status", "updated"])
+
+        po_model.mark_as_fulfilled(commit=True, date_fulfilled=date(2025, 1, 19))
+        po_model.refresh_from_db()
+        return po_model
+
+    def collect_signal_calls(self, signal):
+        calls = []
+        dispatch_uid = f"{self.id()}-{id(signal)}"
+
+        def receiver(sender, **kwargs):
+            calls.append(kwargs)
+
+        signal.connect(
+            receiver,
+            sender=PurchaseOrderModel,
+            weak=False,
+            dispatch_uid=dispatch_uid,
+        )
+        self.addCleanup(
+            signal.disconnect,
+            sender=PurchaseOrderModel,
+            dispatch_uid=dispatch_uid,
+        )
+        return calls
+
+    def assert_signal_received_once(self, calls, po_model, *, commit):
+        self.assertEqual(len(calls), 1)
+        self.assertIs(calls[0]["instance"], po_model)
+        self.assertEqual(calls[0]["commited"], commit)
+
+    def assert_entity_po_url(self, url, setup, po_model):
+        self.assertIsInstance(url, str)
+        self.assertIn(setup["entity_model"].slug, url)
+        self.assertIn(str(po_model.uuid), url)
+
+    def test_action_url_helpers_return_entity_scoped_strings(self):
+        setup = self.create_entity_setup(name="API Purchase Order URL Helper Entity")
+        po_model = self.create_purchase_order(setup)
+
+        url_helpers = [
+            po_model.get_mark_as_draft_url,
+            po_model.get_mark_as_review_url,
+            po_model.get_mark_as_approved_url,
+            po_model.get_mark_as_fulfilled_url,
+            po_model.get_mark_as_canceled_url,
+            po_model.get_mark_as_void_url,
+        ]
+
+        for helper in url_helpers:
+            self.assert_entity_po_url(helper(), setup, po_model)
+
+    def test_display_message_and_html_helpers_include_stable_context(self):
+        setup = self.create_entity_setup(name="API Purchase Order Display Helper Entity")
+        po_model = self.create_purchase_order(setup)
+
+        self.assertIn(po_model.po_number, str(po_model))
+        self.assertIn(po_model.get_po_status_display(), str(po_model))
+
+        html_helpers = [
+            po_model.get_mark_as_draft_html_id,
+            po_model.get_mark_as_review_html_id,
+            po_model.get_mark_as_approved_html_id,
+            po_model.get_mark_as_fulfilled_html_id,
+            po_model.get_mark_as_canceled_html_id,
+            po_model.get_mark_as_void_html_id,
+        ]
+        for helper in html_helpers:
+            self.assertIn(str(po_model.uuid), helper())
+
+        message_helpers = [
+            po_model.get_mark_as_draft_message,
+            po_model.get_mark_as_review_message,
+            po_model.get_mark_as_approved_message,
+            po_model.get_mark_as_fulfilled_message,
+            po_model.get_mark_as_canceled_message,
+            po_model.get_mark_as_void_message,
+        ]
+        for helper in message_helpers:
+            self.assertIn(po_model.po_number, helper())
+
+    def test_status_action_date_reflects_current_status_date(self):
+        setup = self.create_entity_setup(name="API Purchase Order Status Date Entity")
+
+        draft_po = self.create_purchase_order(setup)
+        self.assertEqual(draft_po.get_status_action_date(), date(2025, 1, 15))
+
+        review_po = self.make_review_purchase_order(setup)
+        self.assertEqual(review_po.get_status_action_date(), date(2025, 1, 16))
+
+        approved_po = self.make_approved_purchase_order(setup)
+        self.assertEqual(approved_po.get_status_action_date(), date(2025, 1, 17))
+
+        canceled_po = self.create_purchase_order(setup, title="API Canceled PO")
+        canceled_po.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 18))
+        canceled_po.refresh_from_db()
+        self.assertEqual(canceled_po.get_status_action_date(), date(2025, 1, 18))
+
+        fulfilled_setup = self.create_entity_setup(name="API Purchase Order Fulfilled Status Date Entity")
+        fulfilled_po = self.make_fulfilled_purchase_order(fulfilled_setup)
+        self.assertEqual(fulfilled_po.get_status_action_date(), date(2025, 1, 19))
+
+        void_setup = self.create_entity_setup(name="API Purchase Order Void Status Date Entity")
+        void_po = self.make_approved_purchase_order(void_setup)
+        void_po.mark_as_void(commit=True, void_date=date(2025, 1, 20))
+        void_po.refresh_from_db()
+        self.assertEqual(void_po.get_status_action_date(), date(2025, 1, 20))
+
+    def test_mark_as_review_emits_purchase_order_status_in_review_signal(self):
+        setup = self.create_entity_setup(name="API Purchase Order Review Signal Entity")
+        po_model = self.migrate_inventory_item(self.create_purchase_order(setup), setup)
+        calls = self.collect_signal_calls(po_status_in_review)
+
+        po_model.mark_as_review(commit=True, date_in_review=date(2025, 1, 16))
+
+        self.assert_signal_received_once(calls, po_model, commit=True)
+
+    def test_mark_as_draft_emits_purchase_order_status_draft_signal(self):
+        setup = self.create_entity_setup(name="API Purchase Order Draft Signal Entity")
+        po_model = self.make_review_purchase_order(setup)
+        calls = self.collect_signal_calls(po_status_draft)
+
+        po_model.mark_as_draft(commit=True, date_draft=date(2025, 1, 17))
+
+        self.assert_signal_received_once(calls, po_model, commit=True)
+
+    def test_mark_as_approved_emits_purchase_order_status_approved_signal(self):
+        setup = self.create_entity_setup(name="API Purchase Order Approved Signal Entity")
+        po_model = self.make_review_purchase_order(setup)
+        calls = self.collect_signal_calls(po_status_approved)
+
+        po_model.mark_as_approved(commit=True, date_approved=date(2025, 1, 17))
+
+        self.assert_signal_received_once(calls, po_model, commit=True)
+
+    def test_mark_as_fulfilled_emits_purchase_order_status_fulfilled_signal(self):
+        setup = self.create_entity_setup(name="API Purchase Order Fulfilled Signal Entity")
+        po_model = self.make_approved_purchase_order(setup)
+        bill_model = self.create_paid_bill_for_purchase_order(setup)
+        item_tx = po_model.itemtransactionmodel_set.get()
+        item_tx.bill_model = bill_model
+        item_tx.po_item_status = ItemTransactionModel.STATUS_RECEIVED
+        item_tx.save(update_fields=["bill_model", "po_item_status", "updated"])
+        calls = self.collect_signal_calls(po_status_fulfilled)
+
+        po_model.mark_as_fulfilled(commit=True, date_fulfilled=date(2025, 1, 19))
+
+        self.assert_signal_received_once(calls, po_model, commit=True)
+
+    def test_mark_as_canceled_emits_purchase_order_status_canceled_signal(self):
+        setup = self.create_entity_setup(name="API Purchase Order Canceled Signal Entity")
+        po_model = self.create_purchase_order(setup)
+        calls = self.collect_signal_calls(po_status_canceled)
+
+        po_model.mark_as_canceled(commit=True, date_canceled=date(2025, 1, 20))
+
+        self.assert_signal_received_once(calls, po_model, commit=True)
+
+    def test_mark_as_void_emits_purchase_order_status_void_signal(self):
+        setup = self.create_entity_setup(name="API Purchase Order Void Signal Entity")
+        po_model = self.make_approved_purchase_order(setup)
+        calls = self.collect_signal_calls(po_status_void)
+
+        po_model.mark_as_void(commit=True, void_date=date(2025, 1, 21))
+
+        self.assert_signal_received_once(calls, po_model, commit=True)

--- a/django_ledger/tests/api/test_queryset_contracts_api.py
+++ b/django_ledger/tests/api/test_queryset_contracts_api.py
@@ -1,0 +1,596 @@
+"""
+High-level API behavior tests for QuerySet and Manager contracts.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import (
+    AccountModel,
+    BillModel,
+    EstimateModel,
+    InvoiceModel,
+    ItemTransactionModel,
+    PurchaseOrderModel,
+)
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModel
+from django_ledger.models.vendor import VendorModel
+
+
+class QuerySetContractsHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for public QuerySet and Manager contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document the public filtering API that should remain stable
+    across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_queryset_contract_user",
+            email="api-queryset-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API QuerySet Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable Account",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid Account",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        inventory_account = coa_model.create_account(
+            code="1510",
+            name=f"{name} Inventory Account",
+            role="asset_ca_inv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        accounts_payable = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        unearned_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Unearned Revenue Account",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        cogs_account = coa_model.create_account(
+            code="5010",
+            name=f"{name} COGS Account",
+            role="cogs_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        earnings_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Earnings Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        inactive_cash_account = coa_model.create_account(
+            code="1020",
+            name=f"{name} Inactive Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=False,
+        )
+
+        uom_model = entity_model.create_uom(
+            name=f"{name} Unit",
+            unit_abbr="qs",
+            active=True,
+            commit=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        inactive_customer = CustomerModel(
+            customer_name=f"{name} Inactive Customer",
+            entity_model=entity_model,
+            description=f"{name} Inactive Customer description",
+            active=False,
+            hidden=False,
+        )
+        inactive_customer.full_clean()
+        inactive_customer.save()
+
+        hidden_customer = CustomerModel(
+            customer_name=f"{name} Hidden Customer",
+            entity_model=entity_model,
+            description=f"{name} Hidden Customer description",
+            active=True,
+            hidden=True,
+        )
+        hidden_customer.full_clean()
+        hidden_customer.save()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        inactive_vendor = VendorModel(
+            vendor_name=f"{name} Inactive Vendor",
+            entity_model=entity_model,
+            description=f"{name} Inactive Vendor description",
+            active=False,
+            hidden=False,
+        )
+        inactive_vendor.full_clean()
+        inactive_vendor.save()
+
+        hidden_vendor = VendorModel(
+            vendor_name=f"{name} Hidden Vendor",
+            entity_model=entity_model,
+            description=f"{name} Hidden Vendor description",
+            active=True,
+            hidden=True,
+        )
+        hidden_vendor.full_clean()
+        hidden_vendor.save()
+
+        service_item = entity_model.create_item_service(
+            name=f"{name} Service Item",
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        product_item = entity_model.create_item_product(
+            name=f"{name} Product Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        inventory_item = entity_model.create_item_inventory(
+            name=f"{name} Inventory Item",
+            item_type=ItemModel.ITEM_TYPE_MATERIAL,
+            uom_model=uom_model,
+            inventory_account=inventory_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        expense_item = entity_model.create_item_expense(
+            name=f"{name} Expense Item",
+            expense_type=ItemModel.ITEM_TYPE_OTHER,
+            uom_model=uom_model,
+            expense_account=expense_account,
+            coa_model=coa_model,
+            commit=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "receivable_account": receivable_account,
+            "prepaid_account": prepaid_account,
+            "inventory_account": inventory_account,
+            "accounts_payable": accounts_payable,
+            "unearned_account": unearned_account,
+            "cogs_account": cogs_account,
+            "earnings_account": earnings_account,
+            "expense_account": expense_account,
+            "inactive_cash_account": inactive_cash_account,
+            "uom_model": uom_model,
+            "customer_model": customer_model,
+            "inactive_customer": inactive_customer,
+            "hidden_customer": hidden_customer,
+            "vendor_model": vendor_model,
+            "inactive_vendor": inactive_vendor,
+            "hidden_vendor": hidden_vendor,
+            "service_item": service_item,
+            "product_item": product_item,
+            "inventory_item": inventory_item,
+            "expense_item": expense_item,
+        }
+
+    def create_bill(self, setup):
+        bill_model = BillModel(
+            vendor=setup["vendor_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["prepaid_account"],
+            unearned_account=setup["accounts_payable"],
+        )
+
+        _ledger_model, bill_model = bill_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return bill_model
+
+    def create_invoice(self, setup):
+        invoice_model = InvoiceModel(
+            customer=setup["customer_model"],
+            cash_account=setup["cash_account"],
+            prepaid_account=setup["receivable_account"],
+            unearned_account=setup["unearned_account"],
+        )
+
+        _ledger_model, invoice_model = invoice_model.configure(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return invoice_model
+
+    def create_estimate(self, setup):
+        estimate_model = EstimateModel(
+            terms=EstimateModel.CONTRACT_TERMS_FIXED,
+        )
+
+        estimate_model.configure(
+            entity_slug=setup["entity_model"],
+            customer_model=setup["customer_model"],
+            user_model=self.user,
+            date_draft=date(2026, 1, 15),
+            estimate_title="API QuerySet Estimate",
+            commit=True,
+        )
+
+        return estimate_model
+
+    def create_purchase_order(self, setup):
+        po_model = PurchaseOrderModel()
+
+        po_model.configure(
+            entity_slug=setup["entity_model"],
+            po_title="API QuerySet Purchase Order",
+            user_model=self.user,
+            draft_date=date(2026, 1, 15),
+            commit=True,
+        )
+
+        return po_model
+
+    def migrate_bill_item(self, bill_model, setup):
+        quantity = Decimal("2.00")
+        unit_cost = Decimal("50.00")
+
+        bill_model.migrate_itemtxs(
+            itemtxs={
+                setup["expense_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=BillModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        bill_model.refresh_from_db()
+        return bill_model
+
+    def migrate_invoice_item(self, invoice_model, setup):
+        quantity = Decimal("2.00")
+        unit_cost = Decimal("75.00")
+
+        invoice_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=InvoiceModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        invoice_model.refresh_from_db()
+        return invoice_model
+
+    def migrate_estimate_item(self, estimate_model, setup):
+        quantity = Decimal("2.00")
+        unit_cost = Decimal("30.00")
+        unit_revenue = Decimal("75.00")
+
+        estimate_model.migrate_itemtxs(
+            itemtxs={
+                setup["service_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "unit_revenue": unit_revenue,
+                    "total_amount": quantity * unit_revenue,
+                }
+            },
+            operation=EstimateModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        estimate_model.refresh_from_db()
+        return estimate_model
+
+    def migrate_purchase_order_item(self, po_model, setup):
+        quantity = Decimal("3.00")
+        unit_cost = Decimal("20.00")
+
+        po_model.migrate_itemtxs(
+            itemtxs={
+                setup["inventory_item"].item_number: {
+                    "quantity": quantity,
+                    "unit_cost": unit_cost,
+                    "total_amount": quantity * unit_cost,
+                }
+            },
+            operation=PurchaseOrderModel.ITEMIZE_REPLACE,
+            commit=True,
+        )
+
+        po_model.refresh_from_db()
+        return po_model
+
+    def test_account_queryset_contracts(self):
+        setup = self.create_entity_setup()
+        accounts_qs = AccountModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(accounts_qs.not_coa_root().filter(uuid=setup["cash_account"].uuid).exists())
+        self.assertFalse(accounts_qs.is_coa_root().filter(uuid=setup["cash_account"].uuid).exists())
+
+        self.assertTrue(accounts_qs.available().filter(uuid=setup["cash_account"].uuid).exists())
+        self.assertFalse(accounts_qs.available().filter(uuid=setup["inactive_cash_account"].uuid).exists())
+
+        self.assertTrue(accounts_qs.is_role_default().filter(uuid=setup["cash_account"].uuid).exists())
+        self.assertTrue(accounts_qs.cash().filter(uuid=setup["cash_account"].uuid).exists())
+        self.assertTrue(accounts_qs.expenses().filter(uuid=setup["expense_account"].uuid).exists())
+
+    def test_customer_and_vendor_queryset_contracts(self):
+        setup = self.create_entity_setup()
+
+        customers_qs = CustomerModel.objects.for_entity(setup["entity_model"])
+        vendors_qs = VendorModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(customers_qs.active().filter(uuid=setup["customer_model"].uuid).exists())
+        self.assertFalse(customers_qs.active().filter(uuid=setup["inactive_customer"].uuid).exists())
+        self.assertTrue(customers_qs.inactive().filter(uuid=setup["inactive_customer"].uuid).exists())
+
+        self.assertTrue(customers_qs.visible().filter(uuid=setup["customer_model"].uuid).exists())
+        self.assertFalse(customers_qs.visible().filter(uuid=setup["hidden_customer"].uuid).exists())
+        self.assertTrue(customers_qs.hidden().filter(uuid=setup["hidden_customer"].uuid).exists())
+
+        self.assertTrue(vendors_qs.active().filter(uuid=setup["vendor_model"].uuid).exists())
+        self.assertFalse(vendors_qs.active().filter(uuid=setup["inactive_vendor"].uuid).exists())
+        self.assertTrue(vendors_qs.inactive().filter(uuid=setup["inactive_vendor"].uuid).exists())
+
+        self.assertTrue(vendors_qs.visible().filter(uuid=setup["vendor_model"].uuid).exists())
+        self.assertFalse(vendors_qs.visible().filter(uuid=setup["hidden_vendor"].uuid).exists())
+        self.assertTrue(vendors_qs.hidden().filter(uuid=setup["hidden_vendor"].uuid).exists())
+
+    def test_item_queryset_contracts(self):
+        setup = self.create_entity_setup()
+
+        items_qs = ItemModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(items_qs.services().filter(uuid=setup["service_item"].uuid).exists())
+        self.assertTrue(items_qs.products().filter(uuid=setup["product_item"].uuid).exists())
+        self.assertTrue(items_qs.inventory_all().filter(uuid=setup["inventory_item"].uuid).exists())
+        self.assertTrue(items_qs.expenses().filter(uuid=setup["expense_item"].uuid).exists())
+
+        invoice_items_qs = ItemModel.objects.for_invoice(setup["entity_model"])
+        bill_items_qs = ItemModel.objects.for_bill(setup["entity_model"])
+
+        self.assertTrue(invoice_items_qs.filter(uuid=setup["service_item"].uuid).exists())
+        self.assertTrue(invoice_items_qs.filter(uuid=setup["product_item"].uuid).exists())
+        self.assertFalse(invoice_items_qs.filter(uuid=setup["expense_item"].uuid).exists())
+
+        self.assertTrue(bill_items_qs.filter(uuid=setup["expense_item"].uuid).exists())
+        self.assertTrue(bill_items_qs.filter(uuid=setup["inventory_item"].uuid).exists())
+        self.assertFalse(bill_items_qs.filter(uuid=setup["service_item"].uuid).exists())
+
+    def test_bill_queryset_status_contracts(self):
+        setup = self.create_entity_setup()
+
+        draft_bill = self.create_bill(setup)
+
+        approved_bill = self.create_bill(setup)
+        approved_bill = self.migrate_bill_item(approved_bill, setup)
+        approved_bill.mark_as_review(commit=True)
+        approved_bill.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        approved_bill.refresh_from_db()
+
+        paid_bill = self.create_bill(setup)
+        paid_bill = self.migrate_bill_item(paid_bill, setup)
+        paid_bill.mark_as_review(commit=True)
+        paid_bill.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        paid_bill.mark_as_paid(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        paid_bill.refresh_from_db()
+
+        bills_qs = BillModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(bills_qs.draft().filter(uuid=draft_bill.uuid).exists())
+        self.assertTrue(bills_qs.approved().filter(uuid=approved_bill.uuid).exists())
+        self.assertTrue(bills_qs.paid().filter(uuid=paid_bill.uuid).exists())
+        self.assertTrue(bills_qs.active().filter(uuid=approved_bill.uuid).exists())
+        self.assertTrue(bills_qs.active().filter(uuid=paid_bill.uuid).exists())
+
+    def test_invoice_queryset_status_contracts(self):
+        setup = self.create_entity_setup()
+
+        draft_invoice = self.create_invoice(setup)
+
+        approved_invoice = self.create_invoice(setup)
+        approved_invoice = self.migrate_invoice_item(approved_invoice, setup)
+        approved_invoice.mark_as_review(commit=True)
+        approved_invoice.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        approved_invoice.refresh_from_db()
+
+        paid_invoice = self.create_invoice(setup)
+        paid_invoice = self.migrate_invoice_item(paid_invoice, setup)
+        paid_invoice.mark_as_review(commit=True)
+        paid_invoice.mark_as_approved(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        paid_invoice.mark_as_paid(
+            entity_slug=setup["entity_model"],
+            user_model=self.user,
+            commit=True,
+        )
+        paid_invoice.refresh_from_db()
+
+        invoices_qs = InvoiceModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(invoices_qs.draft().filter(uuid=draft_invoice.uuid).exists())
+        self.assertTrue(invoices_qs.approved().filter(uuid=approved_invoice.uuid).exists())
+        self.assertTrue(invoices_qs.paid().filter(uuid=paid_invoice.uuid).exists())
+        self.assertTrue(invoices_qs.active().filter(uuid=approved_invoice.uuid).exists())
+        self.assertTrue(invoices_qs.active().filter(uuid=paid_invoice.uuid).exists())
+
+    def test_estimate_queryset_status_contracts(self):
+        setup = self.create_entity_setup()
+
+        draft_estimate = self.create_estimate(setup)
+
+        approved_estimate = self.create_estimate(setup)
+        approved_estimate = self.migrate_estimate_item(approved_estimate, setup)
+        approved_estimate.mark_as_review(commit=True)
+        approved_estimate.mark_as_approved(commit=True)
+        approved_estimate.refresh_from_db()
+
+        completed_estimate = self.create_estimate(setup)
+        completed_estimate = self.migrate_estimate_item(completed_estimate, setup)
+        completed_estimate.mark_as_review(commit=True)
+        completed_estimate.mark_as_approved(commit=True)
+        completed_estimate.mark_as_completed(commit=True)
+        completed_estimate.refresh_from_db()
+
+        estimates_qs = EstimateModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(estimates_qs.draft().filter(uuid=draft_estimate.uuid).exists())
+        self.assertTrue(estimates_qs.approved().filter(uuid=approved_estimate.uuid).exists())
+        self.assertTrue(estimates_qs.approved().filter(uuid=completed_estimate.uuid).exists())
+        self.assertTrue(estimates_qs.contracts().filter(uuid=approved_estimate.uuid).exists())
+        self.assertTrue(estimates_qs.contracts().filter(uuid=completed_estimate.uuid).exists())
+        self.assertTrue(estimates_qs.estimates().filter(uuid=draft_estimate.uuid).exists())
+        self.assertFalse(estimates_qs.estimates().filter(uuid=approved_estimate.uuid).exists())
+
+    def test_purchase_order_queryset_status_contracts(self):
+        setup = self.create_entity_setup()
+
+        draft_po = self.create_purchase_order(setup)
+
+        approved_po = self.create_purchase_order(setup)
+        approved_po = self.migrate_purchase_order_item(approved_po, setup)
+        approved_po.mark_as_review(commit=True)
+        approved_po.mark_as_approved(commit=True)
+        approved_po.refresh_from_db()
+
+        purchase_orders_qs = PurchaseOrderModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(purchase_orders_qs.draft().filter(uuid=draft_po.uuid).exists())
+        self.assertTrue(purchase_orders_qs.approved().filter(uuid=approved_po.uuid).exists())
+        self.assertTrue(purchase_orders_qs.active().filter(uuid=approved_po.uuid).exists())
+        self.assertFalse(purchase_orders_qs.fulfilled().filter(uuid=approved_po.uuid).exists())

--- a/django_ledger/tests/api/test_receipt_api.py
+++ b/django_ledger/tests/api/test_receipt_api.py
@@ -1,0 +1,443 @@
+"""
+High-level API behavior tests for ReceiptModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import ReceiptModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel, EntityStateModel
+from django_ledger.models.receipt import ReceiptModelValidationError
+from django_ledger.models.unit import EntityUnitModel
+from django_ledger.models.vendor import VendorModel
+
+
+class ReceiptHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for ReceiptModel contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic receipt invariants that should remain
+    true across swappable-model refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_receipt_contract_user",
+            email="api-receipt-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Receipt Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        transfer_account = coa_model.create_account(
+            code="1020",
+            name=f"{name} Transfer Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        unit_model = EntityUnitModel.add_root(
+            name=f"{name} Unit",
+            slug="api-receipt-unit",
+            entity=entity_model,
+            document_prefix="RCU",
+            active=True,
+            hidden=False,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "transfer_account": transfer_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "unit_model": unit_model,
+        }
+
+    def create_sales_receipt(self, setup, *, receipt_date=date(2026, 1, 15), amount="125.00"):
+        receipt_model = ReceiptModel()
+
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            amount=Decimal(amount),
+            receipt_date=receipt_date,
+            customer_model=setup["customer_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["income_account"],
+            commit=True,
+        )
+
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def create_expense_receipt(self, setup, *, receipt_date=date(2026, 1, 15), amount="75.00"):
+        receipt_model = ReceiptModel()
+
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.EXPENSE_RECEIPT,
+            amount=Decimal(amount),
+            receipt_date=receipt_date,
+            vendor_model=setup["vendor_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["expense_account"],
+            commit=True,
+        )
+
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def create_transfer_receipt(self, setup, *, receipt_date=date(2026, 1, 15), amount="50.00"):
+        receipt_model = ReceiptModel()
+
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+            amount=Decimal(amount),
+            receipt_date=receipt_date,
+            charge_account=setup["cash_account"],
+            receipt_account=setup["transfer_account"],
+            commit=True,
+        )
+
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def test_sales_receipt_configure_creates_customer_receipt_and_posted_ledger(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = self.create_sales_receipt(setup)
+
+        self.assertIsInstance(receipt_model, ReceiptModel)
+        self.assertIsNotNone(receipt_model.uuid)
+        self.assertTrue(receipt_model.receipt_number)
+        self.assertEqual(receipt_model.receipt_type, ReceiptModel.SALES_RECEIPT)
+        self.assertEqual(receipt_model.amount, Decimal("125.00"))
+        self.assertEqual(receipt_model.customer_model_id, setup["customer_model"].uuid)
+        self.assertIsNone(receipt_model.vendor_model_id)
+        self.assertEqual(receipt_model.charge_account_id, setup["cash_account"].uuid)
+        self.assertEqual(receipt_model.receipt_account_id, setup["income_account"].uuid)
+        self.assertTrue(receipt_model.is_sales_receipt())
+        self.assertFalse(receipt_model.is_expense_receipt())
+        self.assertFalse(receipt_model.is_transfer_receipt())
+        self.assertTrue(receipt_model.is_configured())
+        self.assertTrue(receipt_model.can_migrate())
+
+        self.assertIsNotNone(receipt_model.ledger_model_id)
+        self.assertEqual(receipt_model.ledger_model.entity_id, setup["entity_model"].uuid)
+        self.assertTrue(receipt_model.ledger_model.is_posted())
+        self.assertEqual(receipt_model.ledger_model.name, receipt_model.receipt_number)
+
+    def test_expense_receipt_configure_creates_vendor_receipt(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = self.create_expense_receipt(setup)
+
+        self.assertTrue(receipt_model.receipt_number)
+        self.assertEqual(receipt_model.receipt_type, ReceiptModel.EXPENSE_RECEIPT)
+        self.assertEqual(receipt_model.amount, Decimal("75.00"))
+        self.assertEqual(receipt_model.vendor_model_id, setup["vendor_model"].uuid)
+        self.assertIsNone(receipt_model.customer_model_id)
+        self.assertEqual(receipt_model.charge_account_id, setup["cash_account"].uuid)
+        self.assertEqual(receipt_model.receipt_account_id, setup["expense_account"].uuid)
+        self.assertTrue(receipt_model.is_expense_receipt())
+        self.assertFalse(receipt_model.is_sales_receipt())
+        self.assertFalse(receipt_model.is_transfer_receipt())
+        self.assertTrue(receipt_model.is_configured())
+        self.assertTrue(receipt_model.can_migrate())
+
+    def test_transfer_receipt_configure_does_not_require_customer_or_vendor(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = self.create_transfer_receipt(setup)
+
+        self.assertTrue(receipt_model.receipt_number)
+        self.assertEqual(receipt_model.receipt_type, ReceiptModel.TRANSFER_RECEIPT)
+        self.assertIsNone(receipt_model.customer_model_id)
+        self.assertIsNone(receipt_model.vendor_model_id)
+        self.assertTrue(receipt_model.is_transfer_receipt())
+        self.assertFalse(receipt_model.is_sales_receipt())
+        self.assertFalse(receipt_model.is_expense_receipt())
+        self.assertTrue(receipt_model.is_configured())
+        self.assertTrue(receipt_model.can_migrate())
+
+    def test_receipt_for_entity_limits_queryset_to_entity_scope(self):
+        setup = self.create_entity_setup(name="API Receipt Entity A")
+        other_setup = self.create_entity_setup(name="API Receipt Entity B")
+
+        receipt_model = self.create_sales_receipt(setup)
+        other_receipt_model = self.create_sales_receipt(other_setup)
+
+        scoped_qs = ReceiptModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(scoped_qs.filter(uuid=receipt_model.uuid).exists())
+        self.assertFalse(scoped_qs.filter(uuid=other_receipt_model.uuid).exists())
+
+    def test_receipt_queryset_customer_vendor_and_date_filters(self):
+        setup = self.create_entity_setup()
+
+        sales_receipt = self.create_sales_receipt(
+            setup,
+            receipt_date=date(2026, 1, 15),
+        )
+
+        expense_receipt = self.create_expense_receipt(
+            setup,
+            receipt_date=date(2026, 2, 20),
+        )
+
+        receipts_qs = ReceiptModel.objects.for_entity(setup["entity_model"])
+
+        self.assertTrue(
+            receipts_qs.for_customer(setup["customer_model"]).filter(uuid=sales_receipt.uuid).exists()
+        )
+        self.assertFalse(
+            receipts_qs.for_customer(setup["customer_model"]).filter(uuid=expense_receipt.uuid).exists()
+        )
+
+        self.assertTrue(
+            receipts_qs.for_vendor(setup["vendor_model"]).filter(uuid=expense_receipt.uuid).exists()
+        )
+        self.assertFalse(
+            receipts_qs.for_vendor(setup["vendor_model"]).filter(uuid=sales_receipt.uuid).exists()
+        )
+
+        january_qs = receipts_qs.for_dates(
+            from_date=date(2026, 1, 1),
+            to_date=date(2026, 1, 31),
+        )
+
+        self.assertTrue(january_qs.filter(uuid=sales_receipt.uuid).exists())
+        self.assertFalse(january_qs.filter(uuid=expense_receipt.uuid).exists())
+
+    def test_receipt_numbering_uses_entity_state_receipt_key_and_fiscal_year(self):
+        setup = self.create_entity_setup()
+
+        self.create_sales_receipt(setup)
+        self.create_expense_receipt(setup)
+
+        fy_key = setup["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
+
+        receipt_state = EntityStateModel.objects.get(
+            entity_model=setup["entity_model"],
+            entity_unit=None,
+            fiscal_year=fy_key,
+            key=EntityStateModel.KEY_RECEIPT,
+        )
+
+        self.assertEqual(receipt_state.sequence, 2)
+
+    def test_receipt_numbering_is_entity_scoped(self):
+        setup_a = self.create_entity_setup(name="API Receipt State Entity A")
+        setup_b = self.create_entity_setup(name="API Receipt State Entity B")
+
+        receipt_a = self.create_sales_receipt(setup_a)
+        receipt_b = self.create_sales_receipt(setup_b)
+
+        self.assertEqual(receipt_a.receipt_number, receipt_b.receipt_number)
+
+        fy_a = setup_a["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
+        fy_b = setup_b["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
+
+        state_a = EntityStateModel.objects.get(
+            entity_model=setup_a["entity_model"],
+            entity_unit=None,
+            fiscal_year=fy_a,
+            key=EntityStateModel.KEY_RECEIPT,
+        )
+        state_b = EntityStateModel.objects.get(
+            entity_model=setup_b["entity_model"],
+            entity_unit=None,
+            fiscal_year=fy_b,
+            key=EntityStateModel.KEY_RECEIPT,
+        )
+
+        self.assertEqual(state_a.sequence, 1)
+        self.assertEqual(state_b.sequence, 1)
+
+    def test_receipt_configure_rejects_negative_amount(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = ReceiptModel()
+
+        with self.assertRaises(ReceiptModelValidationError):
+            receipt_model.configure(
+                entity_model=setup["entity_model"],
+                receipt_type=ReceiptModel.SALES_RECEIPT,
+                amount=Decimal("-1.00"),
+                receipt_date=date(2026, 1, 15),
+                customer_model=setup["customer_model"],
+                charge_account=setup["cash_account"],
+                receipt_account=setup["income_account"],
+                commit=True,
+            )
+
+    def test_sales_receipt_requires_customer(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = ReceiptModel()
+
+        with self.assertRaises(ReceiptModelValidationError):
+            receipt_model.configure(
+                entity_model=setup["entity_model"],
+                receipt_type=ReceiptModel.SALES_RECEIPT,
+                amount=Decimal("10.00"),
+                receipt_date=date(2026, 1, 15),
+                charge_account=setup["cash_account"],
+                receipt_account=setup["income_account"],
+                commit=True,
+            )
+
+    def test_expense_receipt_requires_vendor(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = ReceiptModel()
+
+        with self.assertRaises(ReceiptModelValidationError):
+            receipt_model.configure(
+                entity_model=setup["entity_model"],
+                receipt_type=ReceiptModel.EXPENSE_RECEIPT,
+                amount=Decimal("10.00"),
+                receipt_date=date(2026, 1, 15),
+                charge_account=setup["cash_account"],
+                receipt_account=setup["expense_account"],
+                commit=True,
+            )
+
+    def test_transfer_receipt_rejects_customer_or_vendor(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = ReceiptModel()
+
+        with self.assertRaises(ReceiptModelValidationError):
+            receipt_model.configure(
+                entity_model=setup["entity_model"],
+                receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+                amount=Decimal("10.00"),
+                receipt_date=date(2026, 1, 15),
+                customer_model=setup["customer_model"],
+                charge_account=setup["cash_account"],
+                receipt_account=setup["transfer_account"],
+                commit=True,
+            )
+
+    def test_receipt_get_type_for_amount_contracts(self):
+        setup = self.create_entity_setup()
+
+        customer_receipt = ReceiptModel(customer_model=setup["customer_model"])
+        vendor_receipt = ReceiptModel(vendor_model=setup["vendor_model"])
+
+        self.assertEqual(
+            customer_receipt.get_receipt_type_for_amount(Decimal("10.00")),
+            ReceiptModel.SALES_RECEIPT,
+        )
+        self.assertEqual(
+            customer_receipt.get_receipt_type_for_amount(Decimal("-10.00")),
+            ReceiptModel.SALES_REFUND,
+        )
+        self.assertEqual(
+            vendor_receipt.get_receipt_type_for_amount(Decimal("-10.00")),
+            ReceiptModel.EXPENSE_RECEIPT,
+        )
+        self.assertEqual(
+            vendor_receipt.get_receipt_type_for_amount(Decimal("10.00")),
+            ReceiptModel.EXPENSE_REFUND,
+        )
+
+    def test_receipt_unit_model_can_be_bound_by_instance(self):
+        setup = self.create_entity_setup()
+
+        receipt_model = ReceiptModel()
+
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            amount=Decimal("25.00"),
+            unit_model=setup["unit_model"],
+            receipt_date=date(2026, 1, 15),
+            customer_model=setup["customer_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["income_account"],
+            commit=True,
+        )
+
+        receipt_model.refresh_from_db()
+
+        self.assertEqual(receipt_model.unit_model_id, setup["unit_model"].uuid)

--- a/django_ledger/tests/api/test_receipt_configure_api.py
+++ b/django_ledger/tests/api/test_receipt_configure_api.py
@@ -1,0 +1,269 @@
+"""
+High-level API tests for ReceiptModel configuration and numbering behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.text import slugify
+
+from django_ledger.models import ReceiptModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.receipt import ReceiptModelValidationError
+from django_ledger.models.unit import EntityUnitModel
+from django_ledger.models.vendor import VendorModel
+from django_ledger.settings import (
+    DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING,
+    DJANGO_LEDGER_RECEIPT_NUMBER_PREFIX,
+)
+
+
+class ReceiptConfigureAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_receipt_configure_user",
+            email="api-receipt-configure-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Receipt Configure Entity", fy_start_month=1):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=fy_start_month,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        transfer_account = coa_model.create_account(
+            code="1020",
+            name=f"{name} Transfer Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        customer_model.refresh_from_db()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        vendor_model.refresh_from_db()
+
+        unit_model = EntityUnitModel.add_root(
+            name=f"{name} Unit",
+            slug=f"{slugify(name)}-unit",
+            entity=entity_model,
+            document_prefix="RCU",
+            active=True,
+            hidden=False,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "transfer_account": transfer_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "unit_model": unit_model,
+        }
+
+    def configure_sales_receipt(self, setup, *, entity_input=None, customer_input=None, unit_input=None, commit=True):
+        receipt_model = ReceiptModel()
+        receipt_model.configure(
+            entity_model=entity_input or setup["entity_model"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            amount=Decimal("125.00"),
+            unit_model=unit_input,
+            receipt_date=date(2026, 1, 15),
+            customer_model=customer_input or setup["customer_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["income_account"],
+            commit=commit,
+        )
+        if commit:
+            receipt_model.refresh_from_db()
+        return receipt_model
+
+    def configure_expense_receipt(self, setup, *, vendor_input=None):
+        receipt_model = ReceiptModel()
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.EXPENSE_RECEIPT,
+            amount=Decimal("75.00"),
+            receipt_date=date(2026, 1, 15),
+            vendor_model=vendor_input or setup["vendor_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["expense_account"],
+            commit=True,
+        )
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def create_numberable_receipt(self, setup, *, saved=False):
+        ledger_model = setup["entity_model"].create_ledger(
+            name="API Receipt Numbering Ledger",
+            posted=True,
+            commit=True,
+        )
+        receipt_kwargs = {
+            "receipt_number": "",
+            "receipt_date": date(2026, 1, 15),
+            "receipt_type": ReceiptModel.SALES_RECEIPT,
+            "ledger_model": ledger_model,
+            "customer_model": setup["customer_model"],
+            "charge_account": setup["cash_account"],
+            "receipt_account": setup["income_account"],
+            "amount": Decimal("10.00"),
+        }
+        if saved:
+            return ReceiptModel.objects.create(**receipt_kwargs)
+        return ReceiptModel(**receipt_kwargs)
+
+    def assert_receipt_number(self, number, *, fiscal_year, sequence):
+        self.assertTrue(number)
+        self.assertTrue(number.startswith(f"{DJANGO_LEDGER_RECEIPT_NUMBER_PREFIX}-{fiscal_year}-"))
+        self.assertTrue(str(number).endswith(str(sequence).zfill(DJANGO_LEDGER_DOCUMENT_NUMBER_PADDING)))
+
+    def test_configure_accepts_entity_model_slug_and_uuid(self):
+        setup = self.create_entity_setup()
+        entity_model = setup["entity_model"]
+
+        by_model = self.configure_sales_receipt(setup, entity_input=entity_model)
+        by_slug = self.configure_sales_receipt(setup, entity_input=entity_model.slug)
+        by_uuid = self.configure_sales_receipt(setup, entity_input=entity_model.uuid)
+
+        for receipt_model in [by_model, by_slug, by_uuid]:
+            self.assertEqual(receipt_model.ledger_model.entity_id, entity_model.uuid)
+            self.assertEqual(receipt_model.customer_model_id, setup["customer_model"].uuid)
+            self.assertTrue(receipt_model.receipt_number)
+
+    def test_configure_commit_false_configures_in_memory_receipt_and_persists_only_ledger(self):
+        setup = self.create_entity_setup(name="API Receipt Configure Commit False Entity")
+
+        receipt_model = self.configure_sales_receipt(setup, commit=False)
+
+        self.assertTrue(receipt_model.is_configured())
+        self.assertTrue(receipt_model.receipt_number)
+        self.assertIsNotNone(receipt_model.ledger_model_id)
+        self.assertFalse(ReceiptModel.objects.filter(uuid=receipt_model.uuid).exists())
+        self.assertTrue(receipt_model.ledger_model.__class__.objects.filter(uuid=receipt_model.ledger_model_id).exists())
+
+    def test_configure_accepts_customer_number_and_uuid(self):
+        setup = self.create_entity_setup(name="API Receipt Configure Customer Entity")
+        customer_model = setup["customer_model"]
+
+        by_number = self.configure_sales_receipt(setup, customer_input=customer_model.customer_number)
+        by_uuid = self.configure_sales_receipt(setup, customer_input=customer_model.uuid)
+
+        self.assertEqual(by_number.customer_model_id, customer_model.uuid)
+        self.assertEqual(by_uuid.customer_model_id, customer_model.uuid)
+
+    def test_configure_accepts_vendor_number_and_uuid(self):
+        setup = self.create_entity_setup(name="API Receipt Configure Vendor Entity")
+        vendor_model = setup["vendor_model"]
+
+        by_number = self.configure_expense_receipt(setup, vendor_input=vendor_model.vendor_number)
+        by_uuid = self.configure_expense_receipt(setup, vendor_input=vendor_model.uuid)
+
+        self.assertEqual(by_number.vendor_model_id, vendor_model.uuid)
+        self.assertEqual(by_uuid.vendor_model_id, vendor_model.uuid)
+
+    def test_configure_accepts_unit_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Receipt Configure Unit Entity")
+        unit_model = setup["unit_model"]
+
+        by_instance = self.configure_sales_receipt(setup, unit_input=unit_model)
+        by_slug = self.configure_sales_receipt(setup, unit_input=unit_model.slug)
+        by_uuid = self.configure_sales_receipt(setup, unit_input=unit_model.uuid)
+
+        self.assertEqual(by_instance.unit_model_id, unit_model.uuid)
+        self.assertEqual(by_slug.unit_model_id, unit_model.uuid)
+        self.assertEqual(by_uuid.unit_model_id, unit_model.uuid)
+
+    def test_generate_receipt_number_commit_false_and_commit_true(self):
+        setup = self.create_entity_setup(name="API Receipt Configure Numbering Entity")
+        fy_key = setup["entity_model"].get_fy_for_date(dt=date(2026, 1, 15))
+
+        unsaved_receipt = self.create_numberable_receipt(setup, saved=False)
+
+        self.assertTrue(unsaved_receipt.can_generate_receipt_number())
+
+        first_number = unsaved_receipt.generate_receipt_number(commit=False)
+
+        self.assert_receipt_number(first_number, fiscal_year=fy_key, sequence=1)
+        self.assertFalse(ReceiptModel.objects.filter(uuid=unsaved_receipt.uuid).exists())
+
+        saved_receipt = self.create_numberable_receipt(setup, saved=True)
+        second_number = saved_receipt.generate_receipt_number(commit=True)
+        saved_receipt.refresh_from_db()
+
+        self.assert_receipt_number(second_number, fiscal_year=fy_key, sequence=2)
+        self.assertEqual(saved_receipt.receipt_number, second_number)
+        self.assertFalse(saved_receipt.can_generate_receipt_number())
+
+    def test_configure_rejects_customer_vendor_mutual_exclusion(self):
+        setup = self.create_entity_setup(name="API Receipt Configure Invalid Entity")
+        receipt_model = ReceiptModel()
+
+        with self.assertRaises(ReceiptModelValidationError):
+            receipt_model.configure(
+                entity_model=setup["entity_model"],
+                receipt_type=ReceiptModel.SALES_RECEIPT,
+                amount=Decimal("25.00"),
+                receipt_date=date(2026, 1, 15),
+                customer_model=setup["customer_model"],
+                vendor_model=setup["vendor_model"],
+                charge_account=setup["cash_account"],
+                receipt_account=setup["income_account"],
+                commit=True,
+            )

--- a/django_ledger/tests/api/test_receipt_delete_url_api.py
+++ b/django_ledger/tests/api/test_receipt_delete_url_api.py
@@ -1,0 +1,290 @@
+"""
+High-level API tests for ReceiptModel delete guards and URL helpers.
+"""
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import ReceiptModel
+from django_ledger.models.bank_account import BankAccountModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.data_import import ImportJobModel, StagedTransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryModel
+from django_ledger.models.receipt import ReceiptModelValidationError
+from django_ledger.models.vendor import VendorModel
+
+
+class ReceiptDeleteURLAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.user = user_model.objects.create_user(
+            username="api_receipt_delete_url_user",
+            email="api-receipt-delete-url-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Receipt Delete URL Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        transfer_account = coa_model.create_account(
+            code="1020",
+            name=f"{name} Transfer Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "transfer_account": transfer_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+        }
+
+    def create_sales_receipt(self, setup, *, receipt_date=date(2026, 1, 15), staged_transaction_model=None):
+        receipt_model = ReceiptModel()
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            amount=Decimal("125.00"),
+            receipt_date=receipt_date,
+            customer_model=setup["customer_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["income_account"],
+            staged_transaction_model=staged_transaction_model,
+            commit=True,
+        )
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def create_expense_receipt(self, setup):
+        receipt_model = ReceiptModel()
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.EXPENSE_RECEIPT,
+            amount=Decimal("75.00"),
+            receipt_date=date(2026, 1, 15),
+            vendor_model=setup["vendor_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["expense_account"],
+            commit=True,
+        )
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def create_transfer_receipt(self, setup):
+        receipt_model = ReceiptModel()
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+            amount=Decimal("50.00"),
+            receipt_date=date(2026, 1, 15),
+            charge_account=setup["cash_account"],
+            receipt_account=setup["transfer_account"],
+            commit=True,
+        )
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def set_last_closing_date(self, entity_model, closing_date):
+        entity_model.last_closing_date = closing_date
+        entity_model.save(update_fields=["last_closing_date"])
+
+    def create_staged_transaction(self, setup):
+        bank_account = BankAccountModel.objects.create(
+            name="API Receipt URL Bank Account",
+            account_type=BankAccountModel.ACCOUNT_CHECKING,
+            account_number="123456789",
+            routing_number="123456789",
+            aba_number="123456789",
+            entity_model=setup["entity_model"],
+            account_model=setup["cash_account"],
+            active=True,
+        )
+        import_job = ImportJobModel.objects.create(
+            description="API Receipt URL Import Job",
+            bank_account_model=bank_account,
+        )
+        import_job.configure(commit=True)
+        return StagedTransactionModel.objects.create(
+            import_job=import_job,
+            fit_id="FIT-RECEIPT-URL",
+            date_posted=date(2026, 1, 15),
+            amount=Decimal("125.00"),
+            name="API Receipt URL Staged Transaction",
+            memo="API receipt URL staged transaction memo",
+            account_model=setup["income_account"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            customer_model=setup["customer_model"],
+        )
+
+    def test_can_delete_reflects_entity_closing_date_boundaries(self):
+        setup = self.create_entity_setup()
+        receipt_model = self.create_sales_receipt(setup, receipt_date=date(2026, 1, 15))
+
+        self.assertTrue(ReceiptModel.objects.get(uuid=receipt_model.uuid).can_delete())
+
+        self.set_last_closing_date(setup["entity_model"], date(2026, 1, 14))
+        self.assertTrue(ReceiptModel.objects.get(uuid=receipt_model.uuid).can_delete())
+
+        self.set_last_closing_date(setup["entity_model"], date(2026, 1, 15))
+        self.assertFalse(ReceiptModel.objects.get(uuid=receipt_model.uuid).can_delete())
+
+        self.set_last_closing_date(setup["entity_model"], date(2026, 1, 16))
+        self.assertFalse(ReceiptModel.objects.get(uuid=receipt_model.uuid).can_delete())
+
+    def test_delete_success_removes_receipt_and_journal_entries_but_leaves_ledger(self):
+        setup = self.create_entity_setup(name="API Receipt Delete Success Entity")
+        receipt_model = self.create_sales_receipt(setup)
+        ledger_model = receipt_model.ledger_model
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc),
+            description="API Receipt Delete Journal Entry",
+        )
+
+        receipt_model.delete()
+
+        self.assertFalse(ReceiptModel.objects.filter(uuid=receipt_model.uuid).exists())
+        self.assertFalse(JournalEntryModel.objects.filter(uuid=journal_entry.uuid).exists())
+        self.assertTrue(ledger_model.__class__.objects.filter(uuid=ledger_model.uuid).exists())
+
+    def test_delete_rejects_closed_period_and_leaves_receipt_intact(self):
+        setup = self.create_entity_setup(name="API Receipt Delete Closed Entity")
+        receipt_model = self.create_sales_receipt(setup, receipt_date=date(2026, 1, 15))
+        self.set_last_closing_date(setup["entity_model"], date(2026, 1, 15))
+        receipt_model = ReceiptModel.objects.get(uuid=receipt_model.uuid)
+
+        with self.assertRaises(ReceiptModelValidationError):
+            receipt_model.delete()
+
+        self.assertTrue(ReceiptModel.objects.filter(uuid=receipt_model.uuid).exists())
+
+    def test_url_helpers_return_entity_scoped_strings_or_none(self):
+        setup = self.create_entity_setup(name="API Receipt URL Helper Entity")
+        sales_receipt = self.create_sales_receipt(setup)
+        expense_receipt = self.create_expense_receipt(setup)
+        transfer_receipt = self.create_transfer_receipt(setup)
+        entity_slug = setup["entity_model"].slug
+
+        absolute_url = sales_receipt.get_absolute_url()
+        self.assertIsInstance(absolute_url, str)
+        self.assertIn(entity_slug, absolute_url)
+        self.assertIn(str(sales_receipt.uuid), absolute_url)
+
+        list_url = sales_receipt.get_list_url()
+        self.assertIsInstance(list_url, str)
+        self.assertIn(entity_slug, list_url)
+        self.assertNotIn(str(sales_receipt.uuid), list_url)
+
+        delete_url = sales_receipt.get_delete_url()
+        self.assertIsInstance(delete_url, str)
+        self.assertIn(entity_slug, delete_url)
+        self.assertIn(str(sales_receipt.uuid), delete_url)
+
+        customer_list_url = sales_receipt.get_customer_list_url()
+        customer_report_url = sales_receipt.get_customer_report_url()
+        self.assertIsInstance(customer_list_url, str)
+        self.assertIsInstance(customer_report_url, str)
+        self.assertIn(entity_slug, customer_list_url)
+        self.assertIn(str(setup["customer_model"].uuid), customer_list_url)
+        self.assertIn(entity_slug, customer_report_url)
+        self.assertIsNone(sales_receipt.get_vendor_list_url())
+        self.assertIsNone(sales_receipt.get_vendor_report_url())
+
+        vendor_list_url = expense_receipt.get_vendor_list_url()
+        vendor_report_url = expense_receipt.get_vendor_report_url()
+        self.assertIsInstance(vendor_list_url, str)
+        self.assertIsInstance(vendor_report_url, str)
+        self.assertIn(entity_slug, vendor_list_url)
+        self.assertIn(str(setup["vendor_model"].uuid), vendor_list_url)
+        self.assertIn(entity_slug, vendor_report_url)
+        self.assertIsNone(expense_receipt.get_customer_list_url())
+        self.assertIsNone(expense_receipt.get_customer_report_url())
+
+        self.assertIsNone(transfer_receipt.get_customer_list_url())
+        self.assertIsNone(transfer_receipt.get_vendor_list_url())
+        self.assertIsNone(transfer_receipt.get_customer_report_url())
+        self.assertIsNone(transfer_receipt.get_vendor_report_url())
+
+    def test_import_job_and_staged_transaction_url_helpers_return_none_or_related_urls(self):
+        setup = self.create_entity_setup(name="API Receipt Import URL Entity")
+        receipt_without_import = self.create_sales_receipt(setup)
+
+        self.assertIsNone(receipt_without_import.get_import_job_url())
+        self.assertIsNone(receipt_without_import.get_staged_tx_url())
+
+        staged_tx = self.create_staged_transaction(setup)
+        receipt_with_import = self.create_sales_receipt(setup, staged_transaction_model=staged_tx)
+
+        import_job_url = receipt_with_import.get_import_job_url()
+        staged_tx_url = receipt_with_import.get_staged_tx_url()
+
+        self.assertIsInstance(import_job_url, str)
+        self.assertIn(setup["entity_model"].slug, import_job_url)
+        self.assertIn(str(staged_tx.import_job_id), import_job_url)
+
+        self.assertIsInstance(staged_tx_url, str)
+        self.assertIn(import_job_url, staged_tx_url)
+        self.assertIn(str(staged_tx.uuid), staged_tx_url)

--- a/django_ledger/tests/api/test_receipt_queryset_api.py
+++ b/django_ledger/tests/api/test_receipt_queryset_api.py
@@ -1,0 +1,244 @@
+"""
+High-level API tests for ReceiptModel queryset and manager behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import ReceiptModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.receipt import ReceiptModelValidationError
+from django_ledger.models.vendor import VendorModel
+
+
+class ReceiptQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_receipt_queryset_admin",
+            email="api-receipt-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_receipt_queryset_manager",
+            email="api-receipt-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_receipt_queryset_other_admin",
+            email="api-receipt-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_receipt_queryset_unrelated",
+            email="api-receipt-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_receipt_queryset_superuser",
+            email="api-receipt-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Receipt Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role="in_operational",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+
+        customer_model = CustomerModel(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            description=f"{name} Customer description",
+            active=True,
+            hidden=False,
+        )
+        customer_model.full_clean()
+        customer_model.save()
+        customer_model.refresh_from_db()
+
+        vendor_model = VendorModel(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            description=f"{name} Vendor description",
+            active=True,
+            hidden=False,
+        )
+        vendor_model.full_clean()
+        vendor_model.save()
+        vendor_model.refresh_from_db()
+
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+        }
+
+    def create_sales_receipt(self, setup, *, receipt_date=date(2026, 1, 15), amount="125.00"):
+        receipt_model = ReceiptModel()
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            amount=Decimal(amount),
+            receipt_date=receipt_date,
+            customer_model=setup["customer_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["income_account"],
+            commit=True,
+        )
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def create_expense_receipt(self, setup, *, receipt_date=date(2026, 1, 15), amount="75.00"):
+        receipt_model = ReceiptModel()
+        receipt_model.configure(
+            entity_model=setup["entity_model"],
+            receipt_type=ReceiptModel.EXPENSE_RECEIPT,
+            amount=Decimal(amount),
+            receipt_date=receipt_date,
+            vendor_model=setup["vendor_model"],
+            charge_account=setup["cash_account"],
+            receipt_account=setup["expense_account"],
+            commit=True,
+        )
+        receipt_model.refresh_from_db()
+        return receipt_model
+
+    def assert_receipt_uuids(self, queryset, expected_receipts):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {receipt.uuid for receipt in expected_receipts},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Receipt Queryset Entity A")
+        other_setup = self.create_entity_setup(
+            name="API Receipt Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        receipt_model = self.create_sales_receipt(setup)
+        self.create_sales_receipt(other_setup)
+
+        entity_model = setup["entity_model"]
+
+        self.assert_receipt_uuids(ReceiptModel.objects.for_entity(entity_model), [receipt_model])
+        self.assert_receipt_uuids(ReceiptModel.objects.for_entity(entity_model.slug), [receipt_model])
+        self.assert_receipt_uuids(ReceiptModel.objects.for_entity(entity_model.uuid), [receipt_model])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_sales_receipt(self.create_entity_setup())
+
+        with self.assertRaises(ReceiptModelValidationError):
+            ReceiptModel.objects.for_entity(object())
+
+        self.assertFalse(ReceiptModel.objects.for_entity("missing-receipt-entity-slug").exists())
+
+    def test_for_user_scopes_to_admin_manager_and_current_superuser_behavior(self):
+        setup = self.create_entity_setup(
+            name="API Receipt Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_setup = self.create_entity_setup(
+            name="API Receipt Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        receipt_model = self.create_sales_receipt(setup)
+        other_receipt_model = self.create_sales_receipt(other_setup)
+
+        self.assert_receipt_uuids(ReceiptModel.objects.all().for_user(self.admin_user), [receipt_model])
+        self.assert_receipt_uuids(ReceiptModel.objects.all().for_user(self.manager_user), [receipt_model])
+        self.assertFalse(ReceiptModel.objects.all().for_user(self.unrelated_user).exists())
+
+        superuser_qs = ReceiptModel.objects.all().for_user(self.superuser)
+        self.assertFalse(superuser_qs.filter(uuid=receipt_model.uuid).exists())
+        self.assertFalse(superuser_qs.filter(uuid=other_receipt_model.uuid).exists())
+
+    def test_for_customer_accepts_model_number_and_uuid(self):
+        setup = self.create_entity_setup(name="API Receipt Queryset Customer Entity")
+        sales_receipt = self.create_sales_receipt(setup)
+        self.create_expense_receipt(setup)
+        customer_model = setup["customer_model"]
+        receipts_qs = ReceiptModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_receipt_uuids(receipts_qs.for_customer(customer_model), [sales_receipt])
+        self.assert_receipt_uuids(receipts_qs.for_customer(customer_model.customer_number), [sales_receipt])
+        self.assert_receipt_uuids(receipts_qs.for_customer(customer_model.uuid), [sales_receipt])
+
+    def test_for_vendor_accepts_model_number_and_uuid(self):
+        setup = self.create_entity_setup(name="API Receipt Queryset Vendor Entity")
+        self.create_sales_receipt(setup)
+        expense_receipt = self.create_expense_receipt(setup)
+        vendor_model = setup["vendor_model"]
+        receipts_qs = ReceiptModel.objects.for_entity(setup["entity_model"])
+
+        self.assert_receipt_uuids(receipts_qs.for_vendor(vendor_model), [expense_receipt])
+        self.assert_receipt_uuids(receipts_qs.for_vendor(vendor_model.vendor_number), [expense_receipt])
+        self.assert_receipt_uuids(receipts_qs.for_vendor(vendor_model.uuid), [expense_receipt])
+
+    def test_for_dates_uses_inclusive_boundaries(self):
+        setup = self.create_entity_setup(name="API Receipt Queryset Date Entity")
+        start_receipt = self.create_sales_receipt(
+            setup,
+            receipt_date=date(2026, 1, 1),
+            amount="10.00",
+        )
+        end_receipt = self.create_sales_receipt(
+            setup,
+            receipt_date=date(2026, 1, 31),
+            amount="20.00",
+        )
+        self.create_sales_receipt(
+            setup,
+            receipt_date=date(2026, 2, 1),
+            amount="30.00",
+        )
+
+        january_qs = ReceiptModel.objects.for_entity(setup["entity_model"]).for_dates(
+            from_date=date(2026, 1, 1),
+            to_date=date(2026, 1, 31),
+        )
+
+        self.assert_receipt_uuids(january_qs, [start_receipt, end_receipt])

--- a/django_ledger/tests/api/test_staged_transaction_classification_mapping_api.py
+++ b/django_ledger/tests/api/test_staged_transaction_classification_mapping_api.py
@@ -1,0 +1,270 @@
+"""
+High-level API tests for StagedTransactionModel classification helpers.
+
+These tests cover transaction type, mapping, receipt, activity, and capability
+helpers without exercising migration, matching, undo, or URL behavior.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, CREDIT, DEBIT
+from django_ledger.models import BankAccountModel, JournalEntryModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.data_import import ImportJobModel, StagedTransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.receipt import ReceiptModel
+from django_ledger.models.unit import EntityUnitModel
+from django_ledger.models.vendor import VendorModel
+
+
+class StagedTransactionClassificationMappingAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_staged_classification_admin",
+            email="api-staged-classification-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Staged Classification Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income",
+            role="in_operational",
+            balance_type=CREDIT,
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type=DEBIT,
+            active=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+        )
+        bank_account.configure(entity_slug=entity_model, user_model=self.admin_user, commit=True)
+        customer_model = CustomerModel.objects.create(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            active=True,
+        )
+        vendor_model = VendorModel.objects.create(
+            vendor_name=f"{name} Vendor",
+            entity_model=entity_model,
+            active=True,
+        )
+        unit_model = EntityUnitModel.add_root(
+            name=f"{name} Unit",
+            slug=f"{name.lower().replace(' ', '-')}-unit",
+            entity=entity_model,
+            document_prefix="SCM",
+            active=True,
+        )
+        import_job = ImportJobModel.objects.create(
+            description=f"{name} Import Job",
+            bank_account_model=bank_account,
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "bank_account": bank_account,
+            "customer_model": customer_model,
+            "vendor_model": vendor_model,
+            "unit_model": unit_model,
+            "import_job": import_job,
+        }
+
+    def create_staged_transaction(
+        self,
+        setup,
+        *,
+        fit_id,
+        amount="125.00",
+        account_model=None,
+        unit_model=None,
+        receipt_type=None,
+        customer_model=None,
+        vendor_model=None,
+        activity=None,
+        matched_transaction_model=None,
+        matched_transaction=False,
+    ):
+        staged_tx = StagedTransactionModel.objects.create(
+            import_job=setup["import_job"],
+            fit_id=fit_id,
+            date_posted=date(2026, 1, 15),
+            amount=Decimal(amount),
+            name=f"API Staged Transaction {fit_id}",
+            memo=f"API staged transaction memo {fit_id}",
+            account_model=account_model,
+            unit_model=unit_model,
+            receipt_type=receipt_type,
+            customer_model=customer_model,
+            vendor_model=vendor_model,
+            activity=activity,
+            matched_transaction_model=matched_transaction_model,
+            matched_transaction=matched_transaction,
+        )
+        return StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+    def test_sales_expense_transfer_and_debt_payment_classification(self):
+        setup = self.create_entity_setup()
+        sales_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-SALES",
+            account_model=setup["income_account"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            customer_model=setup["customer_model"],
+        )
+        expense_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-EXPENSE",
+            amount="-75.00",
+            account_model=setup["expense_account"],
+            receipt_type=ReceiptModel.EXPENSE_RECEIPT,
+            vendor_model=setup["vendor_model"],
+        )
+        transfer_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-TRANSFER",
+            account_model=setup["cash_account"],
+            receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+        )
+        debt_payment_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-DEBT",
+            amount="-25.00",
+            account_model=setup["expense_account"],
+            receipt_type=ReceiptModel.DEBT_PAYMENT,
+            vendor_model=setup["vendor_model"],
+        )
+
+        self.assertTrue(sales_tx.is_sales())
+        self.assertFalse(sales_tx.is_expense())
+        self.assertTrue(expense_tx.is_expense())
+        self.assertFalse(expense_tx.is_sales())
+        self.assertTrue(transfer_tx.is_transfer())
+        self.assertTrue(debt_payment_tx.is_debt_payment())
+
+        self.assertEqual(sales_tx.get_amount(), Decimal("125.00"))
+        self.assertTrue(sales_tx.is_pending())
+        self.assertFalse(sales_tx.is_imported())
+        self.assertTrue(sales_tx.is_mapped())
+
+    def test_mapping_capability_helpers_reflect_receipt_and_transaction_type(self):
+        setup = self.create_entity_setup()
+        sales_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-CAP-SALES",
+            account_model=setup["income_account"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            customer_model=setup["customer_model"],
+        )
+        transfer_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-CAP-TRANSFER",
+            account_model=setup["cash_account"],
+            receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+        )
+
+        self.assertTrue(sales_tx.has_receipt())
+        self.assertTrue(sales_tx.has_mapped_receipt())
+        self.assertTrue(sales_tx.can_have_receipt())
+        self.assertTrue(sales_tx.can_have_customer())
+        self.assertFalse(sales_tx.can_have_vendor())
+        self.assertTrue(sales_tx.can_have_unit())
+        self.assertTrue(sales_tx.can_have_account())
+        self.assertTrue(sales_tx.can_have_bundle_split())
+        self.assertFalse(sales_tx.can_have_amount_split())
+
+        self.assertTrue(transfer_tx.has_receipt())
+        self.assertFalse(transfer_tx.can_have_customer())
+        self.assertFalse(transfer_tx.can_have_vendor())
+        self.assertFalse(transfer_tx.can_have_bundle_split())
+        self.assertFalse(transfer_tx.can_have_activity())
+
+    def test_import_role_set_and_role_mapping_validation(self):
+        setup = self.create_entity_setup()
+        operating_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-ROLE-OPERATING",
+            account_model=setup["income_account"],
+        )
+        unmapped_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-ROLE-UNMAPPED",
+        )
+
+        self.assertEqual({setup["income_account"].role}, operating_tx.get_import_role_set())
+        self.assertTrue(operating_tx.is_role_mapping_valid())
+        self.assertEqual(set(), unmapped_tx.get_import_role_set())
+        self.assertFalse(unmapped_tx.is_role_mapping_valid())
+
+    def test_prospect_activity_helpers_return_current_activity_or_display(self):
+        setup = self.create_entity_setup()
+        staged_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-ACTIVITY",
+            account_model=setup["income_account"],
+        )
+
+        activity = staged_tx.get_prospect_je_activity_try(commit=True)
+        staged_tx.refresh_from_db()
+
+        self.assertEqual(activity, JournalEntryModel.OPERATING_ACTIVITY)
+        self.assertEqual(staged_tx.activity, JournalEntryModel.OPERATING_ACTIVITY)
+        self.assertEqual(staged_tx.get_prospect_je_activity(), JournalEntryModel.OPERATING_ACTIVITY)
+        self.assertEqual(
+            staged_tx.get_prospect_je_activity_display(),
+            JournalEntryModel.MAP_ACTIVITIES[JournalEntryModel.OPERATING_ACTIVITY],
+        )
+        self.assertTrue(staged_tx.has_activity())
+
+    def test_match_and_receipt_presence_helpers_are_state_based(self):
+        setup = self.create_entity_setup()
+        staged_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-STATE",
+            receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+            activity=JournalEntryModel.OPERATING_ACTIVITY,
+        )
+
+        self.assertTrue(staged_tx.has_receipt())
+        self.assertFalse(staged_tx.has_match())
+        self.assertEqual(staged_tx.matches_found(), 0)
+        self.assertTrue(staged_tx.is_cash_transaction())
+        self.assertFalse(staged_tx.has_match_candidates())

--- a/django_ledger/tests/api/test_staged_transaction_import_undo_api.py
+++ b/django_ledger/tests/api/test_staged_transaction_import_undo_api.py
@@ -1,0 +1,256 @@
+"""
+High-level API tests for staged transaction import and undo helpers.
+
+These tests cover migration/undo behavior from StagedTransactionModel without
+testing matching internals, upload flows, or OFX parsing.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, CREDIT, DEBIT
+from django_ledger.models import BankAccountModel, JournalEntryModel, TransactionModel
+from django_ledger.models.customer import CustomerModel
+from django_ledger.models.data_import import (
+    ImportJobModel,
+    StagedTransactionModel,
+    StagedTransactionModelValidationError,
+)
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.receipt import ReceiptModel
+from django_ledger.models.unit import EntityUnitModel
+
+
+class StagedTransactionImportUndoAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_staged_import_undo_admin",
+            email="api-staged-import-undo-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(self, *, name="API Staged Import Undo Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income",
+            role="in_operational",
+            balance_type=CREDIT,
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type=DEBIT,
+            active=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+        )
+        bank_account.configure(entity_slug=entity_model, user_model=self.admin_user, commit=True)
+        customer_model = CustomerModel.objects.create(
+            customer_name=f"{name} Customer",
+            entity_model=entity_model,
+            active=True,
+        )
+        unit_model = EntityUnitModel.add_root(
+            name=f"{name} Unit",
+            slug=f"{name.lower().replace(' ', '-')}-unit",
+            entity=entity_model,
+            document_prefix="SIU",
+            active=True,
+        )
+        import_job = ImportJobModel.objects.create(
+            description=f"{name} Import Job",
+            bank_account_model=bank_account,
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "bank_account": bank_account,
+            "customer_model": customer_model,
+            "unit_model": unit_model,
+            "import_job": import_job,
+        }
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_staged_transaction(
+        self,
+        setup,
+        *,
+        fit_id="FIT-IMPORT",
+        amount="125.00",
+        account_model=None,
+        unit_model=None,
+        receipt_type=None,
+        customer_model=None,
+        parent=None,
+        amount_split=None,
+        bundle_split=True,
+        transaction_model=None,
+    ):
+        staged_tx = StagedTransactionModel.objects.create(
+            import_job=setup["import_job"],
+            parent=parent,
+            fit_id=fit_id,
+            date_posted=date(2026, 1, 15),
+            amount=None if parent else Decimal(amount),
+            amount_split=amount_split,
+            name=f"API Staged Transaction {fit_id}",
+            memo=f"API staged transaction memo {fit_id}",
+            account_model=account_model,
+            unit_model=unit_model,
+            receipt_type=receipt_type,
+            customer_model=customer_model,
+            bundle_split=bundle_split,
+            transaction_model=transaction_model,
+        )
+        return StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+    def test_undo_import_removes_generated_journal_entry_and_unlinks_transaction(self):
+        setup = self.create_entity_setup()
+        staged_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-UNDO-JE",
+            account_model=setup["income_account"],
+            unit_model=setup["unit_model"],
+        )
+
+        staged_tx.migrate_transactions()
+        staged_tx.refresh_from_db()
+        transaction_uuid = staged_tx.transaction_model_id
+        journal_entry_uuid = staged_tx.transaction_model.journal_entry_id
+
+        self.assertTrue(staged_tx.can_undo_import())
+
+        staged_tx.undo_import()
+        staged_tx.refresh_from_db()
+
+        self.assertIsNone(staged_tx.transaction_model_id)
+        self.assertFalse(TransactionModel.objects.filter(uuid=transaction_uuid).exists())
+        self.assertFalse(JournalEntryModel.objects.filter(uuid=journal_entry_uuid).exists())
+
+    def test_undo_import_removes_generated_receipt_and_unlinks_transaction(self):
+        setup = self.create_entity_setup(name="API Staged Undo Receipt Entity")
+        staged_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-UNDO-RECEIPT",
+            account_model=setup["income_account"],
+            unit_model=setup["unit_model"],
+            receipt_type=ReceiptModel.SALES_RECEIPT,
+            customer_model=setup["customer_model"],
+        )
+
+        staged_tx.migrate_receipt(receipt_date=date(2026, 1, 15))
+        staged_tx.refresh_from_db()
+        receipt_uuid = staged_tx.receiptmodel.uuid
+
+        self.assertTrue(staged_tx.can_undo_import())
+
+        staged_tx.undo_import()
+        staged_tx.refresh_from_db()
+
+        self.assertIsNone(staged_tx.transaction_model_id)
+        self.assertFalse(ReceiptModel.objects.filter(uuid=receipt_uuid).exists())
+
+    def test_undo_import_rejects_pending_transaction_by_default(self):
+        setup = self.create_entity_setup(name="API Staged Undo Pending Entity")
+        staged_tx = self.create_staged_transaction(setup, fit_id="FIT-UNDO-PENDING")
+
+        self.assertFalse(staged_tx.can_undo_import())
+        with self.assertRaises(StagedTransactionModelValidationError):
+            staged_tx.undo_import()
+
+    def test_can_undo_import_false_for_bundled_child(self):
+        setup = self.create_entity_setup(name="API Staged Undo Child Entity")
+        parent_tx = self.create_staged_transaction(setup, fit_id="FIT-UNDO-CHILD")
+        parent_tx.add_split(n=1, commit=True)
+        child_tx = StagedTransactionModel.objects.filter(parent=parent_tx).first()
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=setup["import_job"].ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API Staged Undo Child JE",
+        )
+        transaction_model = TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=setup["cash_account"],
+            amount=Decimal("10.00"),
+        )
+        child_tx.transaction_model = transaction_model
+        child_tx.save(update_fields=["transaction_model", "updated"])
+        child_tx = StagedTransactionModel.objects.get(uuid=child_tx.uuid)
+
+        self.assertTrue(child_tx.is_children())
+        self.assertTrue(child_tx.is_bundled())
+        self.assertFalse(child_tx.can_undo_import())
+
+    def test_migrate_transactions_with_split_txs_links_child_transactions(self):
+        setup = self.create_entity_setup(name="API Staged Split Import Entity")
+        parent_tx = self.create_staged_transaction(
+            setup,
+            fit_id="FIT-SPLIT-IMPORT",
+            amount="100.00",
+        )
+        parent_tx.add_split(n=1, commit=True)
+        children = list(StagedTransactionModel.objects.filter(parent=parent_tx))
+        children[0].amount_split = Decimal("60.00")
+        children[0].account_model = setup["income_account"]
+        children[0].unit_model = setup["unit_model"]
+        children[0].save(update_fields=["amount_split", "account_model", "unit_model", "updated"])
+        children[1].amount_split = Decimal("40.00")
+        children[1].account_model = setup["expense_account"]
+        children[1].unit_model = setup["unit_model"]
+        children[1].save(update_fields=["amount_split", "account_model", "unit_model", "updated"])
+        parent_tx = StagedTransactionModel.objects.get(uuid=parent_tx.uuid)
+
+        self.assertTrue(parent_tx.can_import())
+        parent_tx.migrate_transactions(split_txs=True)
+
+        parent_tx.refresh_from_db()
+        child_transaction_ids = list(
+            StagedTransactionModel.objects.filter(parent=parent_tx)
+            .values_list("transaction_model_id", flat=True)
+        )
+
+        self.assertIsNotNone(parent_tx.transaction_model_id)
+        self.assertEqual(len(child_transaction_ids), 2)
+        self.assertTrue(all(child_transaction_ids))

--- a/django_ledger/tests/api/test_staged_transaction_matching_api.py
+++ b/django_ledger/tests/api/test_staged_transaction_matching_api.py
@@ -1,0 +1,246 @@
+"""
+High-level API tests for StagedTransactionModel matching helpers.
+
+These tests cover candidate discovery and match/unmatch state without testing a
+full reconciliation workflow.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, CREDIT, DEBIT
+from django_ledger.models import BankAccountModel, JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.data_import import (
+    ImportJobModel,
+    StagedTransactionModel,
+    StagedTransactionModelValidationError,
+)
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.receipt import ReceiptModel
+
+
+class StagedTransactionMatchingAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_staged_matching_admin",
+            email="api-staged-matching-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self, year=2026, month=1, day=15):
+        if settings.USE_TZ:
+            return datetime(year, month, day, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, 12, 0)
+
+    def create_entity_setup(self, *, name="API Staged Matching Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income",
+            role="in_operational",
+            balance_type=CREDIT,
+            active=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+        )
+        bank_account.configure(entity_slug=entity_model, user_model=self.admin_user, commit=True)
+        import_job = ImportJobModel.objects.create(
+            description=f"{name} Import Job",
+            bank_account_model=bank_account,
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "bank_account": bank_account,
+            "import_job": import_job,
+        }
+
+    def create_posted_transaction(
+        self,
+        setup,
+        *,
+        account,
+        amount="125.00",
+        timestamp=None,
+        posted=True,
+    ):
+        ledger_model = LedgerModel.objects.create(
+            name="API Staged Matching Candidate Ledger",
+            entity=setup["entity_model"],
+            posted=posted,
+        )
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=timestamp or self.make_timestamp(),
+            description="API Staged Matching Candidate Journal Entry",
+        )
+        transaction_model = TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=account,
+            amount=Decimal(amount),
+            description="API staged matching candidate transaction.",
+        )
+        if posted:
+            JournalEntryModel.objects.filter(uuid=journal_entry.uuid).update(posted=True)
+            journal_entry.refresh_from_db()
+        return transaction_model
+
+    def create_staged_transaction(
+        self,
+        setup,
+        *,
+        fit_id="FIT-MATCH",
+        amount="125.00",
+        receipt_type=ReceiptModel.TRANSFER_RECEIPT,
+        matched_transaction_model=None,
+        matched_transaction=False,
+    ):
+        staged_tx = StagedTransactionModel.objects.create(
+            import_job=setup["import_job"],
+            fit_id=fit_id,
+            date_posted=date(2026, 1, 15),
+            amount=Decimal(amount),
+            name=f"API Staged Transaction {fit_id}",
+            memo=f"API staged transaction memo {fit_id}",
+            receipt_type=receipt_type,
+            matched_transaction_model=matched_transaction_model,
+            matched_transaction=matched_transaction,
+        )
+        return StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+    def test_get_match_candidates_returns_posted_same_account_same_amount_within_window(self):
+        setup = self.create_entity_setup()
+        candidate_tx = self.create_posted_transaction(
+            setup,
+            account=setup["cash_account"],
+            amount="125.00",
+            timestamp=self.make_timestamp(2026, 1, 16),
+        )
+        staged_tx = self.create_staged_transaction(setup)
+
+        candidate_qs = staged_tx.get_match_candidates_qs()
+
+        self.assertTrue(candidate_qs.filter(uuid=candidate_tx.uuid).exists())
+
+    def test_get_match_candidates_excludes_unposted_wrong_account_wrong_amount_or_outside_window(self):
+        setup = self.create_entity_setup()
+        matching_tx = self.create_posted_transaction(
+            setup,
+            account=setup["cash_account"],
+            amount="125.00",
+        )
+        unposted_tx = self.create_posted_transaction(
+            setup,
+            account=setup["cash_account"],
+            amount="125.00",
+            posted=False,
+        )
+        wrong_account_tx = self.create_posted_transaction(
+            setup,
+            account=setup["income_account"],
+            amount="125.00",
+        )
+        wrong_amount_tx = self.create_posted_transaction(
+            setup,
+            account=setup["cash_account"],
+            amount="126.00",
+        )
+        outside_window_tx = self.create_posted_transaction(
+            setup,
+            account=setup["cash_account"],
+            amount="125.00",
+            timestamp=self.make_timestamp(2026, 1, 25),
+        )
+        staged_tx = self.create_staged_transaction(setup)
+        candidate_ids = set(staged_tx.get_match_candidates_qs().values_list("uuid", flat=True))
+
+        self.assertIn(matching_tx.uuid, candidate_ids)
+        self.assertNotIn(unposted_tx.uuid, candidate_ids)
+        self.assertNotIn(wrong_account_tx.uuid, candidate_ids)
+        self.assertNotIn(wrong_amount_tx.uuid, candidate_ids)
+        self.assertNotIn(outside_window_tx.uuid, candidate_ids)
+
+    def test_can_match_and_ready_to_match_reflect_candidate_state(self):
+        setup = self.create_entity_setup()
+        candidate_tx = self.create_posted_transaction(
+            setup,
+            account=setup["cash_account"],
+            amount="125.00",
+        )
+        staged_tx = self.create_staged_transaction(
+            setup,
+            matched_transaction_model=candidate_tx,
+            matched_transaction=False,
+        )
+
+        self.assertTrue(staged_tx.can_match())
+        self.assertFalse(staged_tx.can_unmatch())
+        self.assertTrue(
+            StagedTransactionModel.objects.is_ready_to_match()
+            .filter(uuid=staged_tx.uuid)
+            .exists()
+        )
+
+    def test_can_unmatch_and_unmatch_clear_match_state(self):
+        setup = self.create_entity_setup()
+        candidate_tx = self.create_posted_transaction(
+            setup,
+            account=setup["cash_account"],
+            amount="125.00",
+        )
+        staged_tx = self.create_staged_transaction(
+            setup,
+            matched_transaction_model=candidate_tx,
+            matched_transaction=True,
+        )
+
+        self.assertTrue(staged_tx.can_unmatch())
+        self.assertTrue(staged_tx.has_match())
+
+        staged_tx.unmatch(commit=True)
+        staged_tx.refresh_from_db()
+
+        self.assertFalse(staged_tx.matched_transaction)
+        self.assertIsNone(staged_tx.matched_transaction_model_id)
+        self.assertFalse(staged_tx.has_match())
+
+    def test_unmatch_rejects_unmatched_transaction_by_default(self):
+        setup = self.create_entity_setup()
+        staged_tx = self.create_staged_transaction(setup)
+
+        with self.assertRaises(StagedTransactionModelValidationError):
+            staged_tx.unmatch()

--- a/django_ledger/tests/api/test_staged_transaction_queryset_api.py
+++ b/django_ledger/tests/api/test_staged_transaction_queryset_api.py
@@ -1,0 +1,296 @@
+"""
+High-level API behavior tests for StagedTransactionModel queryset helpers.
+
+These tests cover staged transaction scoping and public queryset filters without
+exercising migration, matching internals, split commit, receipt, or undo flows.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, CREDIT, DEBIT
+from django_ledger.models import BankAccountModel, JournalEntryModel, TransactionModel
+from django_ledger.models.data_import import (
+    ImportJobModel,
+    StagedTransactionModel,
+    StagedTransactionModelValidationError,
+)
+from django_ledger.models.entity import EntityModel
+
+
+class StagedTransactionQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_staged_transaction_queryset_admin",
+            email="api-staged-transaction-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_staged_transaction_queryset_other_admin",
+            email="api-staged-transaction-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Staged Transaction QuerySet Entity",
+        admin=None,
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role="in_operational",
+            balance_type=CREDIT,
+            active=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+            hidden=False,
+        )
+        bank_account.configure(
+            entity_slug=entity_model,
+            user_model=admin or self.admin_user,
+            commit=True,
+        )
+        bank_account.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "bank_account": bank_account,
+        }
+
+    def create_import_job(self, setup, *, description="API Staged Transaction QuerySet Job"):
+        import_job = ImportJobModel.objects.create(
+            description=description,
+            bank_account_model=setup["bank_account"],
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return import_job
+
+    def create_staged_transaction(
+        self,
+        import_job,
+        *,
+        fit_id,
+        amount="125.00",
+        account_model=None,
+        parent=None,
+        amount_split=None,
+        transaction_model=None,
+        matched_transaction_model=None,
+        matched_transaction=False,
+        bundle_split=True,
+    ):
+        return StagedTransactionModel.objects.create(
+            import_job=import_job,
+            parent=parent,
+            fit_id=fit_id,
+            date_posted=date(2026, 1, 15),
+            amount=None if parent else Decimal(amount),
+            amount_split=amount_split,
+            name=f"API Staged Transaction {fit_id}",
+            memo=f"API staged transaction memo {fit_id}",
+            account_model=account_model,
+            transaction_model=transaction_model,
+            matched_transaction_model=matched_transaction_model,
+            matched_transaction=matched_transaction,
+            bundle_split=bundle_split,
+        )
+
+    def create_transaction(self, import_job, account_model, *, amount="125.00"):
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=import_job.ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API Staged Transaction QuerySet Journal Entry",
+        )
+        return TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=account_model,
+            amount=Decimal(amount),
+            description="API staged transaction linked transaction.",
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API Staged Transaction Entity Scope A")
+        other_setup = self.create_entity_setup(
+            name="API Staged Transaction Entity Scope B",
+            admin=self.other_admin_user,
+        )
+        import_job = self.create_import_job(setup, description="API Staged Job A")
+        other_import_job = self.create_import_job(
+            other_setup,
+            description="API Staged Job B",
+        )
+        staged_tx = self.create_staged_transaction(import_job, fit_id="FIT-ENTITY-A")
+        other_staged_tx = self.create_staged_transaction(
+            other_import_job,
+            fit_id="FIT-ENTITY-B",
+        )
+        entity_model = setup["entity_model"]
+
+        for entity_lookup in (entity_model, entity_model.slug, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                staged_tx_qs = StagedTransactionModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(staged_tx_qs.filter(uuid=staged_tx.uuid).exists())
+                self.assertFalse(
+                    staged_tx_qs.filter(uuid=other_staged_tx.uuid).exists()
+                )
+
+    def test_for_entity_rejects_invalid_input(self):
+        with self.assertRaises(StagedTransactionModelValidationError):
+            StagedTransactionModel.objects.for_entity(object())
+
+    def test_for_import_job_accepts_model_and_uuid(self):
+        setup = self.create_entity_setup(name="API Staged Transaction Job Scope Entity")
+        import_job = self.create_import_job(setup, description="API Staged Job One")
+        other_import_job = self.create_import_job(
+            setup,
+            description="API Staged Job Two",
+        )
+        staged_tx = self.create_staged_transaction(import_job, fit_id="FIT-JOB-A")
+        other_staged_tx = self.create_staged_transaction(
+            other_import_job,
+            fit_id="FIT-JOB-B",
+        )
+
+        for import_job_lookup in (import_job, import_job.uuid):
+            with self.subTest(import_job_lookup=import_job_lookup):
+                staged_tx_qs = StagedTransactionModel.objects.for_import_job(
+                    import_job_lookup,
+                )
+
+                self.assertTrue(staged_tx_qs.filter(uuid=staged_tx.uuid).exists())
+                self.assertFalse(
+                    staged_tx_qs.filter(uuid=other_staged_tx.uuid).exists()
+                )
+
+    def test_for_import_job_rejects_invalid_input(self):
+        with self.assertRaises(StagedTransactionModelValidationError):
+            StagedTransactionModel.objects.for_import_job(object())
+
+    def test_pending_and_imported_filters_reflect_transaction_links_and_matches(self):
+        setup = self.create_entity_setup(name="API Staged Transaction Pending Entity")
+        import_job = self.create_import_job(setup)
+        pending_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-PENDING",
+        )
+        linked_transaction = self.create_transaction(
+            import_job,
+            setup["cash_account"],
+        )
+        imported_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-IMPORTED",
+            transaction_model=linked_transaction,
+        )
+
+        staged_tx_qs = StagedTransactionModel.objects.for_import_job(import_job)
+        pending_qs = staged_tx_qs.is_pending()
+        imported_qs = staged_tx_qs.is_imported()
+
+        self.assertTrue(pending_qs.filter(uuid=pending_tx.uuid).exists())
+        self.assertFalse(pending_qs.filter(uuid=imported_tx.uuid).exists())
+
+        self.assertTrue(imported_qs.filter(uuid=imported_tx.uuid).exists())
+        self.assertFalse(imported_qs.filter(uuid=pending_tx.uuid).exists())
+
+    def test_parent_filter_returns_only_parent_rows(self):
+        setup = self.create_entity_setup(name="API Staged Transaction Parent Entity")
+        import_job = self.create_import_job(setup)
+        parent_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-PARENT",
+        )
+        child_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-PARENT",
+            parent=parent_tx,
+            amount_split=Decimal("50.00"),
+        )
+
+        parent_qs = StagedTransactionModel.objects.for_import_job(import_job).is_parent()
+
+        self.assertTrue(parent_qs.filter(uuid=parent_tx.uuid).exists())
+        self.assertFalse(parent_qs.filter(uuid=child_tx.uuid).exists())
+
+    def test_ready_filters_return_ready_to_import_and_ready_to_match_rows(self):
+        setup = self.create_entity_setup(name="API Staged Transaction Ready Entity")
+        import_job = self.create_import_job(setup)
+        ready_to_import_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-READY-IMPORT",
+            account_model=setup["income_account"],
+        )
+        not_ready_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-NOT-READY",
+        )
+        matched_transaction = self.create_transaction(
+            import_job,
+            setup["cash_account"],
+        )
+        ready_to_match_tx = self.create_staged_transaction(
+            import_job,
+            fit_id="FIT-READY-MATCH",
+            matched_transaction_model=matched_transaction,
+            matched_transaction=False,
+        )
+
+        staged_tx_qs = StagedTransactionModel.objects.for_import_job(import_job)
+        ready_to_import_qs = staged_tx_qs.is_ready_to_import()
+        ready_to_match_qs = staged_tx_qs.is_ready_to_match()
+
+        self.assertTrue(
+            ready_to_import_qs.filter(uuid=ready_to_import_tx.uuid).exists()
+        )
+        self.assertFalse(ready_to_import_qs.filter(uuid=not_ready_tx.uuid).exists())
+        self.assertFalse(
+            ready_to_import_qs.filter(uuid=ready_to_match_tx.uuid).exists()
+        )
+
+        self.assertTrue(ready_to_match_qs.filter(uuid=ready_to_match_tx.uuid).exists())
+        self.assertFalse(ready_to_match_qs.filter(uuid=ready_to_import_tx.uuid).exists())
+        self.assertFalse(ready_to_match_qs.filter(uuid=not_ready_tx.uuid).exists())

--- a/django_ledger/tests/api/test_staged_transaction_split_commit_api.py
+++ b/django_ledger/tests/api/test_staged_transaction_split_commit_api.py
@@ -1,0 +1,283 @@
+"""
+High-level API behavior tests for StagedTransactionModel split helpers.
+
+These tests cover split state and commit-dictionary behavior without exercising
+migration, matching, receipts, undo, or URL helpers.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.io import ASSET_CA_CASH, CREDIT, DEBIT
+from django_ledger.models import BankAccountModel
+from django_ledger.models.data_import import (
+    ImportJobModel,
+    StagedTransactionModel,
+)
+from django_ledger.models.entity import EntityModel
+
+
+class StagedTransactionSplitCommitAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_staged_transaction_split_admin",
+            email="api-staged-transaction-split-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity_setup(
+        self,
+        *,
+        name="API Staged Transaction Split Entity",
+    ):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash Account",
+            role=ASSET_CA_CASH,
+            balance_type=DEBIT,
+            active=True,
+            is_role_default=True,
+        )
+        income_account = coa_model.create_account(
+            code="4010",
+            name=f"{name} Income Account",
+            role="in_operational",
+            balance_type=CREDIT,
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense Account",
+            role="ex_regular",
+            balance_type=DEBIT,
+            active=True,
+        )
+        bank_account = BankAccountModel(
+            name=f"{name} Bank Account",
+            account_model=cash_account,
+            account_number="000123456789",
+            routing_number="000111000",
+            active=True,
+            hidden=False,
+        )
+        bank_account.configure(
+            entity_slug=entity_model,
+            user_model=self.admin_user,
+            commit=True,
+        )
+        bank_account.refresh_from_db()
+        import_job = ImportJobModel.objects.create(
+            description=f"{name} Import Job",
+            bank_account_model=bank_account,
+        )
+        import_job.configure(commit=True)
+        import_job.refresh_from_db()
+        return {
+            "entity_model": entity_model,
+            "coa_model": coa_model,
+            "cash_account": cash_account,
+            "income_account": income_account,
+            "expense_account": expense_account,
+            "bank_account": bank_account,
+            "import_job": import_job,
+        }
+
+    def create_staged_transaction(
+        self,
+        import_job,
+        *,
+        fit_id="FIT-SPLIT",
+        amount="100.00",
+        account_model=None,
+        parent=None,
+        amount_split=None,
+    ):
+        return StagedTransactionModel.objects.create(
+            import_job=import_job,
+            parent=parent,
+            fit_id=fit_id,
+            date_posted=date(2026, 1, 15),
+            amount=None if parent else Decimal(amount),
+            amount_split=amount_split,
+            name=f"API Staged Transaction {fit_id}",
+            memo=f"API staged transaction memo {fit_id}",
+            account_model=account_model,
+        )
+
+    def get_annotated_staged_transaction(self, staged_tx):
+        return StagedTransactionModel.objects.get(uuid=staged_tx.uuid)
+
+    def test_add_split_commit_false_returns_unsaved_children(self):
+        setup = self.create_entity_setup(name="API Staged Split Commit False Entity")
+        parent_tx = self.create_staged_transaction(setup["import_job"])
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+
+        children = parent_tx.add_split(n=1, commit=False)
+
+        self.assertEqual(len(children), 2)
+        for child in children:
+            self.assertTrue(child._state.adding)
+            self.assertEqual(child.parent, parent_tx)
+            self.assertEqual(child.import_job_id, setup["import_job"].uuid)
+            self.assertEqual(child.fit_id, parent_tx.fit_id)
+            self.assertEqual(child.amount_split, Decimal("0.00"))
+
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+        self.assertFalse(parent_tx.has_children())
+        self.assertFalse(
+            StagedTransactionModel.objects.filter(parent=parent_tx).exists()
+        )
+
+    def test_add_split_commit_true_creates_children(self):
+        setup = self.create_entity_setup(name="API Staged Split Commit True Entity")
+        parent_tx = self.create_staged_transaction(setup["import_job"])
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+
+        children = parent_tx.add_split(n=1, commit=True)
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+        child_qs = StagedTransactionModel.objects.filter(parent=parent_tx)
+
+        self.assertEqual(len(children), 2)
+        self.assertEqual(child_qs.count(), 2)
+        self.assertTrue(parent_tx.has_children())
+        self.assertTrue(parent_tx.is_bundled())
+        for child in child_qs:
+            self.assertTrue(child.is_children())
+            self.assertEqual(child.parent_id, parent_tx.uuid)
+            self.assertEqual(child.import_job_id, setup["import_job"].uuid)
+
+    def test_add_split_on_already_split_parent_appends_one_child(self):
+        setup = self.create_entity_setup(name="API Staged Split Guard Entity")
+        parent_tx = self.create_staged_transaction(setup["import_job"])
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+        parent_tx.add_split(n=1, commit=True)
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+        children_count = StagedTransactionModel.objects.filter(parent=parent_tx).count()
+
+        additional_children = parent_tx.add_split(commit=True)
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+
+        self.assertEqual(len(additional_children), 1)
+        self.assertEqual(
+            children_count + 1,
+            StagedTransactionModel.objects.filter(parent=parent_tx).count(),
+        )
+
+    def test_split_amount_totals_and_mapping_state_helpers(self):
+        setup = self.create_entity_setup(name="API Staged Split Totals Entity")
+        parent_tx = self.create_staged_transaction(setup["import_job"], amount="100.00")
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+        parent_tx.add_split(n=1, commit=True)
+        children = list(StagedTransactionModel.objects.filter(parent=parent_tx))
+        children[0].amount_split = Decimal("60.00")
+        children[0].account_model = setup["income_account"]
+        children[0].save(update_fields=["amount_split", "account_model", "updated"])
+        children[1].amount_split = Decimal("40.00")
+        children[1].account_model = setup["expense_account"]
+        children[1].save(update_fields=["amount_split", "account_model", "updated"])
+
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+
+        self.assertTrue(parent_tx.is_total_amount_split())
+        self.assertTrue(parent_tx.are_all_children_mapped())
+
+        children[1].amount_split = Decimal("39.00")
+        children[1].account_model = None
+        children[1].save(update_fields=["amount_split", "account_model", "updated"])
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+
+        self.assertFalse(parent_tx.is_total_amount_split())
+        self.assertFalse(parent_tx.are_all_children_mapped())
+
+    def test_commit_dict_for_positive_and_negative_amounts_uses_expected_debit_credit_sides(self):
+        setup = self.create_entity_setup(name="API Staged Commit Direction Entity")
+        positive_tx = self.create_staged_transaction(
+            setup["import_job"],
+            fit_id="FIT-POSITIVE",
+            amount="125.00",
+            account_model=setup["income_account"],
+        )
+        negative_tx = self.create_staged_transaction(
+            setup["import_job"],
+            fit_id="FIT-NEGATIVE",
+            amount="-75.00",
+            account_model=setup["expense_account"],
+        )
+        positive_tx = self.get_annotated_staged_transaction(positive_tx)
+        negative_tx = self.get_annotated_staged_transaction(negative_tx)
+
+        positive_commit = positive_tx.commit_dict()[0]
+        negative_commit = negative_tx.commit_dict()[0]
+
+        self.assertEqual(positive_commit[0]["account"], setup["cash_account"])
+        self.assertEqual(positive_commit[0]["amount"], Decimal("125.00"))
+        self.assertEqual(positive_commit[0]["tx_type"], DEBIT)
+        self.assertEqual(positive_commit[1]["account"], setup["income_account"])
+        self.assertEqual(positive_commit[1]["amount"], Decimal("125.00"))
+        self.assertEqual(positive_commit[1]["amount_staged"], Decimal("125.00"))
+        self.assertEqual(positive_commit[1]["tx_type"], CREDIT)
+
+        self.assertEqual(negative_commit[0]["account"], setup["cash_account"])
+        self.assertEqual(negative_commit[0]["amount"], Decimal("75.00"))
+        self.assertEqual(negative_commit[0]["tx_type"], CREDIT)
+        self.assertEqual(negative_commit[1]["account"], setup["expense_account"])
+        self.assertEqual(negative_commit[1]["amount"], Decimal("75.00"))
+        self.assertEqual(negative_commit[1]["amount_staged"], Decimal("-75.00"))
+        self.assertEqual(negative_commit[1]["tx_type"], DEBIT)
+
+    def test_commit_dict_split_txs_uses_child_amounts_and_accounts(self):
+        setup = self.create_entity_setup(name="API Staged Split Commit Dict Entity")
+        parent_tx = self.create_staged_transaction(setup["import_job"], amount="100.00")
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+        parent_tx.add_split(n=1, commit=True)
+        children = list(StagedTransactionModel.objects.filter(parent=parent_tx).order_by("uuid"))
+        children[0].amount_split = Decimal("60.00")
+        children[0].account_model = setup["income_account"]
+        children[0].save(update_fields=["amount_split", "account_model", "updated"])
+        children[1].amount_split = Decimal("40.00")
+        children[1].account_model = setup["expense_account"]
+        children[1].save(update_fields=["amount_split", "account_model", "updated"])
+        parent_tx = self.get_annotated_staged_transaction(parent_tx)
+
+        split_commit = parent_tx.commit_dict(split_txs=True)
+
+        self.assertEqual(len(split_commit), 2)
+
+        child_entries_by_account = {
+            entry[1]["account"].uuid: entry
+            for entry in split_commit
+        }
+
+        income_entry = child_entries_by_account[setup["income_account"].uuid]
+        expense_entry = child_entries_by_account[setup["expense_account"].uuid]
+
+        self.assertEqual(income_entry[0]["account"], setup["cash_account"])
+        self.assertEqual(income_entry[0]["amount"], Decimal("60.00"))
+        self.assertEqual(income_entry[0]["tx_type"], DEBIT)
+        self.assertEqual(income_entry[1]["amount"], Decimal("60.00"))
+        self.assertEqual(income_entry[1]["amount_staged"], Decimal("60.00"))
+        self.assertEqual(income_entry[1]["tx_type"], CREDIT)
+
+        self.assertEqual(expense_entry[0]["account"], setup["cash_account"])
+        self.assertEqual(expense_entry[0]["amount"], Decimal("40.00"))
+        self.assertEqual(expense_entry[0]["tx_type"], DEBIT)
+        self.assertEqual(expense_entry[1]["amount"], Decimal("40.00"))
+        self.assertEqual(expense_entry[1]["amount_staged"], Decimal("40.00"))
+        self.assertEqual(expense_entry[1]["tx_type"], CREDIT)

--- a/django_ledger/tests/api/test_transaction_api.py
+++ b/django_ledger/tests/api/test_transaction_api.py
@@ -1,0 +1,265 @@
+"""
+High-level API behavior tests for TransactionModel.
+
+This file is part of a human-reviewed, AI-assisted contribution using
+OpenAI GPT-5.5. The goal is to strengthen deterministic business-logic
+coverage around Django Ledger's public/high-level API contracts without
+replacing or reorganizing the existing test suite.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+
+from django_ledger.models import AccountModel, JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryValidationError
+from django_ledger.models.transactions import TransactionModelValidationError
+
+
+class TransactionHighLevelAPITest(TestCase):
+    """
+    High-level behavior tests for TransactionModel public API contracts.
+
+    These tests intentionally avoid the randomized/populated test base. The
+    purpose is to document deterministic double-entry invariants that should
+    remain true across refactors.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.user = user_model.objects.create_user(
+            username="api_transaction_contract_user",
+            email="api-transaction-contract-user@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_with_accounting_setup(self, *, name="API Transaction Contract Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name="API Transaction Contract CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        cash_account = coa_model.create_account(
+            code="1010",
+            name="API Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        expense_account = coa_model.create_account(
+            code="6010",
+            name="API Expense Account",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+
+        ledger_model = LedgerModel.objects.create(
+            name="API Transaction Contract Ledger",
+            ledger_xid="api-transaction-contract-ledger",
+            entity=entity_model,
+        )
+
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description="API Transaction Contract Journal Entry",
+        )
+
+        return entity_model, coa_model, ledger_model, journal_entry, cash_account, expense_account
+
+    def test_transaction_requires_journal_entry(self):
+        _entity_model, _coa_model, _ledger_model, _journal_entry, cash_account, _expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        with self.assertRaises(TransactionModel.journal_entry.RelatedObjectDoesNotExist):
+            with transaction.atomic():
+                TransactionModel.objects.create(
+                    tx_type=TransactionModel.DEBIT,
+                    account=cash_account,
+                    amount=Decimal("10.00"),
+                    description="Orphan transaction should fail.",
+                )
+
+    def test_transaction_amount_cannot_be_negative(self):
+        _entity_model, _coa_model, _ledger_model, journal_entry, cash_account, _expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        tx_model = TransactionModel(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=cash_account,
+            amount=Decimal("-10.00"),
+            description="Negative amount should fail validation.",
+        )
+
+        with self.assertRaises(ValidationError):
+            tx_model.full_clean()
+
+    def test_transaction_type_must_be_debit_or_credit(self):
+        _entity_model, _coa_model, _ledger_model, journal_entry, cash_account, _expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        tx_model = TransactionModel(
+            tx_type="invalid",
+            journal_entry=journal_entry,
+            account=cash_account,
+            amount=Decimal("10.00"),
+            description="Invalid tx_type should fail validation.",
+        )
+
+        with self.assertRaises(ValidationError):
+            tx_model.full_clean()
+
+    def test_root_account_cannot_receive_transaction(self):
+        entity_model, _coa_model, _ledger_model, journal_entry, _cash_account, _expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        root_account = AccountModel.objects.for_entity(entity_model).is_coa_root().first()
+
+        with self.assertRaises(ValidationError):
+            with transaction.atomic():
+                TransactionModel.objects.create(
+                    tx_type=TransactionModel.DEBIT,
+                    journal_entry=journal_entry,
+                    account=root_account,
+                    amount=Decimal("10.00"),
+                    description="Root account should not receive transactions.",
+                )
+
+    def test_locked_journal_entry_rejects_new_transaction(self):
+        _entity_model, _coa_model, _ledger_model, journal_entry, cash_account, _expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        journal_entry.locked = True
+        journal_entry.save(update_fields=["locked"])
+
+        with self.assertRaises(TransactionModelValidationError):
+            with transaction.atomic():
+                TransactionModel.objects.create(
+                    tx_type=TransactionModel.DEBIT,
+                    journal_entry=journal_entry,
+                    account=cash_account,
+                    amount=Decimal("10.00"),
+                    description="Locked JE should reject transactions.",
+                )
+
+    def test_balanced_transactions_verify_successfully(self):
+        _entity_model, _coa_model, _ledger_model, journal_entry, cash_account, expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=expense_account,
+            amount=Decimal("100.00"),
+            description="Expense debit.",
+        )
+
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=cash_account,
+            amount=Decimal("100.00"),
+            description="Cash credit.",
+        )
+
+        journal_entry.verify()
+
+    def test_imbalanced_transactions_fail_verification(self):
+        _entity_model, _coa_model, _ledger_model, journal_entry, cash_account, expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=expense_account,
+            amount=Decimal("100.00"),
+            description="Expense debit.",
+        )
+
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=cash_account,
+            amount=Decimal("90.00"),
+            description="Cash credit.",
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.verify()
+
+    def test_transactions_in_same_journal_entry_must_use_single_coa(self):
+        _entity_model, _coa_model, _ledger_model, journal_entry, _cash_account, expense_account = (
+            self.create_entity_with_accounting_setup()
+        )
+
+        other_entity_model = EntityModel.create_entity(
+            name="API Other Entity",
+            admin=self.user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+
+        other_coa_model = other_entity_model.create_chart_of_accounts(
+            coa_name="API Other CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+
+        other_cash_account = other_coa_model.create_account(
+            code="1010",
+            name="API Other Cash Account",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=expense_account,
+            amount=Decimal("100.00"),
+            description="Expense debit.",
+        )
+
+        TransactionModel.objects.create(
+            tx_type=TransactionModel.CREDIT,
+            journal_entry=journal_entry,
+            account=other_cash_account,
+            amount=Decimal("100.00"),
+            description="Other entity cash credit.",
+        )
+
+        with self.assertRaises(JournalEntryValidationError):
+            journal_entry.verify()

--- a/django_ledger/tests/api/test_transaction_date_status_api.py
+++ b/django_ledger/tests/api/test_transaction_date_status_api.py
@@ -1,0 +1,222 @@
+"""
+High-level API behavior tests for TransactionModel date and status filters.
+
+These tests cover date boundaries, closing-entry filters, and cleared/
+reconciled status filters without exercising relation or URL helpers.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+
+
+class TransactionDateStatusAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_tx_date_status_admin",
+            email="api-tx-date-status-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self, year=2026, month=1, day=15, hour=12):
+        if settings.USE_TZ:
+            return datetime(year, month, day, hour, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(year, month, day, hour, 0)
+
+    def create_entity_setup(self, *, name="API Transaction Date Status Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+        }
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API Transaction Date Status Journal Entry",
+        timestamp=None,
+        is_closing_entry=False,
+    ):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=timestamp if timestamp is not None else self.make_timestamp(),
+            description=description,
+            is_closing_entry=is_closing_entry,
+        )
+
+    def create_transaction(
+        self,
+        setup,
+        *,
+        description="API Transaction Date Status Transaction",
+        timestamp=None,
+        is_closing_entry=False,
+        cleared=False,
+        reconciled=False,
+    ):
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description=f"{description} Journal Entry",
+            timestamp=timestamp,
+            is_closing_entry=is_closing_entry,
+        )
+        return TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=setup["expense_account"],
+            amount=Decimal("10.00"),
+            description=description,
+            cleared=cleared,
+            reconciled=reconciled,
+        )
+
+    def transaction_ids(self, queryset):
+        return set(queryset.values_list("uuid", flat=True))
+
+    def test_from_date_filters_date_datetime_and_iso_string_inclusively(self):
+        setup = self.create_entity_setup(name="API TX From Date Entity")
+        before_tx = self.create_transaction(
+            setup,
+            description="API TX Before From Date",
+            timestamp=self.make_timestamp(2026, 1, 14),
+        )
+        boundary_tx = self.create_transaction(
+            setup,
+            description="API TX Boundary From Date",
+            timestamp=self.make_timestamp(2026, 1, 15),
+        )
+        after_tx = self.create_transaction(
+            setup,
+            description="API TX After From Date",
+            timestamp=self.make_timestamp(2026, 1, 16),
+        )
+        expected_ids = {boundary_tx.uuid, after_tx.uuid}
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        for from_date in (
+            self.make_timestamp(2026, 1, 15).date(),
+            self.make_timestamp(2026, 1, 15),
+            "2026-01-15",
+        ):
+            with self.subTest(from_date=from_date):
+                filtered_qs = transaction_qs.from_date(from_date)
+
+                self.assertEqual(expected_ids, self.transaction_ids(filtered_qs))
+                self.assertNotIn(before_tx.uuid, self.transaction_ids(filtered_qs))
+
+    def test_to_date_filters_date_datetime_and_iso_string_inclusively(self):
+        setup = self.create_entity_setup(name="API TX To Date Entity")
+        before_tx = self.create_transaction(
+            setup,
+            description="API TX Before To Date",
+            timestamp=self.make_timestamp(2026, 1, 14),
+        )
+        boundary_tx = self.create_transaction(
+            setup,
+            description="API TX Boundary To Date",
+            timestamp=self.make_timestamp(2026, 1, 15),
+        )
+        after_tx = self.create_transaction(
+            setup,
+            description="API TX After To Date",
+            timestamp=self.make_timestamp(2026, 1, 16),
+        )
+        expected_ids = {before_tx.uuid, boundary_tx.uuid}
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        for to_date in (
+            self.make_timestamp(2026, 1, 15).date(),
+            self.make_timestamp(2026, 1, 15),
+            "2026-01-15",
+        ):
+            with self.subTest(to_date=to_date):
+                filtered_qs = transaction_qs.to_date(to_date)
+
+                self.assertEqual(expected_ids, self.transaction_ids(filtered_qs))
+                self.assertNotIn(after_tx.uuid, self.transaction_ids(filtered_qs))
+
+    def test_closing_entry_filters_return_matching_transactions(self):
+        setup = self.create_entity_setup(name="API TX Closing Filter Entity")
+        closing_tx = self.create_transaction(
+            setup,
+            description="API TX Closing Entry",
+            is_closing_entry=True,
+        )
+        regular_tx = self.create_transaction(
+            setup,
+            description="API TX Regular Entry",
+            is_closing_entry=False,
+        )
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        self.assertEqual({closing_tx.uuid}, self.transaction_ids(transaction_qs.is_closing_entry()))
+        self.assertEqual({regular_tx.uuid}, self.transaction_ids(transaction_qs.not_closing_entry()))
+
+    def test_cleared_filters_return_matching_transactions(self):
+        setup = self.create_entity_setup(name="API TX Cleared Filter Entity")
+        cleared_tx = self.create_transaction(
+            setup,
+            description="API TX Cleared",
+            cleared=True,
+        )
+        uncleared_tx = self.create_transaction(
+            setup,
+            description="API TX Not Cleared",
+            cleared=False,
+        )
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        self.assertEqual({cleared_tx.uuid}, self.transaction_ids(transaction_qs.is_cleared()))
+        self.assertEqual({uncleared_tx.uuid}, self.transaction_ids(transaction_qs.not_cleared()))
+
+    def test_reconciled_filters_return_matching_transactions(self):
+        setup = self.create_entity_setup(name="API TX Reconciled Filter Entity")
+        reconciled_tx = self.create_transaction(
+            setup,
+            description="API TX Reconciled",
+            reconciled=True,
+        )
+        unreconciled_tx = self.create_transaction(
+            setup,
+            description="API TX Not Reconciled",
+            reconciled=False,
+        )
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        self.assertEqual({reconciled_tx.uuid}, self.transaction_ids(transaction_qs.is_reconciled()))
+        self.assertEqual({unreconciled_tx.uuid}, self.transaction_ids(transaction_qs.not_reconciled()))

--- a/django_ledger/tests/api/test_transaction_document_relation_api.py
+++ b/django_ledger/tests/api/test_transaction_document_relation_api.py
@@ -1,0 +1,197 @@
+"""
+High-level API behavior tests for TransactionModel document relation filters.
+
+These tests use draft document wrapper ledgers only; they do not exercise bill
+or invoice lifecycle behavior.
+"""
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import BillModel, InvoiceModel, JournalEntryModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+
+
+class TransactionDocumentRelationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_tx_document_relation_admin",
+            email="api-tx-document-relation-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Transaction Document Relation Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        prepaid_account = coa_model.create_account(
+            code="1310",
+            name=f"{name} Prepaid",
+            role="asset_ca_prepaid",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        payable_account = coa_model.create_account(
+            code="2010",
+            name=f"{name} Accounts Payable",
+            role="lia_cl_acc_payable",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+            is_role_default=True,
+        )
+        deferred_revenue_account = coa_model.create_account(
+            code="2310",
+            name=f"{name} Deferred Revenue",
+            role="lia_cl_def_rev",
+            balance_type="credit",
+            active=True,
+            is_role_default=True,
+        )
+        customer_model = entity_model.create_customer(
+            {
+                "customer_name": f"{name} Customer",
+                "description": f"{name} customer",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+        vendor_model = entity_model.create_vendor(
+            {
+                "vendor_name": f"{name} Vendor",
+                "description": f"{name} vendor",
+                "active": True,
+                "hidden": False,
+            },
+            commit=True,
+        )
+
+        return {
+            "cash_account": cash_account,
+            "customer_model": customer_model,
+            "deferred_revenue_account": deferred_revenue_account,
+            "entity_model": entity_model,
+            "payable_account": payable_account,
+            "prepaid_account": prepaid_account,
+            "receivable_account": receivable_account,
+            "vendor_model": vendor_model,
+        }
+
+    def create_bill(self, setup, *, suffix):
+        return setup["entity_model"].create_bill(
+            vendor_model=setup["vendor_model"],
+            terms=BillModel.TERMS_NET_30,
+            date_draft=date(2026, 1, 15),
+            ledger_name=f"API TX Bill Relation Ledger {suffix}",
+            commit=True,
+        )
+
+    def create_invoice(self, setup, *, suffix):
+        return setup["entity_model"].create_invoice(
+            customer_model=setup["customer_model"],
+            terms=InvoiceModel.TERMS_NET_30,
+            date_draft=date(2026, 1, 15),
+            ledger_name=f"API TX Invoice Relation Ledger {suffix}",
+            commit=True,
+        )
+
+    def create_transaction_for_document(self, document_model, *, account, description):
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=document_model.ledger,
+            timestamp=self.make_timestamp(),
+            description=f"{description} Journal Entry",
+        )
+        return TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=account,
+            amount=Decimal("10.00"),
+            description=description,
+        )
+
+    def transaction_ids(self, queryset):
+        return set(queryset.values_list("uuid", flat=True))
+
+    def test_for_bill_filters_by_bill_model_uuid_and_uuid_string(self):
+        setup = self.create_entity_setup(name="API TX Bill Relation Entity")
+        bill_a = self.create_bill(setup, suffix="A")
+        bill_b = self.create_bill(setup, suffix="B")
+        bill_a_tx = self.create_transaction_for_document(
+            bill_a,
+            account=setup["prepaid_account"],
+            description="API TX Bill Relation A",
+        )
+        bill_b_tx = self.create_transaction_for_document(
+            bill_b,
+            account=setup["prepaid_account"],
+            description="API TX Bill Relation B",
+        )
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        for bill_lookup in (bill_a, bill_a.uuid, str(bill_a.uuid)):
+            with self.subTest(bill_lookup=bill_lookup):
+                bill_qs = transaction_qs.for_bill(bill_lookup)
+
+                self.assertEqual({bill_a_tx.uuid}, self.transaction_ids(bill_qs))
+                self.assertNotIn(bill_b_tx.uuid, self.transaction_ids(bill_qs))
+
+    def test_for_invoice_filters_by_invoice_model_uuid_and_uuid_string(self):
+        setup = self.create_entity_setup(name="API TX Invoice Relation Entity")
+        invoice_a = self.create_invoice(setup, suffix="A")
+        invoice_b = self.create_invoice(setup, suffix="B")
+        invoice_a_tx = self.create_transaction_for_document(
+            invoice_a,
+            account=setup["receivable_account"],
+            description="API TX Invoice Relation A",
+        )
+        invoice_b_tx = self.create_transaction_for_document(
+            invoice_b,
+            account=setup["receivable_account"],
+            description="API TX Invoice Relation B",
+        )
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        for invoice_lookup in (invoice_a, invoice_a.uuid, str(invoice_a.uuid)):
+            with self.subTest(invoice_lookup=invoice_lookup):
+                invoice_qs = transaction_qs.for_invoice(invoice_lookup)
+
+                self.assertEqual({invoice_a_tx.uuid}, self.transaction_ids(invoice_qs))
+                self.assertNotIn(invoice_b_tx.uuid, self.transaction_ids(invoice_qs))

--- a/django_ledger/tests/api/test_transaction_filter_api.py
+++ b/django_ledger/tests/api/test_transaction_filter_api.py
@@ -1,0 +1,396 @@
+"""
+High-level API behavior tests for TransactionModel account, role, unit, and
+activity filters.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.journal_entry import JournalEntryModel as JournalEntryModelClass
+from django_ledger.models.transactions import TransactionModelValidationError
+from django_ledger.models.unit import EntityUnitModel
+
+
+class TransactionFilterAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_tx_filter_admin",
+            email="api-tx-filter-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Transaction Filter Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        receivable_account = coa_model.create_account(
+            code="1210",
+            name=f"{name} Receivable",
+            role="asset_ca_recv",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+        return {
+            "cash_account": cash_account,
+            "entity_model": entity_model,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+            "receivable_account": receivable_account,
+        }
+
+    def create_unit(self, setup, *, name, slug, document_prefix):
+        unit_model = EntityUnitModel.add_root(
+            name=name,
+            slug=slug,
+            entity=setup["entity_model"],
+            document_prefix=document_prefix,
+            active=True,
+            hidden=False,
+        )
+        unit_model.refresh_from_db()
+        return unit_model
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API Transaction Filter Journal Entry",
+        entity_unit=None,
+        activity=None,
+    ):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            entity_unit=entity_unit,
+            timestamp=self.make_timestamp(),
+            description=description,
+            activity=activity,
+        )
+
+    def create_transaction(
+        self,
+        journal_entry,
+        *,
+        account,
+        tx_type=TransactionModel.DEBIT,
+        description="API Transaction Filter Transaction",
+    ):
+        return TransactionModel.objects.create(
+            tx_type=tx_type,
+            journal_entry=journal_entry,
+            account=account,
+            amount=Decimal("10.00"),
+            description=description,
+        )
+
+    def create_transaction_with_account(self, setup, *, account, description):
+        journal_entry = self.create_journal_entry(
+            setup["ledger_model"],
+            description=f"{description} Journal Entry",
+        )
+        return self.create_transaction(
+            journal_entry,
+            account=account,
+            description=description,
+        )
+
+    def transaction_ids(self, queryset):
+        return set(queryset.values_list("uuid", flat=True))
+
+    def test_for_accounts_filters_by_account_models(self):
+        setup = self.create_entity_setup(name="API TX Account Model Filter Entity")
+        cash_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["cash_account"],
+            description="API TX Cash Account Model",
+        )
+        expense_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["expense_account"],
+            description="API TX Expense Account Model",
+        )
+        receivable_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["receivable_account"],
+            description="API TX Receivable Account Model",
+        )
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_accounts([
+            setup["cash_account"],
+            setup["expense_account"],
+        ])
+
+        self.assertEqual({cash_tx.uuid, expense_tx.uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(receivable_tx.uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_accounts_filters_by_account_uuid_objects(self):
+        setup = self.create_entity_setup(name="API TX Account UUID Filter Entity")
+        cash_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["cash_account"],
+            description="API TX Cash Account UUID",
+        )
+        expense_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["expense_account"],
+            description="API TX Expense Account UUID",
+        )
+        receivable_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["receivable_account"],
+            description="API TX Receivable Account UUID",
+        )
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_accounts([
+            setup["cash_account"].uuid,
+            setup["expense_account"].uuid,
+        ])
+
+        self.assertEqual({cash_tx.uuid, expense_tx.uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(receivable_tx.uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_accounts_filters_by_account_code_strings(self):
+        setup = self.create_entity_setup(name="API TX Account Code Filter Entity")
+        cash_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["cash_account"],
+            description="API TX Cash Account Code",
+        )
+        expense_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["expense_account"],
+            description="API TX Expense Account Code",
+        )
+        receivable_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["receivable_account"],
+            description="API TX Receivable Account Code",
+        )
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_accounts([
+            setup["cash_account"].code,
+            setup["expense_account"].code,
+        ])
+
+        self.assertEqual({cash_tx.uuid, expense_tx.uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(receivable_tx.uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_accounts_rejects_invalid_input_and_empty_list(self):
+        setup = self.create_entity_setup(name="API TX Account Invalid Filter Entity")
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"])
+
+        for account_list in (object(), [], [object()]):
+            with self.subTest(account_list=account_list):
+                with self.assertRaises(TransactionModelValidationError):
+                    transaction_qs.for_accounts(account_list)
+
+    def test_for_roles_filters_by_single_role_string(self):
+        setup = self.create_entity_setup(name="API TX Role String Filter Entity")
+        expense_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["expense_account"],
+            description="API TX Expense Role String",
+        )
+        cash_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["cash_account"],
+            description="API TX Cash Role String",
+        )
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_roles("ex_regular")
+
+        self.assertEqual({expense_tx.uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(cash_tx.uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_roles_filters_by_list_and_set_of_roles(self):
+        setup = self.create_entity_setup(name="API TX Role Collection Filter Entity")
+        expense_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["expense_account"],
+            description="API TX Expense Role Collection",
+        )
+        cash_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["cash_account"],
+            description="API TX Cash Role Collection",
+        )
+        receivable_tx = self.create_transaction_with_account(
+            setup,
+            account=setup["receivable_account"],
+            description="API TX Receivable Role Collection",
+        )
+
+        expected_ids = {expense_tx.uuid, cash_tx.uuid}
+        role_list_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_roles([
+            "ex_regular",
+            "asset_ca_cash",
+        ])
+        role_set_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_roles({
+            "ex_regular",
+            "asset_ca_cash",
+        })
+
+        self.assertEqual(expected_ids, self.transaction_ids(role_list_qs))
+        self.assertEqual(expected_ids, self.transaction_ids(role_set_qs))
+        self.assertNotIn(receivable_tx.uuid, self.transaction_ids(role_list_qs))
+
+    def test_for_unit_filters_by_entity_unit_instance_and_slug(self):
+        setup = self.create_entity_setup(name="API TX Unit Filter Entity")
+        unit_a = self.create_unit(
+            setup,
+            name="API TX Unit A",
+            slug="api-tx-unit-a",
+            document_prefix="TUA",
+        )
+        unit_b = self.create_unit(
+            setup,
+            name="API TX Unit B",
+            slug="api-tx-unit-b",
+            document_prefix="TUB",
+        )
+        unit_a_je = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API TX Unit A Journal Entry",
+            entity_unit=unit_a,
+        )
+        unit_b_je = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API TX Unit B Journal Entry",
+            entity_unit=unit_b,
+        )
+        unit_a_tx = self.create_transaction(
+            unit_a_je,
+            account=setup["expense_account"],
+            description="API TX Unit A",
+        )
+        unit_b_tx = self.create_transaction(
+            unit_b_je,
+            account=setup["expense_account"],
+            description="API TX Unit B",
+        )
+
+        unit_instance_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_unit(unit_a)
+        unit_slug_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_unit(unit_a.slug)
+
+        self.assertEqual({unit_a_tx.uuid}, self.transaction_ids(unit_instance_qs))
+        self.assertEqual({unit_a_tx.uuid}, self.transaction_ids(unit_slug_qs))
+        self.assertNotIn(unit_b_tx.uuid, self.transaction_ids(unit_instance_qs))
+
+    def test_for_activity_filters_by_single_activity_string(self):
+        setup = self.create_entity_setup(name="API TX Activity String Filter Entity")
+        operating_je = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API TX Operating Activity JE",
+            activity=JournalEntryModelClass.OPERATING_ACTIVITY,
+        )
+        financing_je = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API TX Financing Activity JE",
+            activity=JournalEntryModelClass.FINANCING_EQUITY,
+        )
+        operating_tx = self.create_transaction(
+            operating_je,
+            account=setup["expense_account"],
+            description="API TX Operating Activity",
+        )
+        financing_tx = self.create_transaction(
+            financing_je,
+            account=setup["cash_account"],
+            description="API TX Financing Activity",
+        )
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_activity(
+            JournalEntryModelClass.OPERATING_ACTIVITY,
+        )
+
+        self.assertEqual({operating_tx.uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(financing_tx.uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_activity_filters_by_list_and_set_of_activities(self):
+        setup = self.create_entity_setup(name="API TX Activity Collection Filter Entity")
+        operating_je = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API TX Operating Activity Collection JE",
+            activity=JournalEntryModelClass.OPERATING_ACTIVITY,
+        )
+        financing_je = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API TX Financing Activity Collection JE",
+            activity=JournalEntryModelClass.FINANCING_EQUITY,
+        )
+        investing_je = self.create_journal_entry(
+            setup["ledger_model"],
+            description="API TX Investing Activity Collection JE",
+            activity=JournalEntryModelClass.INVESTING_PPE,
+        )
+        operating_tx = self.create_transaction(
+            operating_je,
+            account=setup["expense_account"],
+            description="API TX Operating Activity Collection",
+        )
+        financing_tx = self.create_transaction(
+            financing_je,
+            account=setup["cash_account"],
+            description="API TX Financing Activity Collection",
+        )
+        investing_tx = self.create_transaction(
+            investing_je,
+            account=setup["receivable_account"],
+            description="API TX Investing Activity Collection",
+        )
+        expected_ids = {operating_tx.uuid, financing_tx.uuid}
+
+        activity_list_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_activity([
+            JournalEntryModelClass.OPERATING_ACTIVITY,
+            JournalEntryModelClass.FINANCING_EQUITY,
+        ])
+        activity_set_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_activity({
+            JournalEntryModelClass.OPERATING_ACTIVITY,
+            JournalEntryModelClass.FINANCING_EQUITY,
+        })
+
+        self.assertEqual(expected_ids, self.transaction_ids(activity_list_qs))
+        self.assertEqual(expected_ids, self.transaction_ids(activity_set_qs))
+        self.assertNotIn(investing_tx.uuid, self.transaction_ids(activity_list_qs))

--- a/django_ledger/tests/api/test_transaction_helpers_api.py
+++ b/django_ledger/tests/api/test_transaction_helpers_api.py
@@ -1,0 +1,214 @@
+"""
+High-level API behavior tests for TransactionModel helper properties and URLs.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.unit import EntityUnitModel
+
+
+class TransactionHelpersAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_tx_helpers_admin",
+            email="api-tx-helpers-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Transaction Helpers Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+
+        return {
+            "cash_account": cash_account,
+            "coa_model": coa_model,
+            "entity_model": entity_model,
+            "expense_account": expense_account,
+            "ledger_model": ledger_model,
+        }
+
+    def create_unit(self, setup):
+        unit_model = EntityUnitModel.add_root(
+            name="API Transaction Helpers Unit",
+            slug="api-transaction-helpers-unit",
+            entity=setup["entity_model"],
+            document_prefix="THU",
+            active=True,
+            hidden=False,
+        )
+        unit_model.refresh_from_db()
+        return unit_model
+
+    def create_journal_entry(self, setup, *, entity_unit=None):
+        return JournalEntryModel.objects.create(
+            ledger=setup["ledger_model"],
+            entity_unit=entity_unit,
+            timestamp=self.make_timestamp(),
+            description="API Transaction Helpers Journal Entry",
+        )
+
+    def create_transaction(
+        self,
+        journal_entry,
+        *,
+        account,
+        tx_type=TransactionModel.DEBIT,
+        amount=Decimal("10.00"),
+        description="API Transaction Helpers Transaction",
+    ):
+        return TransactionModel.objects.create(
+            tx_type=tx_type,
+            journal_entry=journal_entry,
+            account=account,
+            amount=amount,
+            description=description,
+        )
+
+    def test_with_annotated_details_exposes_unit_account_and_timestamp_fields(self):
+        setup = self.create_entity_setup(name="API TX Annotated Details Entity")
+        unit_model = self.create_unit(setup)
+        journal_entry = self.create_journal_entry(setup, entity_unit=unit_model)
+        transaction_model = self.create_transaction(
+            journal_entry,
+            account=setup["expense_account"],
+            description="API TX Annotated Details",
+        )
+
+        annotated_transaction = TransactionModel.objects.with_annotated_details().get(
+            uuid=transaction_model.uuid,
+        )
+
+        self.assertEqual(unit_model.name, annotated_transaction.entity_unit_name)
+        self.assertEqual(setup["expense_account"].code, annotated_transaction.account_code)
+        self.assertEqual(setup["expense_account"].name, annotated_transaction.account_name)
+        self.assertEqual(journal_entry.timestamp, annotated_transaction.timestamp)
+
+    def test_manager_annotations_and_plain_instance_fallbacks_expose_related_identifiers(self):
+        setup = self.create_entity_setup(name="API TX Helper Property Entity")
+        journal_entry = self.create_journal_entry(setup)
+        transaction_model = self.create_transaction(
+            journal_entry,
+            account=setup["expense_account"],
+            description="API TX Helper Property",
+        )
+
+        annotated_transaction = TransactionModel.objects.get(uuid=transaction_model.uuid)
+        plain_transaction = TransactionModel(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=setup["expense_account"],
+            amount=Decimal("10.00"),
+            description="API TX Plain Helper Property",
+        )
+
+        self.assertEqual(setup["entity_model"].slug, annotated_transaction.entity_slug)
+        self.assertEqual(setup["ledger_model"].uuid, annotated_transaction.ledger_uuid)
+        self.assertEqual(setup["coa_model"].uuid, annotated_transaction.coa_id)
+
+        self.assertEqual(setup["entity_model"].slug, plain_transaction.entity_slug)
+        self.assertEqual(setup["ledger_model"].uuid, plain_transaction.ledger_uuid)
+        self.assertEqual(setup["coa_model"].uuid, plain_transaction.coa_id)
+
+    def test_type_helpers_identify_debits_and_credits(self):
+        setup = self.create_entity_setup(name="API TX Type Helper Entity")
+        journal_entry = self.create_journal_entry(setup)
+        debit_transaction = self.create_transaction(
+            journal_entry,
+            account=setup["expense_account"],
+            tx_type=TransactionModel.DEBIT,
+            description="API TX Debit Helper",
+        )
+        credit_transaction = self.create_transaction(
+            journal_entry,
+            account=setup["cash_account"],
+            tx_type=TransactionModel.CREDIT,
+            description="API TX Credit Helper",
+        )
+
+        self.assertTrue(debit_transaction.is_debit())
+        self.assertFalse(debit_transaction.is_credit())
+        self.assertTrue(credit_transaction.is_credit())
+        self.assertFalse(credit_transaction.is_debit())
+
+    def test_url_helpers_return_entity_ledger_and_journal_entry_scoped_urls(self):
+        setup = self.create_entity_setup(name="API TX URL Helper Entity")
+        journal_entry = self.create_journal_entry(setup)
+        transaction_model = self.create_transaction(
+            journal_entry,
+            account=setup["expense_account"],
+            description="API TX URL Helper",
+        )
+
+        ledger_url = transaction_model.get_ledger_detailr_url()
+        journal_entry_url = transaction_model.get_journal_entry_detail_url()
+
+        self.assertIsInstance(ledger_url, str)
+        self.assertIn(setup["entity_model"].slug, ledger_url)
+        self.assertIn(str(setup["ledger_model"].uuid), ledger_url)
+
+        self.assertIsInstance(journal_entry_url, str)
+        self.assertIn(setup["entity_model"].slug, journal_entry_url)
+        self.assertIn(str(setup["ledger_model"].uuid), journal_entry_url)
+        self.assertIn(str(journal_entry.uuid), journal_entry_url)
+
+    def test_string_representation_includes_account_and_transaction_details(self):
+        setup = self.create_entity_setup(name="API TX String Helper Entity")
+        journal_entry = self.create_journal_entry(setup)
+        transaction_model = self.create_transaction(
+            journal_entry,
+            account=setup["expense_account"],
+            tx_type=TransactionModel.DEBIT,
+            amount=Decimal("42.50"),
+            description="API TX String Helper",
+        )
+        tx_string = str(transaction_model)
+
+        self.assertIn(setup["expense_account"].code, tx_string)
+        self.assertIn(setup["expense_account"].name, tx_string)
+        self.assertIn(setup["expense_account"].balance_type, tx_string)
+        self.assertIn("42.50", tx_string)
+        self.assertIn(TransactionModel.DEBIT, tx_string)

--- a/django_ledger/tests/api/test_transaction_presave_api.py
+++ b/django_ledger/tests/api/test_transaction_presave_api.py
@@ -1,0 +1,150 @@
+"""
+High-level API behavior tests for TransactionModel pre-save guards.
+
+These tests cover account transactionability and update-time journal-entry
+locking behavior without duplicating the basic invariant tests.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.transactions import TransactionModelValidationError
+
+
+class TransactionPreSaveAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_tx_presave_admin",
+            email="api-tx-presave-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Transaction PreSave Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+        ledger_model = LedgerModel.objects.create(
+            name=f"{name} Ledger",
+            ledger_xid=f"{name.lower().replace(' ', '-')}-ledger",
+            entity=entity_model,
+        )
+        journal_entry = JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description=f"{name} Journal Entry",
+        )
+
+        return {
+            "cash_account": cash_account,
+            "expense_account": expense_account,
+            "journal_entry": journal_entry,
+        }
+
+    def create_transaction(
+        self,
+        setup,
+        *,
+        account=None,
+        amount=Decimal("10.00"),
+        description="API Transaction PreSave Transaction",
+    ):
+        return TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=setup["journal_entry"],
+            account=account or setup["expense_account"],
+            amount=amount,
+            description=description,
+        )
+
+    def test_valid_transaction_on_transactable_account_is_accepted(self):
+        setup = self.create_entity_setup(name="API TX Valid PreSave Entity")
+
+        transaction_model = self.create_transaction(
+            setup,
+            account=setup["expense_account"],
+            amount=Decimal("25.00"),
+            description="API TX Valid PreSave",
+        )
+
+        self.assertTrue(TransactionModel.objects.filter(uuid=transaction_model.uuid).exists())
+        self.assertEqual(Decimal("25.00"), transaction_model.amount)
+
+    def test_locked_account_rejects_new_transaction(self):
+        setup = self.create_entity_setup(name="API TX Locked Account Entity")
+        setup["expense_account"].lock(commit=True)
+
+        with self.assertRaises(TransactionModelValidationError):
+            self.create_transaction(
+                setup,
+                account=setup["expense_account"],
+                description="API TX Locked Account Rejected",
+            )
+
+    def test_updating_existing_transaction_after_journal_entry_becomes_locked_is_rejected(self):
+        setup = self.create_entity_setup(name="API TX Locked JE Update Entity")
+        transaction_model = self.create_transaction(
+            setup,
+            description="API TX Locked JE Update",
+        )
+        setup["journal_entry"].locked = True
+        setup["journal_entry"].save(verify=False, update_fields=["locked", "updated"])
+
+        transaction_model.amount = Decimal("30.00")
+        with self.assertRaises(TransactionModelValidationError):
+            transaction_model.save(update_fields=["amount", "updated"])
+
+        transaction_model.refresh_from_db()
+        self.assertEqual(Decimal("10.00"), transaction_model.amount)
+
+    def test_updating_existing_transaction_after_journal_entry_becomes_posted_is_rejected(self):
+        setup = self.create_entity_setup(name="API TX Posted JE Update Entity")
+        transaction_model = self.create_transaction(
+            setup,
+            description="API TX Posted JE Update",
+        )
+        JournalEntryModel.objects.filter(uuid=setup["journal_entry"].uuid).update(posted=True)
+        transaction_model = TransactionModel.objects.get(uuid=transaction_model.uuid)
+
+        transaction_model.amount = Decimal("30.00")
+        with self.assertRaises(TransactionModelValidationError):
+            transaction_model.save(update_fields=["amount", "updated"])
+
+        transaction_model.refresh_from_db()
+        self.assertEqual(Decimal("10.00"), transaction_model.amount)

--- a/django_ledger/tests/api/test_transaction_queryset_api.py
+++ b/django_ledger/tests/api/test_transaction_queryset_api.py
@@ -1,0 +1,265 @@
+"""
+High-level API behavior tests for TransactionModel manager and queryset helpers.
+
+These tests cover entity/user scoping and posted transaction filtering without
+requiring randomized fixtures.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityManagementModel, EntityModel
+from django_ledger.models.transactions import TransactionModelValidationError
+
+
+class TransactionQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_tx_queryset_admin",
+            email="api-tx-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_tx_queryset_other_admin",
+            email="api-tx-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_tx_queryset_manager",
+            email="api-tx-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_tx_queryset_unrelated",
+            email="api-tx-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_tx_queryset_superuser",
+            email="api-tx-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Transaction QuerySet Entity", admin=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        cash_account = coa_model.create_account(
+            code="1010",
+            name=f"{name} Cash",
+            role="asset_ca_cash",
+            balance_type="debit",
+            active=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+
+        return {
+            "cash_account": cash_account,
+            "entity_model": entity_model,
+            "expense_account": expense_account,
+        }
+
+    def create_ledger(
+        self,
+        entity_model,
+        *,
+        name="API Transaction QuerySet Ledger",
+        ledger_xid="api-transaction-queryset-ledger",
+        posted=False,
+    ):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+            posted=posted,
+        )
+
+    def create_journal_entry(
+        self,
+        ledger_model,
+        *,
+        description="API Transaction QuerySet Journal Entry",
+        posted=False,
+        force_create=False,
+    ):
+        create_kwargs = {
+            "ledger": ledger_model,
+            "timestamp": self.make_timestamp(),
+            "description": description,
+            "posted": posted,
+        }
+        if force_create:
+            create_kwargs["force_create"] = True
+        return JournalEntryModel.objects.create(**create_kwargs)
+
+    def create_transaction(
+        self,
+        journal_entry,
+        *,
+        account,
+        tx_type=TransactionModel.DEBIT,
+        amount=Decimal("10.00"),
+        description="API Transaction QuerySet Transaction",
+    ):
+        return TransactionModel.objects.create(
+            tx_type=tx_type,
+            journal_entry=journal_entry,
+            account=account,
+            amount=amount,
+            description=description,
+        )
+
+    def create_transaction_for_entity(
+        self,
+        setup,
+        *,
+        ledger_xid,
+        posted_ledger=False,
+        posted_journal_entry=False,
+        description="API Transaction QuerySet Transaction",
+    ):
+        ledger_model = self.create_ledger(
+            setup["entity_model"],
+            ledger_xid=ledger_xid,
+            posted=posted_ledger,
+        )
+        journal_entry = self.create_journal_entry(
+            ledger_model,
+            description=f"{description} Journal Entry",
+            posted=False,
+        )
+        transaction_model = self.create_transaction(
+            journal_entry,
+            account=setup["expense_account"],
+            description=description,
+        )
+        if posted_journal_entry:
+            JournalEntryModel.objects.filter(uuid=journal_entry.uuid).update(posted=True)
+        return transaction_model
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        setup = self.create_entity_setup(name="API TX For Entity A")
+        other_setup = self.create_entity_setup(
+            name="API TX For Entity B",
+            admin=self.other_admin_user,
+        )
+        transaction_model = self.create_transaction_for_entity(
+            setup,
+            ledger_xid="api-tx-for-entity-a",
+            description="API TX For Entity A",
+        )
+        other_transaction = self.create_transaction_for_entity(
+            other_setup,
+            ledger_xid="api-tx-for-entity-b",
+            description="API TX For Entity B",
+        )
+        entity_model = setup["entity_model"]
+
+        for entity_lookup in (entity_model, entity_model.slug, entity_model.uuid):
+            with self.subTest(entity_lookup=entity_lookup):
+                transaction_qs = TransactionModel.objects.for_entity(entity_lookup)
+
+                self.assertTrue(transaction_qs.filter(uuid=transaction_model.uuid).exists())
+                self.assertFalse(transaction_qs.filter(uuid=other_transaction.uuid).exists())
+
+    def test_for_entity_rejects_invalid_input(self):
+        with self.assertRaises(TransactionModelValidationError):
+            TransactionModel.objects.for_entity(object())
+
+    def test_for_user_scopes_transactions_by_entity_access(self):
+        setup = self.create_entity_setup(name="API TX User Scope Entity")
+        other_setup = self.create_entity_setup(
+            name="API TX Other User Scope Entity",
+            admin=self.other_admin_user,
+        )
+        transaction_model = self.create_transaction_for_entity(
+            setup,
+            ledger_xid="api-tx-user-scope",
+            description="API TX User Scope",
+        )
+        other_transaction = self.create_transaction_for_entity(
+            other_setup,
+            ledger_xid="api-tx-other-user-scope",
+            description="API TX Other User Scope",
+        )
+
+        EntityManagementModel.objects.create(
+            entity=setup["entity_model"],
+            user=self.manager_user,
+            permission_level="read",
+        )
+
+        admin_qs = TransactionModel.objects.for_user(self.admin_user)
+        manager_qs = TransactionModel.objects.for_user(self.manager_user)
+        unrelated_qs = TransactionModel.objects.for_user(self.unrelated_user)
+        superuser_qs = TransactionModel.objects.for_user(self.superuser)
+
+        self.assertTrue(admin_qs.filter(uuid=transaction_model.uuid).exists())
+        self.assertFalse(admin_qs.filter(uuid=other_transaction.uuid).exists())
+
+        self.assertTrue(manager_qs.filter(uuid=transaction_model.uuid).exists())
+        self.assertFalse(manager_qs.filter(uuid=other_transaction.uuid).exists())
+
+        self.assertFalse(unrelated_qs.filter(uuid=transaction_model.uuid).exists())
+        self.assertFalse(unrelated_qs.filter(uuid=other_transaction.uuid).exists())
+
+        self.assertTrue(superuser_qs.filter(uuid=transaction_model.uuid).exists())
+        self.assertTrue(superuser_qs.filter(uuid=other_transaction.uuid).exists())
+
+    def test_posted_returns_only_transactions_with_posted_journal_entry_and_posted_ledger(self):
+        setup = self.create_entity_setup(name="API TX Posted Filter Entity")
+        posted_transaction = self.create_transaction_for_entity(
+            setup,
+            ledger_xid="api-tx-posted-both",
+            posted_ledger=True,
+            posted_journal_entry=True,
+            description="API TX Posted Both",
+        )
+        journal_entry_only_posted = self.create_transaction_for_entity(
+            setup,
+            ledger_xid="api-tx-posted-je-only",
+            posted_ledger=False,
+            posted_journal_entry=True,
+            description="API TX Posted Journal Entry Only",
+        )
+        ledger_only_posted = self.create_transaction_for_entity(
+            setup,
+            ledger_xid="api-tx-posted-ledger-only",
+            posted_ledger=True,
+            posted_journal_entry=False,
+            description="API TX Posted Ledger Only",
+        )
+
+        posted_qs = TransactionModel.objects.for_entity(setup["entity_model"]).posted()
+
+        self.assertTrue(posted_qs.filter(uuid=posted_transaction.uuid).exists())
+        self.assertFalse(posted_qs.filter(uuid=journal_entry_only_posted.uuid).exists())
+        self.assertFalse(posted_qs.filter(uuid=ledger_only_posted.uuid).exists())

--- a/django_ledger/tests/api/test_transaction_relation_api.py
+++ b/django_ledger/tests/api/test_transaction_relation_api.py
@@ -1,0 +1,174 @@
+"""
+High-level API behavior tests for TransactionModel ledger and journal-entry
+relation filters.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models import JournalEntryModel, LedgerModel, TransactionModel
+from django_ledger.models.entity import EntityModel
+
+
+class TransactionRelationAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+
+        cls.admin_user = user_model.objects.create_user(
+            username="api_tx_relation_admin",
+            email="api-tx-relation-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def make_timestamp(self):
+        if settings.USE_TZ:
+            return datetime(2026, 1, 15, 12, 0, tzinfo=ZoneInfo(settings.TIME_ZONE))
+        return datetime(2026, 1, 15, 12, 0)
+
+    def create_entity_setup(self, *, name="API Transaction Relation Entity"):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        coa_model = entity_model.create_chart_of_accounts(
+            coa_name=f"{name} CoA",
+            commit=True,
+            assign_as_default=True,
+        )
+        expense_account = coa_model.create_account(
+            code="6010",
+            name=f"{name} Expense",
+            role="ex_regular",
+            balance_type="debit",
+            active=True,
+        )
+
+        return {
+            "entity_model": entity_model,
+            "expense_account": expense_account,
+        }
+
+    def create_ledger(self, entity_model, *, name, ledger_xid):
+        return LedgerModel.objects.create(
+            name=name,
+            ledger_xid=ledger_xid,
+            entity=entity_model,
+        )
+
+    def create_journal_entry(self, ledger_model, *, description):
+        return JournalEntryModel.objects.create(
+            ledger=ledger_model,
+            timestamp=self.make_timestamp(),
+            description=description,
+        )
+
+    def create_transaction(self, journal_entry, *, account, description):
+        return TransactionModel.objects.create(
+            tx_type=TransactionModel.DEBIT,
+            journal_entry=journal_entry,
+            account=account,
+            amount=Decimal("10.00"),
+            description=description,
+        )
+
+    def transaction_ids(self, queryset):
+        return set(queryset.values_list("uuid", flat=True))
+
+    def create_two_ledger_setup(self):
+        setup = self.create_entity_setup()
+        ledger_a = self.create_ledger(
+            setup["entity_model"],
+            name="API TX Relation Ledger A",
+            ledger_xid="api-tx-relation-ledger-a",
+        )
+        ledger_b = self.create_ledger(
+            setup["entity_model"],
+            name="API TX Relation Ledger B",
+            ledger_xid="api-tx-relation-ledger-b",
+        )
+        journal_entry_a = self.create_journal_entry(
+            ledger_a,
+            description="API TX Relation JE A",
+        )
+        journal_entry_b = self.create_journal_entry(
+            ledger_b,
+            description="API TX Relation JE B",
+        )
+        transaction_a = self.create_transaction(
+            journal_entry_a,
+            account=setup["expense_account"],
+            description="API TX Relation Transaction A",
+        )
+        transaction_b = self.create_transaction(
+            journal_entry_b,
+            account=setup["expense_account"],
+            description="API TX Relation Transaction B",
+        )
+
+        return {
+            "entity_model": setup["entity_model"],
+            "journal_entry_a": journal_entry_a,
+            "journal_entry_b": journal_entry_b,
+            "ledger_a": ledger_a,
+            "ledger_b": ledger_b,
+            "transaction_a": transaction_a,
+            "transaction_b": transaction_b,
+        }
+
+    def test_for_ledger_filters_by_ledger_model_instance(self):
+        setup = self.create_two_ledger_setup()
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_ledger(
+            setup["ledger_a"],
+        )
+
+        self.assertEqual({setup["transaction_a"].uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(setup["transaction_b"].uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_ledger_filters_by_ledger_uuid_object(self):
+        setup = self.create_two_ledger_setup()
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_ledger(
+            setup["ledger_a"].uuid,
+        )
+
+        self.assertEqual({setup["transaction_a"].uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(setup["transaction_b"].uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_journal_entry_filters_by_journal_entry_model_instance(self):
+        setup = self.create_two_ledger_setup()
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_journal_entry(
+            setup["journal_entry_a"],
+        )
+
+        self.assertEqual({setup["transaction_a"].uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(setup["transaction_b"].uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_journal_entry_filters_by_journal_entry_uuid_object(self):
+        setup = self.create_two_ledger_setup()
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_journal_entry(
+            setup["journal_entry_a"].uuid,
+        )
+
+        self.assertEqual({setup["transaction_a"].uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(setup["transaction_b"].uuid, self.transaction_ids(transaction_qs))
+
+    def test_for_journal_entry_filters_by_journal_entry_uuid_string(self):
+        setup = self.create_two_ledger_setup()
+
+        transaction_qs = TransactionModel.objects.for_entity(setup["entity_model"]).for_journal_entry(
+            str(setup["journal_entry_a"].uuid),
+        )
+
+        self.assertEqual({setup["transaction_a"].uuid}, self.transaction_ids(transaction_qs))
+        self.assertNotIn(setup["transaction_b"].uuid, self.transaction_ids(transaction_qs))

--- a/django_ledger/tests/api/test_unit_of_measure_api.py
+++ b/django_ledger/tests/api/test_unit_of_measure_api.py
@@ -1,0 +1,131 @@
+"""
+High-level API tests for UnitOfMeasureModel manager and queryset behavior.
+"""
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from django_ledger.models.entity import EntityModel
+from django_ledger.models.items import ItemModelValidationError, UnitOfMeasureModel
+
+
+class UnitOfMeasureQuerySetAPITest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        user_model = get_user_model()
+        cls.admin_user = user_model.objects.create_user(
+            username="api_uom_queryset_admin",
+            email="api-uom-queryset-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.manager_user = user_model.objects.create_user(
+            username="api_uom_queryset_manager",
+            email="api-uom-queryset-manager@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.other_admin_user = user_model.objects.create_user(
+            username="api_uom_queryset_other_admin",
+            email="api-uom-queryset-other-admin@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.unrelated_user = user_model.objects.create_user(
+            username="api_uom_queryset_unrelated",
+            email="api-uom-queryset-unrelated@example.com",
+            password="NeverUseThisPassword12345",
+        )
+        cls.superuser = user_model.objects.create_superuser(
+            username="api_uom_queryset_superuser",
+            email="api-uom-queryset-superuser@example.com",
+            password="NeverUseThisPassword12345",
+        )
+
+    def create_entity(self, *, name="API UOM Queryset Entity", admin_user=None, manager_user=None):
+        entity_model = EntityModel.create_entity(
+            name=name,
+            admin=admin_user or self.admin_user,
+            use_accrual_method=True,
+            fy_start_month=1,
+        )
+        if manager_user is not None:
+            entity_model.managers.add(manager_user)
+        return entity_model
+
+    def create_uom(self, entity_model, *, name="API Queryset Unit", unit_abbr="api-uom", active=True):
+        return entity_model.create_uom(
+            name=name,
+            unit_abbr=unit_abbr,
+            active=active,
+            commit=True,
+        )
+
+    def assert_uom_uuids(self, queryset, expected_uoms):
+        self.assertEqual(
+            set(queryset.values_list("uuid", flat=True)),
+            {uom_model.uuid for uom_model in expected_uoms},
+        )
+
+    def test_for_entity_accepts_model_slug_and_uuid(self):
+        entity_model = self.create_entity(name="API UOM Queryset Entity A")
+        other_entity_model = self.create_entity(
+            name="API UOM Queryset Entity B",
+            admin_user=self.other_admin_user,
+        )
+        uom_model = self.create_uom(entity_model, unit_abbr="api-uom-a")
+        self.create_uom(other_entity_model, unit_abbr="api-uom-b")
+
+        self.assert_uom_uuids(UnitOfMeasureModel.objects.for_entity(entity_model), [uom_model])
+        self.assert_uom_uuids(UnitOfMeasureModel.objects.for_entity(entity_model.slug), [uom_model])
+        self.assert_uom_uuids(UnitOfMeasureModel.objects.for_entity(entity_model.uuid), [uom_model])
+
+    def test_for_entity_rejects_invalid_input_and_missing_slug_returns_empty_queryset(self):
+        self.create_uom(self.create_entity())
+
+        with self.assertRaises(ItemModelValidationError):
+            UnitOfMeasureModel.objects.for_entity(object())
+
+        self.assertFalse(UnitOfMeasureModel.objects.for_entity("missing-uom-entity-slug").exists())
+
+    def test_for_entity_active_returns_only_active_units(self):
+        entity_model = self.create_entity()
+        active_uom = self.create_uom(entity_model, name="API Active Unit", unit_abbr="api-act", active=True)
+        inactive_uom = self.create_uom(
+            entity_model,
+            name="API Inactive Unit",
+            unit_abbr="api-inact",
+            active=False,
+        )
+
+        active_qs = UnitOfMeasureModel.objects.for_entity_active(entity_model)
+
+        self.assertTrue(active_qs.filter(uuid=active_uom.uuid).exists())
+        self.assertFalse(active_qs.filter(uuid=inactive_uom.uuid).exists())
+
+    def test_for_user_scopes_to_admin_manager_and_current_superuser_behavior(self):
+        entity_model = self.create_entity(
+            name="API UOM Queryset Access Entity",
+            manager_user=self.manager_user,
+        )
+        other_entity_model = self.create_entity(
+            name="API UOM Queryset Other Access Entity",
+            admin_user=self.other_admin_user,
+        )
+        uom_model = self.create_uom(entity_model, unit_abbr="api-acc")
+        self.create_uom(other_entity_model, unit_abbr="api-oacc")
+
+        self.assert_uom_uuids(UnitOfMeasureModel.objects.all().for_user(self.admin_user), [uom_model])
+        self.assert_uom_uuids(UnitOfMeasureModel.objects.all().for_user(self.manager_user), [uom_model])
+        self.assertFalse(UnitOfMeasureModel.objects.all().for_user(self.unrelated_user).exists())
+        self.assertFalse(UnitOfMeasureModel.objects.all().for_user(self.superuser).exists())
+
+    def test_str_returns_user_facing_unit_name_and_abbreviation(self):
+        uom_model = self.create_uom(
+            self.create_entity(),
+            name="API Hours",
+            unit_abbr="api-hrs",
+        )
+
+        display = str(uom_model)
+
+        self.assertTrue(display)
+        self.assertIn("API Hours", display)
+        self.assertIn("api-hrs", display)

--- a/django_ledger/urls/estimate.py
+++ b/django_ledger/urls/estimate.py
@@ -4,7 +4,7 @@ from django_ledger.views import (EstimateModelListView, EstimateModelCreateView,
                                  EstimateModelDetailView, EstimateModelUpdateView,
                                  EstimateActionMarkAsDraftView, EstimateActionMarkAsReviewView,
                                  EstimateActionMarkAsApprovedView, EstimateActionMarkAsCompletedView,
-                                 EstimateActionMarkAsCanceledView)
+                                 EstimateActionMarkAsCanceledView, EstimateActionMarkAsVoidView)
 
 urlpatterns = [
     path('<slug:entity_slug>/list/', EstimateModelListView.as_view(), name='customer-estimate-list'),
@@ -35,4 +35,7 @@ urlpatterns = [
     path('<slug:entity_slug>/action/<uuid:ce_pk>/mark-as-canceled/',
          EstimateActionMarkAsCanceledView.as_view(),
          name='customer-estimate-action-mark-as-canceled'),
+    path('<slug:entity_slug>/action/<uuid:ce_pk>/mark-as-void/',
+         EstimateActionMarkAsVoidView.as_view(),
+         name='customer-estimate-action-mark-as-void'),
 ]

--- a/django_ledger/views/estimate.py
+++ b/django_ledger/views/estimate.py
@@ -302,3 +302,7 @@ class EstimateActionMarkAsCompletedView(BaseEstimateActionView):
 
 class EstimateActionMarkAsCanceledView(BaseEstimateActionView):
     action_name = 'mark_as_canceled'
+
+
+class EstimateActionMarkAsVoidView(BaseEstimateActionView):
+    action_name = 'mark_as_void'


### PR DESCRIPTION
# Add High-Level Public API Behavior Coverage for Django Ledger Models

## Summary

This PR adds a broad high-level API behavior test layer under:

```text
django_ledger/tests/api/
```

The goal is to document and protect Django Ledger’s public model API behavior: model methods, managers, querysets, numbering helpers, lifecycle actions, URL/display helpers, cross-model bindings, import/staging workflows, and entity-scoped data integrity.

This is not intended to replace the existing test suite. It adds contract-style coverage around public APIs that downstream applications may call directly.

The test campaign also surfaced several public API bugs. Those production fixes are included with focused regression coverage.

## Review note

The commit history reflects the chronological development of the campaign. It shows the work progressing model-by-model, with failures either characterized or fixed as they appeared.

For review, it may be easier to use the model-family sections below rather than reading the commits as the primary organization.

Some package/build metadata and generated asset files may also appear in the branch diff from the broader branch history. The main review focus is the API behavior test campaign and related public API fixes described below.

## What changed

This PR adds or expands high-level API coverage for these model families:

```text
Core accounting:
- EntityModel
- EntityStateModel
- EntityUnitModel
- ChartOfAccountModel / default CoA data
- AccountModel
- LedgerModel
- JournalEntryModel
- TransactionModel

Import / staging / receipts / closing:
- BankAccountModel
- ImportJobModel
- StagedTransactionModel
- ReceiptModel
- ClosingEntryModel
- ClosingEntryTransactionModel

Commercial documents:
- BillModel
- InvoiceModel
- EstimateModel
- PurchaseOrderModel

Items and line items:
- UnitOfMeasureModel
- ItemModel
- ItemTransactionModel

Commercial parties:
- CustomerModel
- VendorModel

Infrastructure / compatibility:
- LazyLoader model/report resolution
- schema top-level shape
- deprecated entity_slug= behavior
```

The README for `django_ledger/tests/api/` was also updated to explain the purpose, scope, and design goals of this test layer.

## Test design

The tests follow these principles:

- deterministic setup instead of randomized fixtures,
- public API behavior over private implementation details,
- model-family and behavior-family organization,
- regression tests paired with production fixes,
- characterization coverage for surprising but stable current behavior,
- minimal production changes only when a clear public bug was confirmed.

The tests avoid pinning brittle internals such as exact SQL annotation implementation, private dictionary shapes, full generated-number strings, and database error message text.

## Production fixes included

### Entity / Ledger

- Fixed parent entity creation ordering so failed parent validation does not leave behind an invalid root entity.
- Fixed explicit CoA lookup in Entity account helpers.
- Fixed fiscal-year closing digest wrapper argument forwarding.
- Fixed stale closing-entry metadata cache behavior after closing books.
- Added a cross-entity guard for explicit bank-account ledger account bindings.
- Fixed Entity URL helpers for import-job and account-list routes/kwargs.
- Fixed `LedgerModelQuerySet.unposted()` to return unposted ledgers.
- Fixed `LedgerModelQuerySet.current()` behavior when the entity has no closing date.
- Fixed locked-period journal entry detection to consider the earliest posted journal entry.

### Import / StagedTransaction / Receipt

- Fixed ImportJob slug-based entity scoping.
- Fixed stale ImportJob URL helper routes.
- Fixed `StagedTransactionModel.unmatch()` so matched transaction state is fully cleared.
- Fixed `ReceiptModel.can_delete()` when `last_closing_date` is `None`.
- Fixed `ReceiptModel.configure(...)` lookup variants for vendor, customer, and entity unit inputs.

### Closing entries

- Fixed `ClosingEntryTransactionModel.objects.for_entity(...)` lazy-loader usage.
- Fixed closing-entry transaction slug scoping.
- Fixed `ClosingEntryModel.get_delete_url()` route resolution.
- Fixed single-sided closing migration to raise `ClosingEntryValidationError` instead of leaking `KeyError`.

### Invoice

- Fixed `InvoiceModelQuerySet.in_review()` to filter review invoices instead of draft invoices.
- Fixed `mark_as_approved(date_approved=...)` persistence.
- Fixed `mark_as_draft(draft_date=...)` persistence.
- Fixed `generate_descriptive_title()` to identify invoices as invoices, not bills.

### Estimate

- Fixed `EstimateModel.configure(date_draft=...)` to preserve explicit draft dates.
- Fixed `EstimateModel.configure(...)` to reject customers from another entity.
- Added the missing mark-as-void view and route for estimates.
- Added a cross-entity guard to `InvoiceModel.can_bind_estimate(...)`.

### Purchase orders / Bill binding

- Fixed non-DB PO item aggregation to use `po_total_amount`.
- Fixed draft date persistence in `mark_as_draft(...)`.
- Fixed PO void transition query construction.
- Fixed `date_void` persistence.
- Fixed fulfilled date preservation.
- Fixed `po_amount_received` persistence.
- Fixed configure-time estimate binding order.
- Added a cross-entity guard to `BillModel.can_bind_po(...)`.
- Fixed list-backed `po_items` handling in fulfillment.
- Fixed `get_po_bill_queryset()` overmatching through shared item models.

### Items / item transactions / inventory

- Fixed estimate item eligibility so services are included.
- Fixed `ItemTransactionModelQuerySet.is_orphan()` to exclude invoice-owned rows.
- Fixed `ItemTransactionModel.is_ordered()` to compare against `STATUS_ORDERED`.
- Fixed `EntityModel.create_item_inventory(..., inventory_account=..., coa_model=None)` default CoA resolution.

### Customer / Vendor

- Fixed `vendor_picture_upload_to(...)` to use vendor numbering.
- Fixed invalid input handling in `CustomerModel.validate_for_entity(...)`.
- Fixed stale customer validation wording.
- Fixed invalid input handling in `VendorModel.validate_for_entity(...)`.
- Fixed Customer/Vendor `clean()` methods so inherited contact validation runs.

## Characterization coverage

Some behaviors were intentionally documented rather than changed.

Examples include:

- `commit=False` may consume entity-state sequences.
- `commit=False` may mutate in-memory state without persisting the main row.
- Bill and invoice `overdue()` filters are date-based and not status-scoped.
- Invoice payment dates before approval dates are currently accepted.
- Estimate gross-margin helper currently behaves like markup.
- Customer validation remains narrower than vendor validation.
- Some signal payloads preserve existing spelling such as `commited`.
- Hidden-but-active records are included by `active()` and excluded by `visible()`.

These tests are not intended to force behavior changes. They document current public behavior so future refactors can be intentional.

## Verification

Targeted tests were run for each batch.

Whenever production code changed, the full high-level API suite was run.

Recent verification milestones:

```bash
.venv/bin/python manage.py test django_ledger.tests.api
# Ran 816 tests
# OK (skipped=1)
```

Final isolated infrastructure and compatibility smoke tests also passed:

```bash
.venv/bin/python manage.py test \
  django_ledger.tests.api.test_model_infrastructure_api \
  django_ledger.tests.api.test_deprecated_entity_slug_api

# Ran 6 tests
# OK
```

## Why this is useful

This coverage should help protect downstream users and future maintainers before larger changes involving:

- manager/queryset refactors,
- entity-scoped and fiscal-year-scoped numbering,
- document lifecycle changes,
- ledger/journal entry posting internals,
- cross-entity data integrity,
- swappable-model or extension work,
- import/staging and reconciliation workflows,
- commercial document and item-line behavior.

## AI assistance disclosure

This test campaign was developed with AI assistance and human review. AI helped draft test structures and iterate on failures; the contributor inspected the source, ran the tests, reviewed behavior, and made the final decisions about which contracts and fixes to keep.